### PR TITLE
Fix: bug in trafficLightManipulator

### DIFF
--- a/srunner/scenariomanager/atomic_scenario_behavior.py
+++ b/srunner/scenariomanager/atomic_scenario_behavior.py
@@ -1256,7 +1256,7 @@ class TrafficLightManipulator(AtomicBehavior):
     """
 
     MAX_DISTANCE_TRAFFIC_LIGHT = 15
-    RANDOM_VALUE_INTERVENTION = 0.3
+    RANDOM_VALUE_INTERVENTION = 0.4
     RED = carla.TrafficLightState.Red
     GREEN = carla.TrafficLightState.Green
 
@@ -1291,7 +1291,9 @@ class TrafficLightManipulator(AtomicBehavior):
                 # nothing else to do in this iteration...
                 return new_status
 
-            distance_to_traffic_light = traffic_light.get_location().distance(self.ego_vehicle.get_location())
+            base_transform = traffic_light.get_transform()
+            area_loc = carla.Location(base_transform.transform(traffic_light.trigger_volume.location))
+            distance_to_traffic_light = area_loc.distance(self.ego_vehicle.get_location())
 
             if self.debug:
                 print("[{}] distance={}".format(traffic_light.id, distance_to_traffic_light))
@@ -1321,8 +1323,10 @@ class TrafficLightManipulator(AtomicBehavior):
 
             else:
                 # the traffic light has been manipulated...
-                distance_to_traffic_light = self.target_traffic_light.get_location().distance(
-                    self.ego_vehicle.get_location())
+                base_transform =  self.target_traffic_light.get_transform()
+                area_loc = carla.Location(base_transform.transform( self.target_traffic_light.trigger_volume.location))
+                distance_to_traffic_light = area_loc.distance(self.ego_vehicle.get_location())
+
                 if self.debug:
                     print("++ distance={}".format(distance_to_traffic_light))
 


### PR DESCRIPTION
TrafficLightManipulator was using distance of the ego-car to the actual traffic light pole
instead of distance between the ego-car and the trigger area of the traffic light.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [X] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [X] Extended the README / documentation, if necessary
  - [X] Code compiles correctly and runs
  - [X] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [X] Changelog is updated

-->

#### Description

  Fix: bug in trafficLightManipulator
    
    TrafficLightManipulator was using distance of the ego-car to the actual traffic light pole
    instead of distance between the ego-car and the trigger area of the traffic light.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 3.5.5
  * **Unreal Engine version(s):** NA
  * **CARLA version:** overnight

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/257)
<!-- Reviewable:end -->
