### PR TITLE
Fixed scenario cleanup when running sequences or repetitions

### DIFF
--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -233,7 +233,7 @@ class ScenarioRunner(object):
 
                 # Stop scenario and cleanup
                 self.manager.stop_scenario()
-                del scenario
+                scenario.remove_all_actors()
 
                 self.cleanup()
 

--- a/srunner/challenge/test_challenge_route.py
+++ b/srunner/challenge/test_challenge_route.py
@@ -151,7 +151,7 @@ def test_routes(args):
 
     # clean up
     for scenario in list_scenarios:
-        del scenario
+        scenario.remove_all_actors()
     challenge.cleanup(ego=True)
     challenge.agent_instance.destroy()
 

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -218,6 +218,9 @@ class CarlaDataProvider(object):
         CarlaDataProvider._actor_location_map.clear()
         CarlaDataProvider._traffic_light_map.clear()
         CarlaDataProvider._map = None
+        CarlaDataProvider._world = None
+        CarlaDataProvider._sync_flag = False
+        CarlaDataProvider._ego_vehicle_route = None
 
 
 class CarlaActorPool(object):
@@ -421,6 +424,9 @@ class CarlaActorPool(object):
 
         CarlaActorPool._carla_actor_pool = dict()
         CarlaActorPool._world = None
+        CarlaActorPool._client = None
+        CarlaActorPool._spawn_points = None
+        CarlaActorPool._spawn_index = 0
 
     @staticmethod
     def remove_all_actors_in_surrounding(location, distance):


### PR DESCRIPTION
The following fixes are included
- Reset of py_tree states to INVALID --> Next run does not skip execution
- Removal of destructor calls for scenarios --> Proper actor cleanup


#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.5
  * **Unreal Engine version(s):** 4.21
  * **CARLA version:** 0.9.5

#### Possible Drawbacks
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/177)
<!-- Reviewable:end -->
