### PR TITLE
Setting default flag for avoid_collision as False.

### DIFF
--- a/srunner/scenariomanager/atomic_scenario_behavior.py
+++ b/srunner/scenariomanager/atomic_scenario_behavior.py
@@ -821,7 +821,7 @@ class WaypointFollower(AtomicBehavior):
     """
 
     def __init__(self, actor, target_speed, plan=None, blackboard_queue_name=None,
-                 avoid_collision=True, name="FollowWaypoints"):
+                 avoid_collision=False, name="FollowWaypoints"):
         """
         Set up actor and local planner
         """


### PR DESCRIPTION
#### Description
Quick fix: Currently there is an issue with obstacle_lane_detection() hence setting the avoid_collision flag in WaypointFollower atomic behavior to False.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):**  Ubuntu 18.04
  * **Python version(s):**  2.7
  * **Unreal Engine version(s):** ...
  * **CARLA version:** 0.9.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/123)
<!-- Reviewable:end -->
