### PR TITLE
Set autopilot only if its a vehicle in Carla data provider

### DIFF
--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -239,8 +239,11 @@ class CarlaActorPool(object):
             raise Exception(
                 "Error: Unable to spawn vehicle {} at {}".format(model, spawn_point))
         else:
-            # Let's deactivate the autopilot of the actor
-            actor.set_autopilot(autopilot)
+            # Let's deactivate the autopilot of the actor if it belongs to vehicle
+            if actor in blueprint_library.filter('vehicle.*'):
+                actor.set_autopilot(autopilot)
+            else:
+                pass
 
         return actor
 


### PR DESCRIPTION
* Added a check to set autopilot only if 'Actor' object has 'set_autopilot' attribute (set_autopilot is applicable only for the vehicle).

<!-- Please explain the changes you made here as detailed as possible. -->


#### Where has this been tested?

  * **Platform(s):** linux 18.04
  * **Python version(s):** 2.7
  * **CARLA version:** 0.9.4



<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/98)
<!-- Reviewable:end -->
