### PR TITLE
Removed collisions with sidewalk as failures

### DIFF
--- a/srunner/scenariomanager/atomic_scenario_criteria.py
+++ b/srunner/scenariomanager/atomic_scenario_criteria.py
@@ -287,7 +287,7 @@ class CollisionTest(Criterion):
 
         registered = False
         actor_type = None
-        if 'static' in event.other_actor.type_id:
+        if 'static' in event.other_actor.type_id and 'sidewalk' not in event.other_actor.type_id:
             actor_type = TrafficEventType.COLLISION_STATIC
             self.test_status = "FAILURE"
         elif 'vehicle' in event.other_actor.type_id:


### PR DESCRIPTION
A sidewalk should only count as invasion not as collision

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/270)
<!-- Reviewable:end -->
