### PR TITLE
Reduced duration (distance) of control loss scenario

### DIFF
--- a/srunner/scenarios/control_loss.py
+++ b/srunner/scenarios/control_loss.py
@@ -34,8 +34,6 @@ class ControlLoss(BasicScenario):
 
     category = "ControlLoss"
 
-    timeout = 60            # Timeout of scenario in seconds
-
     def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=60):
         """
@@ -52,7 +50,7 @@ class ControlLoss(BasicScenario):
         self._current_throttle_noise = [0]
         self._start_distance = 20
         self._trigger_dist = 2
-        self._end_distance = 70
+        self._end_distance = 30
         self._ego_vehicle_max_steer = 0.0
         self._ego_vehicle_max_throttle = 1.0
         self._ego_vehicle_target_velocity = 15


### PR DESCRIPTION
#### Description

Title says everything

#### Where has this been tested?

  * **Platform(s):** 16.04
  * **Python version(s):** 2.7 and 3.5
  * **Unreal Engine version(s):** 4.21
  * **CARLA version:** Latest master


#### Discussion
I think the behavior should end after the last jitter, however it continues for a certain distance. Therefore, I reduced the distance for now. Please merge, if you agree. Otherwise, the end_noise behavior should be moved to an earlier place in the behavior sequence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/202)
<!-- Reviewable:end -->
