### PR TITLE
Added "appear" and detroy behaviors to all scenario actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added wrong way test
 * Added new traffic event logger
 * Added running red light test
+* Added running stop test
 * Added various helper methods to allow generic scenario execution
 * Updated folder structure and naming convention in lowercase
 * Reworked scenario execution
@@ -31,11 +32,13 @@
     - WaypointFollower: follows auto-generated waypoints indefinitely or follows a given waypoint list
     - HandBrakeVehicle: sets the handbrake value for a given actor
     - ActorDestroy: destroys a given actor
+    - ActorTransformSetter: sets transform of given actor
 * Fixes
     - Fixed SteerVehicle atomic behavior to keep vehicle velocity
 * Updated NHTSA Traffic Scenarios
     - OppositeVehicleRunningRedLight: Updated to allow execution at different locations
 * Added NHTSA Traffic Scenarios
+    - Updated all traffic scenarios to let the other actors appear upon scenario triggering and removal on scenario end
     - ManeuverOppositeDirection: hero vehicle must maneuver in the opposite lane to pass a leading vehicle.
     - OtherLeadingVehicle: hero vehicle must react to the deceleration of leading vehicle and change lane to avoid collision and follow
                            the vehicle in changed lane

--- a/srunner/scenariomanager/atomic_scenario_behavior.py
+++ b/srunner/scenariomanager/atomic_scenario_behavior.py
@@ -783,6 +783,7 @@ class Idle(AtomicBehavior):
 
 
 class WaypointFollower(AtomicBehavior):
+
     """
     This is an atomic behavior to follow waypoints indefinitely
     while maintaining a given speed or if given a waypoint plan,
@@ -895,18 +896,18 @@ class ActorDestroy(AtomicBehavior):
         return new_status
 
 
-class SetActorTransform(AtomicBehavior):
+class ActorTransformSetter(AtomicBehavior):
 
     """
     This class contains an atomic behavior to set the transform
     of an actor.
     """
 
-    def __init__(self, actor, transform, name="SetActorTransform"):
+    def __init__(self, actor, transform, name="ActorTransformSetter"):
         """
         Init
         """
-        super(SetActorTransform, self).__init__(name)
+        super(ActorTransformSetter, self).__init__(name)
         self._actor = actor
         self._transform = transform
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))

--- a/srunner/scenariomanager/atomic_scenario_behavior.py
+++ b/srunner/scenariomanager/atomic_scenario_behavior.py
@@ -893,3 +893,31 @@ class ActorDestroy(AtomicBehavior):
             new_status = py_trees.common.Status.SUCCESS
 
         return new_status
+
+
+class SetActorTransform(AtomicBehavior):
+
+    """
+    This class contains an atomic behavior to set the transform
+    of an actor.
+    """
+
+    def __init__(self, actor, transform, name="SetActorTransform"):
+        """
+        Init
+        """
+        super(SetActorTransform, self).__init__(name)
+        self._actor = actor
+        self._transform = transform
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+
+    def update(self):
+        """
+        Transform actor
+        """
+        new_status = py_trees.common.Status.RUNNING
+
+        self._actor.set_transform(self._transform)
+        new_status = py_trees.common.Status.SUCCESS
+
+        return new_status

--- a/srunner/scenariomanager/atomic_scenario_criteria.py
+++ b/srunner/scenariomanager/atomic_scenario_criteria.py
@@ -407,6 +407,7 @@ class ReachedRegionTest(Criterion):
 
         return new_status
 
+
 class OnSidewalkTest(Criterion):
 
     """
@@ -437,7 +438,7 @@ class OnSidewalkTest(Criterion):
         current_location = self._actor.get_location()
         closet_waypoint = self._map.get_waypoint(current_location)
         waypoint_adj_right = closet_waypoint.get_right_lane()
-        waypoint_adj_left =  closet_waypoint.get_left_lane()
+        waypoint_adj_left = closet_waypoint.get_left_lane()
 
         # skipping shoulders
         if waypoint_adj_right and waypoint_adj_right.lane_type == 'shoulder':
@@ -450,7 +451,6 @@ class OnSidewalkTest(Criterion):
             distance = current_location.distance(waypoint_adj_right.transform.location)
         elif waypoint_adj_left and waypoint_adj_left.lane_type == 'sidewalk':
             distance = current_location.distance(waypoint_adj_left.transform.location)
-
 
         if distance >= self.MAX_INVASION_ALLOWED:
             # we are not on a sidewalk
@@ -474,6 +474,7 @@ class OnSidewalkTest(Criterion):
         Cleanup sensor
         """
         super(OnSidewalkTest, self).terminate(new_status)
+
 
 class WrongLaneTest(Criterion):
 

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -128,6 +128,7 @@ class CarlaDataProvider(object):
             else:
                 raise KeyError(
                     "Traffic light '{}' already registered. Cannot register twice!".format(traffic_light.id))
+
     @staticmethod
     def get_world():
         return CarlaDataProvider._world
@@ -136,7 +137,6 @@ class CarlaDataProvider(object):
     def set_world(world):
         CarlaDataProvider._world = world
         CarlaDataProvider._map = CarlaDataProvider._world.get_map()
-
 
     @staticmethod
     def get_map(world=None):

--- a/srunner/scenarios/scenario_helper.py
+++ b/srunner/scenarios/scenario_helper.py
@@ -131,7 +131,7 @@ def generate_target_waypoint(waypoint, turn=0):
                 wp_list[-3].transform.location,
                 wp_list[-2].transform.location)
             angle_wp = math.acos(
-                np.dot(v_1, v_2)/abs((np.linalg.norm(v_1)*np.linalg.norm(v_2))))
+                np.dot(v_1, v_2) / abs((np.linalg.norm(v_1) * np.linalg.norm(v_2))))
             if angle_wp < threshold:
                 break
         elif reached_junction and not wp_list[-1].is_intersection:
@@ -184,7 +184,7 @@ def get_intersection(ego_actor, other_actor):
         waypoint_choice = waypoint.next(1)
         #   Select the straighter path at intersection
         if len(waypoint_choice) > 1:
-            max_dot = -1*float('inf')
+            max_dot = -1 * float('inf')
             loc_projection = current_location + carla.Location(
                 x=math.cos(math.radians(waypoint.transform.rotation.yaw)),
                 y=math.sin(math.radians(waypoint.transform.rotation.yaw)))


### PR DESCRIPTION
To avoid traffic jams due to not moving actors in not yet triggered are already passed scenarios, an "appear" behavior and an destroy behavior was added to all scenarios.

The appear behavior is reached by adjusting the actor transform. At the beginning, all actors are spawned under the surface, and only upon triggering the scenario, the actors appear. 

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.5
  * **Unreal Engine version(s):** 4.21
  * **CARLA version:** 0.9.4+

#### Possible Drawbacks
Some scenarios look a bit strange now, due to the sudden appearance of actors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/112)
<!-- Reviewable:end -->
