### PR TITLE
Avoid removing actors twice.

### DIFF
--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -415,7 +415,15 @@ class CarlaActorPool(object):
 
         CarlaActorPool._carla_actor_pool[actor.id] = actor
         return actor
-
+    @staticmethod
+    def actor_id_exists(actor_id):
+        """
+        Check if a certain id is still at the simulation
+        """
+        if actor_id in CarlaActorPool._carla_actor_pool:
+            return True
+        else:
+            return False
     @staticmethod
     def get_actor_by_id(actor_id):
         """

--- a/srunner/scenarios/basic_scenario.py
+++ b/srunner/scenarios/basic_scenario.py
@@ -142,6 +142,7 @@ class BasicScenario(object):
         """
         for i, _ in enumerate(self.other_actors):
             if self.other_actors[i] is not None:
-                CarlaActorPool.remove_actor_by_id(self.other_actors[i].id)
+                if CarlaActorPool.actor_id_exists(self.other_actors[i].id):
+                    CarlaActorPool.remove_actor_by_id(self.other_actors[i].id)
                 self.other_actors[i] = None
         self.other_actors = []


### PR DESCRIPTION

#### Description

The background class already remove actors, but they are not erased from the other actor list.
Added a check to see if the actor is already removed before removing it.

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...
  * **CARLA version:** ...

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/195)
<!-- Reviewable:end -->
