### PR TITLE
Fixed all next()-calls in scenariomanager module

### DIFF
--- a/srunner/scenariomanager/atomic_scenario_behavior.py
+++ b/srunner/scenariomanager/atomic_scenario_behavior.py
@@ -241,7 +241,7 @@ class InTriggerDistanceToNextIntersection(AtomicBehavior):
         self._map = CarlaDataProvider.get_map()
 
         waypoint = self._map.get_waypoint(self._actor.get_location())
-        while not waypoint.is_intersection:
+        while waypoint and not waypoint.is_intersection:
             waypoint = waypoint.next(1)[-1]
 
         self._final_location = waypoint.transform.location

--- a/srunner/scenariomanager/atomic_scenario_criteria.py
+++ b/srunner/scenariomanager/atomic_scenario_criteria.py
@@ -540,6 +540,9 @@ class WrongLaneTest(Criterion):
         if not (self._last_road_id == current_road_id and self._last_lane_id == current_lane_id):
             next_waypoint = lane_waypoint.next(2.0)[0]
 
+            if not next_waypoint:
+                return
+
             vector_wp = np.array([next_waypoint.transform.location.x - lane_waypoint.transform.location.x,
                                   next_waypoint.transform.location.y - lane_waypoint.transform.location.y])
 
@@ -879,6 +882,8 @@ class RunningStopTest(Criterion):
         waypoint = self._map.get_waypoint(current_location)
         for i in range(multi_step):
             waypoint = waypoint.next(self.WAYPOINT_STEP)[0]
+            if not waypoint:
+                break
             list_locations.append(waypoint.transform.location)
 
         for actor_location in list_locations:

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -176,7 +176,7 @@ class CarlaDataProvider(object):
 
         # Create list of all waypoints until next intersection
         list_of_waypoints = []
-        while not waypoint.is_intersection:
+        while waypoint and not waypoint.is_intersection:
             list_of_waypoints.append(waypoint)
             waypoint = waypoint.next(2.0)[0]
 


### PR DESCRIPTION
The next() method for waypoints may return None. This special case has
to be detected and handled properly.

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated --> not required as this is just a fix on development

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.5
  * **Unreal Engine version(s):** 4.21
  * **CARLA version:** 0.9.4+

#### Possible Drawbacks
None
<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/127)
<!-- Reviewable:end -->
