### PR TITLE
Resetting actor kinematics on ActorTransformSetter

### DIFF
--- a/srunner/scenariomanager/atomic_scenario_behavior.py
+++ b/srunner/scenariomanager/atomic_scenario_behavior.py
@@ -978,6 +978,8 @@ class ActorTransformSetter(AtomicBehavior):
         """
         new_status = py_trees.common.Status.RUNNING
 
+        self._actor.set_velocity(carla.Vector3D(0, 0, 0))
+        self._actor.set_angular_velocity(carla.Vector3D(0, 0, 0))
         self._actor.set_transform(self._transform)
         new_status = py_trees.common.Status.SUCCESS
         return new_status


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [X] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [X] Extended the README / documentation, if necessary
  - [X] Code compiles correctly and runs
  - [X] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [X] Changelog is updated

-->

#### Description
Added code to reset actor velocity and angular velocity to 0 before moving the actors above ground.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2.7
  * **Unreal Engine version(s):** 
  * **CARLA version:** Carla overnight build of monday

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/139)
<!-- Reviewable:end -->
