### PR TITLE
Adding Destroy Atomic Behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
     - InTriggerDistanceToNextIntersection: check if a vehicle is within certain distance with respect to the next intersection
     - WaypointFollower: follows auto-generated waypoints indefinitely or follows a given waypoint list
     - HandBrakeVehicle: sets the handbrake value for a given actor
+    - ActorDestroy: destroys a given actor
 * Fixes
     - Fixed SteerVehicle atomic behavior to keep vehicle velocity
 * Updated NHTSA Traffic Scenarios

--- a/srunner/scenariomanager/atomic_scenario_behavior.py
+++ b/srunner/scenariomanager/atomic_scenario_behavior.py
@@ -20,6 +20,7 @@ from agents.navigation.roaming_agent import *
 from agents.navigation.basic_agent import *
 
 from srunner.scenariomanager.carla_data_provider import CarlaDataProvider
+from srunner.scenariomanager.carla_data_provider import CarlaActorPool
 
 EPSILON = 0.001
 
@@ -887,7 +888,8 @@ class ActorDestroy(AtomicBehavior):
     def update(self):
         new_status = py_trees.common.Status.RUNNING
         if self._actor:
-            self._actor.destroy()
+            CarlaActorPool.remove_actor_by_id(self._actor.id)
+            self._actor = None
             new_status = py_trees.common.Status.SUCCESS
 
         return new_status

--- a/srunner/scenariomanager/atomic_scenario_behavior.py
+++ b/srunner/scenariomanager/atomic_scenario_behavior.py
@@ -867,3 +867,27 @@ class HandBrakeVehicle(AtomicBehavior):
         self._vehicle.apply_control(self._control)
 
         return new_status
+
+
+class ActorDestroy(AtomicBehavior):
+
+    """
+    This class contains an actor destroy behavior.
+    Given a actor this behavior will delete it.
+    """
+
+    def __init__(self, actor, name="ActorDestroy"):
+        """
+        Setup actor
+        """
+        super(ActorDestroy, self).__init__(name)
+        self._actor = actor
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+
+    def update(self):
+        new_status = py_trees.common.Status.RUNNING
+        if self._actor:
+            self._actor.destroy()
+            new_status = py_trees.common.Status.SUCCESS
+
+        return new_status


### PR DESCRIPTION
* Prepared a behaviour to destroy an actor
* Useful when actor is required to be destroyed from behaviour tree

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated

-->

#### Description
This will help to destroy actors from the tree, which can be used for end conditions also.
<!-- Please explain the changes you made here as detailed as possible. -->

#### Where has this been tested?

  * **Platform(s):**  Linux 18.04
  * **Python version(s):** 2.7
  * **CARLA version:** 0.9.4

#### Possible Drawbacks
Since this behaviour uses destroy method possibility of getting warnings that actor is already destroyed when final cleanup runs.  
<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/91)
<!-- Reviewable:end -->
