### PR TITLE
 changing the start positions

### DIFF
--- a/srunner/challenge/challenge_evaluator_routes.py
+++ b/srunner/challenge/challenge_evaluator_routes.py
@@ -240,12 +240,10 @@ class ChallengeEvaluator(object):
         :return: return the ones sampled for this case.
         """
         def position_sampled(scenario_choice, sampled_scenarios):
-            print ("Trying to insert ", scenario_choice)
             # Check if this position was already sampled
             for existent_scenario in sampled_scenarios:
                 # If the scenarios have equal positions then it is true.
                 if compare_scenarios(scenario_choice, existent_scenario):
-                    print ('This position was already sampled')
                     return True
 
             return False

--- a/srunner/challenge/challenge_evaluator_routes.py
+++ b/srunner/challenge/challenge_evaluator_routes.py
@@ -109,7 +109,6 @@ def compare_scenarios(scenario_choice, existent_scenario):
     choice_vec = transform_to_pos_vec(scenario_choice)
     existent_vec = transform_to_pos_vec(existent_scenario)
     for pos_choice in choice_vec:
-
         for pos_existent in existent_vec:
 
             dx = float(pos_choice['x']) - float(pos_existent['x'])
@@ -241,10 +240,12 @@ class ChallengeEvaluator(object):
         :return: return the ones sampled for this case.
         """
         def position_sampled(scenario_choice, sampled_scenarios):
+            print ("Trying to insert ", scenario_choice)
             # Check if this position was already sampled
             for existent_scenario in sampled_scenarios:
                 # If the scenarios have equal positions then it is true.
                 if compare_scenarios(scenario_choice, existent_scenario):
+                    print ('This position was already sampled')
                     return True
 
             return False

--- a/srunner/scenariomanager/atomic_scenario_criteria.py
+++ b/srunner/scenariomanager/atomic_scenario_criteria.py
@@ -687,8 +687,6 @@ class RouteCompletionTest(Criterion):
         self._current_index = 0
         self._route_length = len(self._route)
         self._waypoints, _ = zip(*self._route)
-        print (self._waypoints)
-
         self._traffic_event = TrafficEvent(type=TrafficEventType.ROUTE_COMPLETION)
         self.list_traffic_events.append(self._traffic_event)
         self._percentage_route_completed = 0.0

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -170,13 +170,10 @@ class CarlaDataProvider(object):
         CarlaDataProvider.prepare_map()
         location = CarlaDataProvider.get_location(actor)
 
-        print(" location cached ", location)
         if not use_cached_location:
             location = actor.get_transform().location
 
         waypoint = CarlaDataProvider._map.get_waypoint(location)
-        print ("Waypoint ", waypoint)
-
         # Create list of all waypoints until next intersection
         list_of_waypoints = []
         while waypoint and not waypoint.is_intersection:
@@ -185,7 +182,6 @@ class CarlaDataProvider(object):
 
         # If the list is empty, the actor is in an intersection
         if not list_of_waypoints:
-            print ("agent is in an intersection")
             return None
 
         relevant_traffic_light = None

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -169,10 +169,13 @@ class CarlaDataProvider(object):
 
         CarlaDataProvider.prepare_map()
         location = CarlaDataProvider.get_location(actor)
+
+        print(" location cached ", location)
         if not use_cached_location:
             location = actor.get_transform().location
 
         waypoint = CarlaDataProvider._map.get_waypoint(location)
+        print ("Waypoint ", waypoint)
 
         # Create list of all waypoints until next intersection
         list_of_waypoints = []
@@ -182,6 +185,7 @@ class CarlaDataProvider(object):
 
         # If the list is empty, the actor is in an intersection
         if not list_of_waypoints:
+            print ("agent is in an intersection")
             return None
 
         relevant_traffic_light = None

--- a/srunner/scenarios/follow_leading_vehicle.py
+++ b/srunner/scenarios/follow_leading_vehicle.py
@@ -93,7 +93,7 @@ class FollowLeadingVehicle(BasicScenario):
         first_vehicle_transform = carla.Transform(
             carla.Location(self._other_actor_transform.location.x,
                            self._other_actor_transform.location.y,
-                           self._other_actor_transform.location.z - 5),
+                           self._other_actor_transform.location.z - 500),
             self._other_actor_transform.rotation)
         first_vehicle = CarlaActorPool.request_new_actor('vehicle.nissan.patrol', first_vehicle_transform)
         self.other_actors.append(first_vehicle)
@@ -209,7 +209,7 @@ class FollowLeadingVehicleWithObstacle(BasicScenario):
         first_actor_transform = carla.Transform(
             carla.Location(first_actor_waypoint.transform.location.x,
                            first_actor_waypoint.transform.location.y,
-                           first_actor_waypoint.transform.location.z - 5),
+                           first_actor_waypoint.transform.location.z - 500),
             first_actor_waypoint.transform.rotation)
         self._first_actor_transform = carla.Transform(
             carla.Location(first_actor_waypoint.transform.location.x,
@@ -220,7 +220,7 @@ class FollowLeadingVehicleWithObstacle(BasicScenario):
         second_actor_transform = carla.Transform(
             carla.Location(second_actor_waypoint.transform.location.x,
                            second_actor_waypoint.transform.location.y,
-                           second_actor_waypoint.transform.location.z - 5),
+                           second_actor_waypoint.transform.location.z - 500),
             carla.Rotation(second_actor_waypoint.transform.rotation.pitch, yaw_1,
                            second_actor_waypoint.transform.rotation.roll))
         self._second_actor_transform = carla.Transform(

--- a/srunner/scenarios/no_signal_junction_crossing.py
+++ b/srunner/scenarios/no_signal_junction_crossing.py
@@ -48,6 +48,7 @@ class NoSignalJunctionCrossing(BasicScenario):
         """
 
         self._other_actor_transform = None
+        self.timeout = 0
 
         super(NoSignalJunctionCrossing, self).__init__("NoSignalJunctionCrossing",
                                                        ego_vehicle,
@@ -64,7 +65,7 @@ class NoSignalJunctionCrossing(BasicScenario):
         first_vehicle_transform = carla.Transform(
             carla.Location(config.other_actors[0].transform.location.x,
                            config.other_actors[0].transform.location.y,
-                           config.other_actors[0].transform.location.z - 5),
+                           config.other_actors[0].transform.location.z - 500),
             config.other_actors[0].transform.rotation)
         first_vehicle = CarlaActorPool.request_new_actor(config.other_actors[0].model, first_vehicle_transform)
         self.other_actors.append(first_vehicle)

--- a/srunner/scenarios/object_crash_intersection.py
+++ b/srunner/scenarios/object_crash_intersection.py
@@ -81,7 +81,7 @@ class VehicleTurningRight(BasicScenario):
         actor_transform = carla.Transform(
             carla.Location(self._other_actor_transform.location.x,
                            self._other_actor_transform.location.y,
-                           self._other_actor_transform.location.z - 5),
+                           self._other_actor_transform.location.z - 500),
             self._other_actor_transform.rotation)
 
         first_vehicle = CarlaActorPool.request_new_actor('vehicle.diamondback.century', actor_transform)
@@ -202,7 +202,7 @@ class VehicleTurningLeft(BasicScenario):
         actor_transform = carla.Transform(
             carla.Location(self._other_actor_transform.location.x,
                            self._other_actor_transform.location.y,
-                           self._other_actor_transform.location.z - 5),
+                           self._other_actor_transform.location.z - 500),
             self._other_actor_transform.rotation)
 
         first_vehicle = CarlaActorPool.request_new_actor('vehicle.diamondback.century', actor_transform)

--- a/srunner/scenarios/object_crash_vehicle.py
+++ b/srunner/scenarios/object_crash_vehicle.py
@@ -62,7 +62,7 @@ class StationaryObjectCrossing(BasicScenario):
         lane_width = self._reference_waypoint.lane_width
         location, _ = get_location_in_distance(self.ego_vehicle, _start_distance)
         waypoint = self._wmap.get_waypoint(location)
-        offset = {"orientation": 270, "position": 90, "z": 0.2, "k": 0.2}
+        offset = {"orientation": 270, "position": 90, "z": 0.4, "k": 0.2}
         position_yaw = waypoint.transform.rotation.yaw + offset['position']
         orientation_yaw = waypoint.transform.rotation.yaw + offset['orientation']
         offset_location = carla.Location(
@@ -162,7 +162,7 @@ class DynamicObjectCrossing(BasicScenario):
         lane_width = self._reference_waypoint.lane_width
         location, _ = get_location_in_distance(self.ego_vehicle, _start_distance)
         waypoint = self._wmap.get_waypoint(location)
-        offset = {"orientation": 270, "position": 90, "z": 0.2, "k": 1.1}
+        offset = {"orientation": 270, "position": 90, "z": 0.4, "k": 1.1}
         position_yaw = waypoint.transform.rotation.yaw + offset['position']
         orientation_yaw = waypoint.transform.rotation.yaw + offset['orientation']
         offset_location = carla.Location(

--- a/srunner/scenarios/opposite_vehicle_taking_priority.py
+++ b/srunner/scenarios/opposite_vehicle_taking_priority.py
@@ -98,7 +98,7 @@ class OppositeVehicleRunningRedLight(BasicScenario):
         first_vehicle_transform = carla.Transform(
             carla.Location(config.other_actors[0].transform.location.x,
                            config.other_actors[0].transform.location.y,
-                           config.other_actors[0].transform.location.z - 5),
+                           config.other_actors[0].transform.location.z - 500),
             config.other_actors[0].transform.rotation)
         first_vehicle = CarlaActorPool.request_new_actor(config.other_actors[0].model, first_vehicle_transform)
         self.other_actors.append(first_vehicle)

--- a/srunner/scenarios/other_leading_vehicle.py
+++ b/srunner/scenarios/other_leading_vehicle.py
@@ -38,6 +38,7 @@ class OtherLeadingVehicle(BasicScenario):
     """
     This class holds everything required for a simple "Other Leading Vehicle"
     scenario involving a user controlled vehicle and two other actors.
+    Traffic Scenario 05
     """
     category = "OtherLeadingVehicle"
 
@@ -69,6 +70,7 @@ class OtherLeadingVehicle(BasicScenario):
                                                   debug_mode,
                                                   criteria_enable=criteria_enable)
         # traffic light
+        print(" other vehicle ", self.other_actors[0].get_transform())
         self._traffic_light = CarlaDataProvider.get_next_traffic_light(self.other_actors[0], False)
 
         if self._traffic_light is None:
@@ -96,13 +98,13 @@ class OtherLeadingVehicle(BasicScenario):
         first_vehicle_transform = carla.Transform(
             carla.Location(first_vehicle_waypoint.transform.location.x,
                            first_vehicle_waypoint.transform.location.y,
-                           first_vehicle_waypoint.transform.location.z - 5),
+                           first_vehicle_waypoint.transform.location.z - 500),
             first_vehicle_waypoint.transform.rotation)
 
         second_vehicle_transform = carla.Transform(
             carla.Location(second_vehicle_waypoint.transform.location.x,
                            second_vehicle_waypoint.transform.location.y,
-                           second_vehicle_waypoint.transform.location.z - 5),
+                           second_vehicle_waypoint.transform.location.z - 500),
             second_vehicle_waypoint.transform.rotation)
 
         first_vehicle = CarlaActorPool.request_new_actor('vehicle.nissan.patrol', first_vehicle_transform)

--- a/srunner/scenarios/signalized_junction_left_turn.py
+++ b/srunner/scenarios/signalized_junction_left_turn.py
@@ -51,7 +51,7 @@ class SignalizedJunctionLeftTurn(BasicScenario):
                                                          world,
                                                          debug_mode,
                                                          criteria_enable=criteria_enable)
-        print (" ego vehicle ", self.ego_vehicle.get_transform())
+
         self._traffic_light = CarlaDataProvider.get_next_traffic_light(self.ego_vehicle, False)
         if self._traffic_light is None:
             print("No traffic light for the given location of the ego vehicle found")
@@ -59,7 +59,6 @@ class SignalizedJunctionLeftTurn(BasicScenario):
         self._traffic_light.set_state(carla.TrafficLightState.Green)
         self._traffic_light.set_green_time(self.timeout)
         # other vehicle's traffic light
-        print(" other actor ", self.ego_vehicle.get_transform())
         traffic_light_other = CarlaDataProvider.get_next_traffic_light(self.other_actors[0], False)
         if traffic_light_other is None:
             print("No traffic light for the given location of the other vehicle found")

--- a/srunner/scenarios/signalized_junction_left_turn.py
+++ b/srunner/scenarios/signalized_junction_left_turn.py
@@ -51,7 +51,7 @@ class SignalizedJunctionLeftTurn(BasicScenario):
                                                          world,
                                                          debug_mode,
                                                          criteria_enable=criteria_enable)
-
+        print (" ego vehicle ", self.ego_vehicle.get_transform())
         self._traffic_light = CarlaDataProvider.get_next_traffic_light(self.ego_vehicle, False)
         if self._traffic_light is None:
             print("No traffic light for the given location of the ego vehicle found")
@@ -59,6 +59,7 @@ class SignalizedJunctionLeftTurn(BasicScenario):
         self._traffic_light.set_state(carla.TrafficLightState.Green)
         self._traffic_light.set_green_time(self.timeout)
         # other vehicle's traffic light
+        print(" other actor ", self.ego_vehicle.get_transform())
         traffic_light_other = CarlaDataProvider.get_next_traffic_light(self.other_actors[0], False)
         if traffic_light_other is None:
             print("No traffic light for the given location of the other vehicle found")
@@ -74,7 +75,7 @@ class SignalizedJunctionLeftTurn(BasicScenario):
         first_vehicle_transform = carla.Transform(
             carla.Location(config.other_actors[0].transform.location.x,
                            config.other_actors[0].transform.location.y,
-                           config.other_actors[0].transform.location.z - 5),
+                           config.other_actors[0].transform.location.z - 500),
             config.other_actors[0].transform.rotation)
         first_vehicle = CarlaActorPool.request_new_actor(config.other_actors[0].model, first_vehicle_transform)
         self.other_actors.append(first_vehicle)

--- a/srunner/scenarios/signalized_junction_right_turn.py
+++ b/srunner/scenarios/signalized_junction_right_turn.py
@@ -50,7 +50,7 @@ class SignalizedJunctionRightTurn(BasicScenario):
                                                           world,
                                                           debug_mode,
                                                           criteria_enable=criteria_enable)
-
+        print ("ego transform ", self.ego_vehicle)
         self._traffic_light = CarlaDataProvider.get_next_traffic_light(self.ego_vehicle, False)
         if self._traffic_light is None:
             print("No traffic light for the given location of the ego vehicle found")
@@ -73,7 +73,7 @@ class SignalizedJunctionRightTurn(BasicScenario):
         first_vehicle_transform = carla.Transform(
             carla.Location(config.other_actors[0].transform.location.x,
                            config.other_actors[0].transform.location.y,
-                           config.other_actors[0].transform.location.z - 0),
+                           config.other_actors[0].transform.location.z - 500),
             config.other_actors[0].transform.rotation)
         first_vehicle = CarlaActorPool.request_new_actor(config.other_actors[0].model, first_vehicle_transform)
         self.other_actors.append(first_vehicle)

--- a/srunner/scenarios/signalized_junction_right_turn.py
+++ b/srunner/scenarios/signalized_junction_right_turn.py
@@ -50,7 +50,7 @@ class SignalizedJunctionRightTurn(BasicScenario):
                                                           world,
                                                           debug_mode,
                                                           criteria_enable=criteria_enable)
-        print ("ego transform ", self.ego_vehicle)
+
         self._traffic_light = CarlaDataProvider.get_next_traffic_light(self.ego_vehicle, False)
         if self._traffic_light is None:
             print("No traffic light for the given location of the ego vehicle found")

--- a/srunner/testing/test_scenario_building.py
+++ b/srunner/testing/test_scenario_building.py
@@ -47,13 +47,13 @@ class TestScenarioBuilder(unittest.TestCase):
         # For each of the routes to be evaluated.
         for route_description in list_route_descriptions:
 
-            if route_description['town_name'] == 'Town03' or route_description['town_name'] == 'Town04':
+            print (" TOWN  ", route_description['town_name'])
+            if route_description['town_name'] == 'Town01' or route_description['town_name'] == 'Town03':
                 continue
             challenge.world = client.load_world(route_description['town_name'])
 
             # Set the actor pool so the scenarios can prepare themselves when needed
             CarlaActorPool.set_world(challenge.world)
-
             CarlaDataProvider.set_world(challenge.world)
             # find and filter potential scenarios
             # Returns the iterpolation in a different format
@@ -67,19 +67,30 @@ class TestScenarioBuilder(unittest.TestCase):
             # Sample the scenarios
             sampled_scenarios = challenge.scenario_sampling(potential_scenarios_definitions)
 
+
             # prepare route's trajectory
-            elevate_transform = route_description['trajectory'][0][0].transform
+            elevate_transform = route_description['trajectory'][0][0]
             elevate_transform.location.z += 0.5
             challenge.prepare_ego_car(elevate_transform)
 
             # build the master scenario based on the route and the target.
-            master_scenario = challenge.build_master_scenario(route_description['trajectory'], route_description['town_name'])
+            print ("loading master")
+            master_scenario = challenge.build_master_scenario(route_description['trajectory'],
+                                                              route_description['town_name'])
             list_scenarios = [master_scenario]
-            print (" TOWN  ", route_description['town_name'])
             print (" Built the master scenario ")
             # build the instance based on the parsed definitions.
             print (sampled_scenarios)
-            list_scenarios += challenge.build_scenario_instances(sampled_scenarios, route_description['town_name'])
+            # remove scenario 8 and 9
+            scenario_removed = []
+            for possible_scenario in sampled_scenarios:
+                if possible_scenario['name'] == 'Scenario8' or possible_scenario['name'] == 'Scenario7' or \
+                        possible_scenario['name'] == 'Scenario9' or possible_scenario['name'] == 'Scenario5':
+                    continue
+                else:
+                    scenario_removed.append(possible_scenario)
+
+            list_scenarios += challenge.build_scenario_instances(scenario_removed, route_description['town_name'])
             print (" Scenarios present ", list_scenarios)
 
             challenge.cleanup(ego=True)


### PR DESCRIPTION

#### Description

This pr changes the start position of scenarios to a deeper level.
I also fixed a bug on timeout initialization. 

Current Status:
Town 01 Spawn all scenarios
Town 03-Town04 Fails because there are start positions on intersections


#### Where has this been tested?

  * **Platform(s):** ubntu
  * **Python version(s):** 3.5
  * **Unreal Engine version(s):** ...
  * **CARLA version:** nightly from las friday.
#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/136)
<!-- Reviewable:end -->
