### PR TITLE
Added methods to calculate distances along route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Added running red light test
 * Added running stop test
 * Added various helper methods to allow generic scenario execution
+* Added method to calculate distance along a route
 * Updated folder structure and naming convention in lowercase
 * Reworked scenario execution
     - Every scenario has to have a configuration provided as XML file.
@@ -39,6 +40,7 @@
     - ActorTransformSetter: sets transform of given actor
     - ActorSource: creates actors indefinitely around a location if no other vehicles are present within a threshold
     - ActorSink: indefinitely destroys vehicles that wander close to a location within a threshold
+    - InTriggerDistanceToLocationAlongRoute: check if an actor is within a certain distance to a given location along a given route
 * Fixes
     - Fixed SteerVehicle atomic behavior to keep vehicle velocity
 * Updated NHTSA Traffic Scenarios

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,6 @@
+# Frequently Asked Questions
+
+## I receive the error "TypeError: 'instancemethod' object has no attribute '__getitem__'" in the agent navigation
+
+This issue is most likely caused by an outdated version of the Python Networkx package. Please remove the current installation
+(e.g. sudo apt-get remove python-networkx) and install it using "pip install --user networkx".

--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -34,7 +34,7 @@ then
     echo "export CARLA_ROOT=${CARLA_ROOT}" >> ${HOME}/.bashrc
     echo "export CARLA_SERVER=${CARLA_SERVER}" >> ${HOME}/.bashrc
     echo "export ROOT_SCENARIO_RUNNER=`pwd`" >> ${HOME}/.bashrc
-    echo "export PYTHONPATH=\"${CARLA_ROOT}/PythonAPI/:${ROOT_SCENARIO_RUNNER}:`pwd`:${PYTHONPATH}\" " >> ${HOME}/.bashrc
+    echo "export PYTHONPATH=\"${CARLA_ROOT}/PythonAPI/carla/:${CARLA_ROOT}/PythonAPI/carla/agents/:${ROOT_SCENARIO_RUNNER}:`pwd`:${PYTHONPATH}\" " >> ${HOME}/.bashrc
 
     echo "== CARLA server setup successfully!"
     echo "== Remember to run: source ${HOME}/.bashrc"

--- a/srunner/challenge/challenge_evaluator_routes.py
+++ b/srunner/challenge/challenge_evaluator_routes.py
@@ -118,6 +118,7 @@ def compare_scenarios(scenario_choice, existent_scenario):
 
     return False
 
+
 def convert_transform_to_location(transform_vec):
 
     location_vec = []
@@ -125,7 +126,6 @@ def convert_transform_to_location(transform_vec):
         location_vec.append((transform_tuple[0].location, transform_tuple[1]))
 
     return location_vec
-
 
 
 Z_DISTANCE_AVOID_COLLISION = 0.5  # z vallue to add in oder to avoid spawning vehicles to close to the ground
@@ -739,7 +739,6 @@ class ChallengeEvaluator(object):
                     scenarios_after_filter[trigger].append(possible_scenario)
         return scenarios_after_filter
 
-
     def valid_sensors_configuration(self, agent, track):
         if Track(track) != agent.track:
             return False, "You are submitting to the wrong track [{}]!".format(Track(track))
@@ -803,6 +802,8 @@ class ChallengeEvaluator(object):
                                                                                 route_description['trajectory'])
             potential_scenarios_definitions, existent_triggers = parser.scan_route_for_scenarios(route_description,
                                                                                                  world_annotations)
+            CarlaDataProvider.set_ego_vehicle_route(convert_transform_to_location(route_description['trajectory']))
+
             # Sample the scenarios to be used for this route instance.
             sampled_scenarios_definitions = self.scenario_sampling(potential_scenarios_definitions)
             # create agent

--- a/srunner/challenge/test_challenge_route.py
+++ b/srunner/challenge/test_challenge_route.py
@@ -28,6 +28,13 @@ from srunner.scenariomanager.carla_data_provider import CarlaActorPool, CarlaDat
 # We import the challenge evaluator here
 from srunner.challenge.challenge_evaluator_routes import ChallengeEvaluator
 
+def convert_transform_to_location(transform_vec):
+
+    location_vec = []
+    for transform_tuple in transform_vec:
+        location_vec.append((transform_tuple[0].location, transform_tuple[1]))
+
+    return location_vec
 
 def create_configuration_scenario( scenario_desc, scenario_type):
     waypoint = scenario_desc['transform']
@@ -79,6 +86,8 @@ def test_routes(args):
     # prepare route's trajectory
     gps_route, route_description['trajectory'] = interpolate_trajectory(challenge.world,
                                                                         route_description['trajectory'])
+
+    CarlaDataProvider.set_ego_vehicle_route(convert_transform_to_location(route_description['trajectory']))
 
     potential_scenarios_definitions, existent_triggers = parser.scan_route_for_scenarios(route_description,
                                                                                          world_annotations)

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -49,6 +49,7 @@ class CarlaDataProvider(object):
     _map = None
     _world = None
     _sync_flag = False
+    _ego_vehicle_route = None
 
     @staticmethod
     def register_actor(actor):
@@ -199,6 +200,14 @@ class CarlaDataProvider(object):
                     distance_to_relevant_traffic_light = distance
 
         return relevant_traffic_light
+
+    @staticmethod
+    def set_ego_vehicle_route(route):
+        CarlaDataProvider._ego_vehicle_route = route
+
+    @staticmethod
+    def get_ego_vehicle_route():
+        return CarlaDataProvider._ego_vehicle_route
 
     @staticmethod
     def cleanup():

--- a/srunner/scenarios/basic_scenario.py
+++ b/srunner/scenarios/basic_scenario.py
@@ -12,11 +12,9 @@ This module provide the basic class for all user-defined scenarios.
 from __future__ import print_function
 
 import py_trees
-import math
 import carla
-import numpy as np
 
-from srunner.scenariomanager.atomic_scenario_behavior import InTimeToArrivalToLocation
+from srunner.scenariomanager.atomic_scenario_behavior import InTriggerDistanceToLocationAlongRoute
 from srunner.scenariomanager.carla_data_provider import CarlaActorPool, CarlaDataProvider
 from srunner.scenariomanager.scenario_manager import Scenario
 
@@ -44,7 +42,7 @@ class BasicScenario(object):
         self._check_town(world)
 
         self.ego_vehicle = ego_vehicle
-        self.name = name
+        self.name = name + str(config.trigger_point)
         self.terminate_on_failure = terminate_on_failure
 
         # Initializing adversarial actors
@@ -70,10 +68,12 @@ class BasicScenario(object):
         if config.trigger_point:
             start_location = config.trigger_point.location     # start location of the scenario
 
-        time_to_start_location = 2.0                               # seconds
         behavior_seq = py_trees.composites.Sequence()
         if start_location:
-            behavior_seq.add_child(InTimeToArrivalToLocation(self.ego_vehicle, time_to_start_location, start_location))
+            behavior_seq.add_child(InTriggerDistanceToLocationAlongRoute(self.ego_vehicle,
+                                                                         CarlaDataProvider.get_ego_vehicle_route(),
+                                                                         start_location,
+                                                                         30))
         behavior_seq.add_child(behavior)
 
         self.scenario = Scenario(behavior_seq, criteria, self.name, self.timeout, self.terminate_on_failure)

--- a/srunner/scenarios/basic_scenario.py
+++ b/srunner/scenarios/basic_scenario.py
@@ -42,7 +42,7 @@ class BasicScenario(object):
         self._check_town(world)
 
         self.ego_vehicle = ego_vehicle
-        self.name = name + str(config.trigger_point)
+        self.name = name
         self.terminate_on_failure = terminate_on_failure
 
         # Initializing adversarial actors

--- a/srunner/tools/config_parser.py
+++ b/srunner/tools/config_parser.py
@@ -41,6 +41,7 @@ class RouteConfiguration(object):
 
             self.data.append((carla.Location(x, y, z), connection))
 
+
 class TargetConfiguration(object):
 
     """
@@ -98,7 +99,7 @@ class ActorConfiguration(ActorConfigurationData):
         amount = 1
         if 'amount' in node.keys():
             amount = int(node.attrib['amount'])
-        
+
         super(ActorConfiguration, self).__init__(
             set_attrib(node, 'model', 'vehicle.*'),
             carla.Transform(carla.Location(x=pos_x, y=pos_y, z=pos_z), carla.Rotation(yaw=yaw)),

--- a/srunner/utilities/code_check_and_formatting.sh
+++ b/srunner/utilities/code_check_and_formatting.sh
@@ -4,9 +4,11 @@ autopep8 scenario_runner.py --in-place --max-line-length=120
 autopep8 srunner/scenariomanager/*.py --in-place --max-line-length=120
 autopep8 srunner/scenarios/*.py --in-place --max-line-length=120
 autopep8 srunner/challenge/*.py --in-place --max-line-length=120
+autopep8 srunner/tools/*.py --in-place --max-line-length=120
 
 
 pylint --rcfile=.pylintrc --disable=I srunner/scenariomanager/
 pylint --rcfile=.pylintrc srunner/scenarios/
 pylint --rcfile=.pylintrc srunner/challenge/
+pylint --rcfile=.pylintrc srunner/tools/
 pylint --rcfile=.pylintrc scenario_runner.py


### PR DESCRIPTION
#### Description
A new atomic behavior InTriggerDistanceToLocationAlongRoute was added.

As the name indiciates, the behavior calculates the distance to a given
location along a given route.

Therefore, a new method was added to tools/scenario_helper.py to
calculate the distance along a given route: get_distance_along_route()

The new behavior is used in the BasicScenario class to trigger a
scenario.

*Fixes* the trigger issue if a scenario is not directly "located" on the ego vehicle route

*Other edits*
- Added FAQ
- Updated setup script to match CARLA 0.9.5

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** Python 3.5 , 2.7
  * **Unreal Engine version(s):** 4.21
  * **CARLA version:** 0.95

#### Possible Drawbacks

If there is a loop in the route, a scenario is only triggered on the first pass of the loop segment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/165)
<!-- Reviewable:end -->
