### PR TITLE
Do not modify the image encoding

### DIFF
--- a/srunner/challenge/envs/sensor_interface.py
+++ b/srunner/challenge/envs/sensor_interface.py
@@ -190,8 +190,6 @@ class CallBack(object):
         array = np.frombuffer(image.raw_data, dtype=np.dtype("uint8"))
         array = copy.deepcopy(array)
         array = np.reshape(array, (image.height, image.width, 4))
-        array = array[:, :, :3]
-        array = array[:, :, ::-1]
         self._data_provider.update_sensor(tag, array, image.frame_number)
 
     def _parse_lidar_cb(self, lidar_data, tag):


### PR DESCRIPTION
Carla+PythonAPI currently send out RGBA8 encoding.

In challenge mode it's currently converted to RGB8.

We should have the same encoding in normal- and challenge-mode to be able to reuse algorithms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/181)
<!-- Reviewable:end -->
