### PR TITLE
Map reload issue fix for Waypoint Follower behaviour

### DIFF
--- a/srunner/scenariomanager/atomic_scenario_behavior.py
+++ b/srunner/scenariomanager/atomic_scenario_behavior.py
@@ -800,7 +800,10 @@ class WaypointFollower(AtomicBehavior):
         self._local_planner = None
         self._plan = plan
 
-    def initialise(self):
+    def setup(self, timeout=5):
+        """
+        Delayed one-time initialization
+        """
         args_lateral_dict = {
             'K_P': 1.0,
             'K_D': 0.01,
@@ -813,14 +816,16 @@ class WaypointFollower(AtomicBehavior):
         if self._plan is not None:
             self._local_planner.set_global_plan(self._plan)
 
+        return True
+
     def update(self):
         """
         Run local planner, obtain and apply control to actor
         """
-
         new_status = py_trees.common.Status.RUNNING
-        control = self._local_planner.run_step(debug=False)
-        self._actor.apply_control(control)
+        if self._local_planner is not None:
+            control = self._local_planner.run_step(debug=False)
+            self._actor.apply_control(control)
 
         return new_status
 


### PR DESCRIPTION
Overriding initialize() method was causing local planner instantiation to occur repeated once the behaviour moved out of RUNNING state which was causing open drive reloads indefinitely.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->
* Moved one time initialisation code to setup() method
* Check on local planner reference in update method

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2.7
  * **CARLA version:** 0.9.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/105)
<!-- Reviewable:end -->
