### PR TITLE
Support for multiple ego vehicles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Latest changes
+* Added support for multiple ego vehicles plus an example
+* Added commandline option for output directory
+* Added option to load external scenario implementations (in python)
+* Added option to scenario_runner to load external scenario XMLs
 
 ## CARLA Scenario_Runner 0.9.5
 * Added support for CARLA challenge

--- a/Docs/creating_new_scenario.md
+++ b/Docs/creating_new_scenario.md
@@ -76,3 +76,12 @@ Finally the scenario configuration should be added to the Configs/ folder. If yo
 extend an already existing scenario module, you can simply extend the corresponding
 XML, otherwise add a new XML file. In this case you can use any of the existing
 XML files as blueprint.
+
+If you want to add multiple ego vehicles for a scenario, make sure that they use different
+role names, e.g.
+```
+    <scenario name="MultiEgoTown03" type="FreeRide" town="Town03">
+        <ego_vehicle x="207" y="59" z="0" yaw="180" model="vehicle.lincoln.mkz2017" rolename="hero"/>
+        <ego_vehicle x="237" y="-95.0754252474" z="0" yaw="90" model="vehicle.tesla.model3" rolename="hero2"/>
+    </scenario>
+```

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -230,6 +230,7 @@ class ScenarioRunner(object):
             scenario_configurations = parse_scenario_configuration(scenario_config_file, args.scenario)
 
             # Execute each configuration
+            config_counter = 0
             for config in scenario_configurations:
                 if args.reloadWorld:
                     self.world = self.client.load_world(config.town)
@@ -247,7 +248,7 @@ class ScenarioRunner(object):
                 scenario_class = self.get_scenario_class_or_fail(config.type)
                 try:
                     CarlaActorPool.set_world(self.world)
-                    self.prepare_ego_vehicles(config, args.waitForEgo)
+                    self.prepare_ego_vehicles(config, args.waitForEgo or (config_counter > 0))
                     scenario = scenario_class(self.world,
                                               self.ego_vehicles,
                                               config,
@@ -259,6 +260,7 @@ class ScenarioRunner(object):
                         traceback.print_exc()
                     print(exception)
                     self.cleanup()
+                    config_counter += 1
                     continue
 
                 # Load scenario and run it
@@ -272,7 +274,10 @@ class ScenarioRunner(object):
                 self.manager.stop_scenario()
                 scenario.remove_all_actors()
 
-                self.cleanup(ego=(not args.waitForEgo))
+                self.cleanup()
+                config_counter += 1
+
+            self.cleanup(ego=(not args.waitForEgo))
 
             print("No more scenarios .... Exiting")
 

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -78,13 +78,12 @@ class ScenarioRunner(object):
     ego_vehicles = []
 
     # Tunable parameters
-    client_timeout = 10.0  # in seconds
-    wait_for_world = 10.0  # in seconds
+    client_timeout = 30.0  # in seconds
+    wait_for_world = 20.0  # in seconds
 
     # CARLA world and scenario handlers
     world = None
     manager = None
-
 
     additional_scenario_module = None
 
@@ -149,9 +148,8 @@ class ScenarioRunner(object):
         CarlaActorPool.cleanup()
 
         if ego:
-            for i,_ in enumerate(self.ego_vehicles):
+            for i, _ in enumerate(self.ego_vehicles):
                 if self.ego_vehicles[i]:
-                    self.ego_vehicles[i]
                     self.ego_vehicles[i] = None
             self.ego_vehicles = []
 
@@ -183,7 +181,6 @@ class ScenarioRunner(object):
                         if carla_vehicle.attributes['role_name'] == ego_vehicle.rolename:
                             ego_vehicle_found = True
                             self.ego_vehicles.append(carla_vehicle)
-                            self.ego_vehicles[-1].set_transform(ego_vehicle.transform)
                             break
                     if not ego_vehicle_found:
                         ego_vehicle_missing = True
@@ -229,7 +226,8 @@ class ScenarioRunner(object):
 
             # Execute each configuration
             for config in scenario_configurations:
-                self.world = self.client.load_world(config.town)
+                if args.reloadWorld:
+                    self.world = self.client.load_world(config.town)
                 CarlaActorPool.set_client(self.client)
                 CarlaDataProvider.set_world(self.world)
 
@@ -293,6 +291,8 @@ if __name__ == '__main__':
     PARSER.add_argument('--waitForEgo', action="store_true", help='Connect the scenario to an existing ego vehicle')
     PARSER.add_argument('--configFile', default='', help='Provide an additional scenario configuration file (*.xml)')
     PARSER.add_argument('--additionalScenario', default='', help='Provide additional scenario implementations (*.py)')
+    PARSER.add_argument('--reloadWorld', action="store_true",
+                        help='Reload the CARLA world before starting a scenario (default=True)')
     # pylint: disable=line-too-long
     PARSER.add_argument(
         '--scenario', help='Name of the scenario to be executed. Use the preposition \'group:\' to run all scenarios of one class, e.g. ControlLoss or FollowLeadingVehicle')

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -147,11 +147,12 @@ class ScenarioRunner(object):
         CarlaDataProvider.cleanup()
         CarlaActorPool.cleanup()
 
-        if ego:
-            for i, _ in enumerate(self.ego_vehicles):
-                if self.ego_vehicles[i]:
-                    self.ego_vehicles[i] = None
-            self.ego_vehicles = []
+        for i, _ in enumerate(self.ego_vehicles):
+            if self.ego_vehicles[i]:
+                if ego:
+                    self.ego_vehicles[i].destroy()
+                self.ego_vehicles[i] = None
+        self.ego_vehicles = []
 
     def prepare_ego_vehicles(self, config, wait_for_ego_vehicles=False):
         """
@@ -167,8 +168,6 @@ class ScenarioRunner(object):
                                                                     vehicle.transform,
                                                                     vehicle.rolename,
                                                                     True))
-            # sync state
-            CarlaDataProvider.get_world().wait_for_tick()
         else:
             ego_vehicle_missing = True
             while ego_vehicle_missing:
@@ -185,6 +184,12 @@ class ScenarioRunner(object):
                     if not ego_vehicle_found:
                         ego_vehicle_missing = True
                         break
+
+            for i, _ in enumerate(self.ego_vehicles):
+                self.ego_vehicles[i].set_transform(config.ego_vehicles[i].transform)
+
+        # sync state
+        CarlaDataProvider.get_world().wait_for_tick()
 
     def analyze_scenario(self, args, config):
         """
@@ -267,7 +272,7 @@ class ScenarioRunner(object):
                 self.manager.stop_scenario()
                 scenario.remove_all_actors()
 
-                self.cleanup(ego=True)
+                self.cleanup(ego=(not args.waitForEgo))
 
             print("No more scenarios .... Exiting")
 

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -184,14 +184,12 @@ class ScenarioRunner(object):
 
             # Load the scenario configurations provided in the config file
             scenario_configurations = None
-            if args.scenario.startswith("group:"):
-                scenario_configurations = parse_scenario_configuration(args.scenario, args.scenario)
-            else:
-                scenario_config_file = find_scenario_config(args.scenario)
-                if scenario_config_file is None:
-                    print("Configuration for scenario {} cannot be found!".format(args.scenario))
-                    continue
-                scenario_configurations = parse_scenario_configuration(scenario_config_file, args.scenario)
+            scenario_config_file = find_scenario_config(args.scenario, args.configFile)
+            if scenario_config_file is None:
+                print("Configuration for scenario {} cannot be found!".format(args.scenario))
+                continue
+
+            scenario_configurations = parse_scenario_configuration(scenario_config_file, args.scenario)
 
             # Execute each configuration
             for config in scenario_configurations:
@@ -255,6 +253,7 @@ if __name__ == '__main__':
     PARSER.add_argument('--output', action="store_true", help='Provide results on stdout')
     PARSER.add_argument('--file', action="store_true", help='Write results into a txt file')
     PARSER.add_argument('--junit', action="store_true", help='Write results into a junit file')
+    PARSER.add_argument('--configFile', default='', help='Provide an additional scenario configuration file')
     # pylint: disable=line-too-long
     PARSER.add_argument(
         '--scenario', help='Name of the scenario to be executed. Use the preposition \'group:\' to run all scenarios of one class, e.g. ControlLoss or FollowLeadingVehicle')
@@ -268,7 +267,7 @@ if __name__ == '__main__':
 
     if ARGUMENTS.list:
         print("Currently the following scenarios are supported:")
-        print(*get_list_of_scenarios(), sep='\n')
+        print(*get_list_of_scenarios(ARGUMENTS.configFile), sep='\n')
         sys.exit(0)
 
     if ARGUMENTS.list_class:

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -196,11 +196,14 @@ class ScenarioRunner(object):
 
         current_time = str(datetime.now().strftime('%Y-%m-%d-%H-%M-%S'))
         junit_filename = None
+        config_name = config.name
+        if args.outputDir != '':
+            config_name = os.path.join(args.outputDir, config_name)
         if args.junit:
-            junit_filename = config.name + current_time + ".xml"
+            junit_filename = config_name + current_time + ".xml"
         filename = None
         if args.file:
-            filename = config.name + current_time + ".txt"
+            filename = config_name + current_time + ".txt"
 
         if not self.manager.analyze_scenario(args.output, filename, junit_filename):
             print("Success!")
@@ -286,6 +289,7 @@ if __name__ == '__main__':
     PARSER.add_argument('--output', action="store_true", help='Provide results on stdout')
     PARSER.add_argument('--file', action="store_true", help='Write results into a txt file')
     PARSER.add_argument('--junit', action="store_true", help='Write results into a junit file')
+    PARSER.add_argument('--outputDir', default='', help='Directory for output files (default: this directory)')
     PARSER.add_argument('--waitForEgo', action="store_true", help='Connect the scenario to an existing ego vehicle')
     PARSER.add_argument('--configFile', default='', help='Provide an additional scenario configuration file (*.xml)')
     PARSER.add_argument('--additionalScenario', default='', help='Provide additional scenario implementations (*.py)')

--- a/srunner/challenge/challenge_evaluator_routes.py
+++ b/srunner/challenge/challenge_evaluator_routes.py
@@ -183,15 +183,15 @@ class ChallengeEvaluator(object):
 
         if phase_codename == 'dev':
             split_name = 'dev_split'
-            self.routes = '{}/srunner/challenge/routes_devtest.xml'.format(scenario_runner_root)
+            self.routes =  '{}/srunner/challenge/routes_devtest.xml'.format(scenario_runner_root)
             repetitions = 1
         elif phase_codename == 'validation':
             split_name = 'val_split'
-            self.routes = '{}/srunner/challenge/routes_testprep.xml'.format(scenario_runner_root)
+            self.routes =  '{}/srunner/challenge/routes_testprep.xml'.format(scenario_runner_root)
             repetitions = 3
         elif phase_codename == 'test':
             split_name = 'test_split'
-            self.routes = '{}/srunner/challenge/routes_testchallenge.xml'.format(scenario_runner_root)
+            self.routes =  '{}/srunner/challenge/routes_testchallenge.xml'.format(scenario_runner_root)
             repetitions = 3
         else:
             # debug mode
@@ -252,6 +252,7 @@ class ChallengeEvaluator(object):
         # debugging parameters
         self.route_visible = self.debug > 0
 
+
     def within_available_time(self):
         current_time = datetime.datetime.now()
         elapsed_seconds = (current_time - self.start_wall_time).seconds
@@ -279,6 +280,7 @@ class ChallengeEvaluator(object):
 
         CarlaActorPool.cleanup()
         CarlaDataProvider.cleanup()
+
 
         if ego and self.ego_vehicle is not None:
             self.ego_vehicle.destroy()
@@ -340,7 +342,7 @@ class ChallengeEvaluator(object):
 
             for position in range(start, end):
                 self.world.debug.draw_point(waypoints[position][0].location + carla.Location(z=vertical_shift),
-                                            size=0.2, color=color, life_time=persistency)
+                                       size=0.2, color=color, life_time=persistency)
 
         self.world.debug.draw_point(waypoints[0][0].location + carla.Location(z=vertical_shift), size=0.2,
                                     color=carla.Color(0, 0, 255), life_time=persistency)
@@ -485,16 +487,17 @@ class ChallengeEvaluator(object):
         master_scenario_configuration.town = town_name
         # TODO THIS NAME IS BIT WEIRD SINCE THE EGO VEHICLE  IS ALREADY THERE, IT IS MORE ABOUT THE TRANSFORM
         master_scenario_configuration.ego_vehicle = ActorConfigurationData('vehicle.lincoln.mkz2017',
-                                                                           self.ego_vehicle.get_transform())
-        master_scenario_configuration.trigger_point = self.ego_vehicle.get_transform()
+                                                                           self.ego_vehicle.get_transform(),
+                                                                           'hero')
+        master_scenario_configuration.trigger_points = [self.ego_vehicle.get_transform()]
         CarlaDataProvider.register_actor(self.ego_vehicle)
 
         # Provide an initial blackboard entry to ensure all scenarios are running correctly
         blackboard = py_trees.blackboard.Blackboard()
         blackboard.set('master_scenario_command', 'scenarios_running')
 
-        return MasterScenario(self.world, self.ego_vehicle, master_scenario_configuration,
-                              timeout=timeout, debug_mode=self.debug > 1)
+        return MasterScenario(self.world, [self.ego_vehicle], master_scenario_configuration,
+                              timeout=timeout, debug_mode=self.debug>1)
 
     def build_background_scenario(self, town_name, timeout=300):
         scenario_configuration = ScenarioConfiguration()
@@ -503,6 +506,7 @@ class ChallengeEvaluator(object):
 
         model = 'vehicle.*'
         transform = carla.Transform()
+        rolename = 'background'
         autopilot = True
         random = True
 
@@ -521,19 +525,19 @@ class ChallengeEvaluator(object):
         else:
             amount = 1
 
-        actor_configuration_instance = ActorConfigurationData(model, transform, autopilot, random, amount)
+        actor_configuration_instance = ActorConfigurationData(model, transform, rolename, autopilot, random, amount)
         scenario_configuration.other_actors = [actor_configuration_instance]
 
-        return BackgroundActivity(self.world, self.ego_vehicle, scenario_configuration,
-                                  timeout=timeout, debug_mode=self.debug > 1)
+        return BackgroundActivity(self.world, [self.ego_vehicle], scenario_configuration,
+                                  timeout=timeout, debug_mode=self.debug>1)
 
     def build_trafficlight_scenario(self, town_name, timeout=300):
         scenario_configuration = ScenarioConfiguration()
         scenario_configuration.route = None
         scenario_configuration.town = town_name
 
-        return TrafficLightScenario(self.world, self.ego_vehicle, scenario_configuration,
-                                    timeout=timeout, debug_mode=self.debug > 1)
+        return TrafficLightScenario(self.world, [self.ego_vehicle], scenario_configuration,
+                                    timeout=timeout, debug_mode=self.debug>1)
 
     def build_scenario_instances(self, scenario_definition_vec, town_name, timeout=300):
         """
@@ -561,11 +565,12 @@ class ChallengeEvaluator(object):
             scenario_configuration = ScenarioConfiguration()
             scenario_configuration.other_actors = list_of_actor_conf_instances
             scenario_configuration.town = town_name
-            scenario_configuration.trigger_point = egoactor_trigger_position
-            scenario_configuration.ego_vehicle = ActorConfigurationData('vehicle.lincoln.mkz2017',
-                                                                        self.ego_vehicle.get_transform())
+            scenario_configuration.trigger_points = [egoactor_trigger_position]
+            scenario_configuration.ego_vehicles = [ActorConfigurationData('vehicle.lincoln.mkz2017',
+                                                                          self.ego_vehicle.get_transform(),
+                                                                          'hero')]
             try:
-                scenario_instance = ScenarioClass(self.world, self.ego_vehicle, scenario_configuration,
+                scenario_instance = ScenarioClass(self.world, [self.ego_vehicle], scenario_configuration,
                                                   criteria_enable=False, timeout=timeout)
             except Exception as e:
                 if self.debug > 1:
@@ -642,6 +647,7 @@ class ChallengeEvaluator(object):
                                              draw_shadow=False, color=carla.Color(255, 255, 255),
                                              life_time=0.01)
 
+
             if self.route_visible:
                 turn_positions_and_labels = clean_route(trajectory)
                 self.draw_waypoints(trajectory, turn_positions_and_labels,
@@ -658,14 +664,15 @@ class ChallengeEvaluator(object):
                 except Exception:
                     attempts += 1
                     print('======[WARNING] The server is frozen [{}/{} attempts]!!'.format(attempts,
-                                                                                           self.MAX_CONNECTION_ATTEMPTS))
+                                                                                       self.MAX_CONNECTION_ATTEMPTS))
                     time.sleep(2.0)
                     continue
+
 
             # check for scenario termination
             for i, _ in enumerate(self.list_scenarios):
 
-                if self.debug == 1:
+                if self.debug==1:
                     behavior = self.list_scenarios[i].scenario.scenario_tree.children[0]
                     if behavior.tip():
                         print("{} {} {} {}".format(self.list_scenarios[i].scenario.scenario_tree.name,
@@ -676,8 +683,8 @@ class ChallengeEvaluator(object):
                         "InTriggerDistanceToLocationAlongRoute" and self.list_scenarios[
                         i].scenario.scenario_tree.name != "MasterScenario" and
                         self.list_scenarios[i].scenario.scenario_tree.name != "BackgroundActivity" and
-                            self.list_scenarios[i].scenario.scenario_tree.name != "TrafficLightScenario"):
-                        pass  # TODO: find a fix for this ascii bug
+                        self.list_scenarios[i].scenario.scenario_tree.name != "TrafficLightScenario"):
+                        pass # TODO: find a fix for this ascii bug
                         # py_trees.display.print_ascii_tree(self.list_scenarios[i].scenario.scenario_tree, 2, True)
 
                     # The scenario status can be: INVALID, RUNNING, SUCCESS, FAILURE. Only the last two
@@ -689,6 +696,7 @@ class ChallengeEvaluator(object):
                     self.list_scenarios[i].remove_all_actors()
                     self.list_scenarios[i] = None
             self.list_scenarios[:] = [scenario for scenario in self.list_scenarios if scenario]
+
 
         # Route finished set for the background scenario to also finish
         blackboard = py_trees.blackboard.Blackboard()
@@ -708,6 +716,7 @@ class ChallengeEvaluator(object):
 
         return_message = error_message
         return_message += "\n=================================="
+
 
         current_statistics = {'id': -1,
                               'score_composed': score_composed,
@@ -827,6 +836,7 @@ class ChallengeEvaluator(object):
 
         return score_composed, score_route, score_penalty
 
+
     def record_route_statistics_default(self, route_id):
         """
           This function is intended to be called from outside and provide
@@ -921,9 +931,9 @@ class ChallengeEvaluator(object):
 
         return_message += "\n=================================="
         return_message += "\n==[r{}:{}] [Score = {:.2f} : (route_score={}, infractions=-{})]".format(route_id, result,
-                                                                                                     score_composed,
-                                                                                                     score_route,
-                                                                                                     score_penalty)
+                                                                                                 score_composed,
+                                                                                                 score_route,
+                                                                                                 score_penalty)
         if list_collisions:
             return_message += "\n===== Collisions:"
             for item in list_collisions:
@@ -978,6 +988,7 @@ class ChallengeEvaluator(object):
             for stats in self.statistics_routes:
                 help_message += "{}\n\n".format(stats['help_text'])
 
+
         else:
             submission_status = 'FINISHED'
 
@@ -993,7 +1004,7 @@ class ChallengeEvaluator(object):
         # create json structure
         json_data = {
             'submission_status': submission_status,
-            'stderr': help_message if self.phase == 'dev' or self.phase == 'debug' else 'No metadata provided for '
+            'stderr': help_message if self.phase == 'dev' or  self.phase == 'debug' else 'No metadata provided for '
                                                                                          'this phase',
             'result': [
                 {
@@ -1149,9 +1160,9 @@ class ChallengeEvaluator(object):
 
         self.background_scenario = self.build_background_scenario(_route_description['town_name'],
                                                                   timeout=route_timeout)
-
+        
         self.traffic_light_scenario = self.build_trafficlight_scenario(_route_description['town_name'],
-                                                                       timeout=route_timeout)
+                                                                  timeout=route_timeout)
 
         self.list_scenarios = [self.master_scenario, self.background_scenario, self.traffic_light_scenario]
         # build the instance based on the parsed definitions.
@@ -1323,6 +1334,7 @@ if __name__ == '__main__':
     if not ROOT_SCENARIO_RUNNER:
         print("Error. ROOT_SCENARIO_RUNNER not found. Please run setup_environment.sh first.")
         sys.exit(0)
+
 
     if ARGUMENTS.scenarios is None:
         print("Please specify a path to a scenario specification file  '--scenarios path-to-file'\n\n")

--- a/srunner/challenge/challenge_evaluator_routes.py
+++ b/srunner/challenge/challenge_evaluator_routes.py
@@ -183,15 +183,15 @@ class ChallengeEvaluator(object):
 
         if phase_codename == 'dev':
             split_name = 'dev_split'
-            self.routes =  '{}/srunner/challenge/routes_devtest.xml'.format(scenario_runner_root)
+            self.routes = '{}/srunner/challenge/routes_devtest.xml'.format(scenario_runner_root)
             repetitions = 1
         elif phase_codename == 'validation':
             split_name = 'val_split'
-            self.routes =  '{}/srunner/challenge/routes_testprep.xml'.format(scenario_runner_root)
+            self.routes = '{}/srunner/challenge/routes_testprep.xml'.format(scenario_runner_root)
             repetitions = 3
         elif phase_codename == 'test':
             split_name = 'test_split'
-            self.routes =  '{}/srunner/challenge/routes_testchallenge.xml'.format(scenario_runner_root)
+            self.routes = '{}/srunner/challenge/routes_testchallenge.xml'.format(scenario_runner_root)
             repetitions = 3
         else:
             # debug mode
@@ -252,7 +252,6 @@ class ChallengeEvaluator(object):
         # debugging parameters
         self.route_visible = self.debug > 0
 
-
     def within_available_time(self):
         current_time = datetime.datetime.now()
         elapsed_seconds = (current_time - self.start_wall_time).seconds
@@ -280,7 +279,6 @@ class ChallengeEvaluator(object):
 
         CarlaActorPool.cleanup()
         CarlaDataProvider.cleanup()
-
 
         if ego and self.ego_vehicle is not None:
             self.ego_vehicle.destroy()
@@ -342,7 +340,7 @@ class ChallengeEvaluator(object):
 
             for position in range(start, end):
                 self.world.debug.draw_point(waypoints[position][0].location + carla.Location(z=vertical_shift),
-                                       size=0.2, color=color, life_time=persistency)
+                                            size=0.2, color=color, life_time=persistency)
 
         self.world.debug.draw_point(waypoints[0][0].location + carla.Location(z=vertical_shift), size=0.2,
                                     color=carla.Color(0, 0, 255), life_time=persistency)
@@ -497,7 +495,7 @@ class ChallengeEvaluator(object):
         blackboard.set('master_scenario_command', 'scenarios_running')
 
         return MasterScenario(self.world, [self.ego_vehicle], master_scenario_configuration,
-                              timeout=timeout, debug_mode=self.debug>1)
+                              timeout=timeout, debug_mode=self.debug > 1)
 
     def build_background_scenario(self, town_name, timeout=300):
         scenario_configuration = ScenarioConfiguration()
@@ -529,7 +527,7 @@ class ChallengeEvaluator(object):
         scenario_configuration.other_actors = [actor_configuration_instance]
 
         return BackgroundActivity(self.world, [self.ego_vehicle], scenario_configuration,
-                                  timeout=timeout, debug_mode=self.debug>1)
+                                  timeout=timeout, debug_mode=self.debug > 1)
 
     def build_trafficlight_scenario(self, town_name, timeout=300):
         scenario_configuration = ScenarioConfiguration()
@@ -537,7 +535,7 @@ class ChallengeEvaluator(object):
         scenario_configuration.town = town_name
 
         return TrafficLightScenario(self.world, [self.ego_vehicle], scenario_configuration,
-                                    timeout=timeout, debug_mode=self.debug>1)
+                                    timeout=timeout, debug_mode=self.debug > 1)
 
     def build_scenario_instances(self, scenario_definition_vec, town_name, timeout=300):
         """
@@ -647,7 +645,6 @@ class ChallengeEvaluator(object):
                                              draw_shadow=False, color=carla.Color(255, 255, 255),
                                              life_time=0.01)
 
-
             if self.route_visible:
                 turn_positions_and_labels = clean_route(trajectory)
                 self.draw_waypoints(trajectory, turn_positions_and_labels,
@@ -664,15 +661,14 @@ class ChallengeEvaluator(object):
                 except Exception:
                     attempts += 1
                     print('======[WARNING] The server is frozen [{}/{} attempts]!!'.format(attempts,
-                                                                                       self.MAX_CONNECTION_ATTEMPTS))
+                                                                                           self.MAX_CONNECTION_ATTEMPTS))
                     time.sleep(2.0)
                     continue
-
 
             # check for scenario termination
             for i, _ in enumerate(self.list_scenarios):
 
-                if self.debug==1:
+                if self.debug == 1:
                     behavior = self.list_scenarios[i].scenario.scenario_tree.children[0]
                     if behavior.tip():
                         print("{} {} {} {}".format(self.list_scenarios[i].scenario.scenario_tree.name,
@@ -683,8 +679,8 @@ class ChallengeEvaluator(object):
                         "InTriggerDistanceToLocationAlongRoute" and self.list_scenarios[
                         i].scenario.scenario_tree.name != "MasterScenario" and
                         self.list_scenarios[i].scenario.scenario_tree.name != "BackgroundActivity" and
-                        self.list_scenarios[i].scenario.scenario_tree.name != "TrafficLightScenario"):
-                        pass # TODO: find a fix for this ascii bug
+                            self.list_scenarios[i].scenario.scenario_tree.name != "TrafficLightScenario"):
+                        pass  # TODO: find a fix for this ascii bug
                         # py_trees.display.print_ascii_tree(self.list_scenarios[i].scenario.scenario_tree, 2, True)
 
                     # The scenario status can be: INVALID, RUNNING, SUCCESS, FAILURE. Only the last two
@@ -696,7 +692,6 @@ class ChallengeEvaluator(object):
                     self.list_scenarios[i].remove_all_actors()
                     self.list_scenarios[i] = None
             self.list_scenarios[:] = [scenario for scenario in self.list_scenarios if scenario]
-
 
         # Route finished set for the background scenario to also finish
         blackboard = py_trees.blackboard.Blackboard()
@@ -716,7 +711,6 @@ class ChallengeEvaluator(object):
 
         return_message = error_message
         return_message += "\n=================================="
-
 
         current_statistics = {'id': -1,
                               'score_composed': score_composed,
@@ -836,7 +830,6 @@ class ChallengeEvaluator(object):
 
         return score_composed, score_route, score_penalty
 
-
     def record_route_statistics_default(self, route_id):
         """
           This function is intended to be called from outside and provide
@@ -931,9 +924,9 @@ class ChallengeEvaluator(object):
 
         return_message += "\n=================================="
         return_message += "\n==[r{}:{}] [Score = {:.2f} : (route_score={}, infractions=-{})]".format(route_id, result,
-                                                                                                 score_composed,
-                                                                                                 score_route,
-                                                                                                 score_penalty)
+                                                                                                     score_composed,
+                                                                                                     score_route,
+                                                                                                     score_penalty)
         if list_collisions:
             return_message += "\n===== Collisions:"
             for item in list_collisions:
@@ -988,7 +981,6 @@ class ChallengeEvaluator(object):
             for stats in self.statistics_routes:
                 help_message += "{}\n\n".format(stats['help_text'])
 
-
         else:
             submission_status = 'FINISHED'
 
@@ -1004,7 +996,7 @@ class ChallengeEvaluator(object):
         # create json structure
         json_data = {
             'submission_status': submission_status,
-            'stderr': help_message if self.phase == 'dev' or  self.phase == 'debug' else 'No metadata provided for '
+            'stderr': help_message if self.phase == 'dev' or self.phase == 'debug' else 'No metadata provided for '
                                                                                          'this phase',
             'result': [
                 {
@@ -1160,9 +1152,9 @@ class ChallengeEvaluator(object):
 
         self.background_scenario = self.build_background_scenario(_route_description['town_name'],
                                                                   timeout=route_timeout)
-        
+
         self.traffic_light_scenario = self.build_trafficlight_scenario(_route_description['town_name'],
-                                                                  timeout=route_timeout)
+                                                                       timeout=route_timeout)
 
         self.list_scenarios = [self.master_scenario, self.background_scenario, self.traffic_light_scenario]
         # build the instance based on the parsed definitions.
@@ -1334,7 +1326,6 @@ if __name__ == '__main__':
     if not ROOT_SCENARIO_RUNNER:
         print("Error. ROOT_SCENARIO_RUNNER not found. Please run setup_environment.sh first.")
         sys.exit(0)
-
 
     if ARGUMENTS.scenarios is None:
         print("Please specify a path to a scenario specification file  '--scenarios path-to-file'\n\n")

--- a/srunner/configs/FreeRide.xml
+++ b/srunner/configs/FreeRide.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<scenarios>
+    <scenario name="FreeRideTown01" type="FreeRide" town="Town01">
+        <ego_vehicle x="312" y="129" z="0" yaw="180" model="vehicle.tesla.model3" rolename="hero"/>
+    </scenario>
+    <scenario name="FreeRideTown02" type="FreeRide" town="Town02">
+        <ego_vehicle x="132" y="215" z="0" yaw="90" model="vehicle.tesla.model3" rolename="hero"/>
+    </scenario>
+    <scenario name="FreeRideTown03" type="FreeRide" town="Town03">
+        <ego_vehicle x="207" y="59" z="0" yaw="180" model="vehicle.tesla.model3" rolename="hero"/>
+    </scenario>
+    <scenario name="FreeRideTown04" type="FreeRide" town="Town04">
+        <ego_vehicle x="269" y="-246" z="0" yaw="0" model="vehicle.tesla.model3" rolename="hero"/>
+    </scenario>
+    <scenario name="MultiEgoTown01" type="FreeRide" town="Town01">
+        <ego_vehicle x="270" y="129" z="0" yaw="180" model="vehicle.lincoln.mkz2017" rolename="hero"/>
+        <ego_vehicle x="100" y="133" z="0" yaw="0" model="vehicle.tesla.model3" rolename="hero2"/>
+    </scenario>
+    <scenario name="MultiEgoTown03" type="FreeRide" town="Town03">
+        <ego_vehicle x="207" y="59" z="0" yaw="180" model="vehicle.lincoln.mkz2017" rolename="hero"/>
+        <ego_vehicle x="237" y="-95.0754252474" z="0" yaw="90" model="vehicle.tesla.model3" rolename="hero2"/>
+    </scenario>
+</scenarios>

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -347,6 +347,8 @@ class CarlaDataProvider(object):
     def set_ego_vehicle_route(route):
         """
         Set the route of the ego vehicle
+
+        @todo extend ego_vehicle_route concept to support multi ego_vehicle scenarios
         """
         CarlaDataProvider._ego_vehicle_route = route
 
@@ -424,7 +426,7 @@ class CarlaActorPool(object):
         CarlaActorPool._spawn_index = 0
 
     @staticmethod
-    def setup_actor(model, spawn_point, hero=False, autopilot=False, random_location=False):
+    def setup_actor(model, spawn_point, rolename='scenario', hero=False, autopilot=False, random_location=False):
         """
         Function to setup the most relevant actor parameters,
         incl. spawn point and vehicle model.
@@ -440,7 +442,7 @@ class CarlaActorPool(object):
             blueprint.set_attribute('is_invincible', 'false')
 
         if hero:
-            blueprint.set_attribute('role_name', 'hero')
+            blueprint.set_attribute('role_name', rolename)
         elif autopilot:
             blueprint.set_attribute('role_name', 'autopilot')
         else:

--- a/srunner/scenariomanager/result_writer.py
+++ b/srunner/scenariomanager/result_writer.py
@@ -74,7 +74,8 @@ class ResultOutputProvider(object):
         self.logger.info("Duration: System Time %5.2fs --- Game Time %5.2fs",
                          self._data.scenario_duration_system,
                          self._data.scenario_duration_game)
-        self.logger.info("Ego vehicle:  %s", self._data.ego_vehicle)
+        for ego_vehicle in self._data.ego_vehicles:
+            self.logger.info("Ego vehicle:  %s", ego_vehicle)
 
         actor_string = ""
         for actor in self._data.other_actors:

--- a/srunner/scenariomanager/scenario_manager.py
+++ b/srunner/scenariomanager/scenario_manager.py
@@ -112,7 +112,7 @@ class ScenarioManager(object):
         self.scenario = None
         self.scenario_tree = None
         self.scenario_class = None
-        self.ego_vehicle = None
+        self.ego_vehicles = None
         self.other_actors = None
 
         self._debug_mode = debug_mode
@@ -137,10 +137,10 @@ class ScenarioManager(object):
         self.scenario_class = scenario
         self.scenario = scenario.scenario
         self.scenario_tree = self.scenario.scenario_tree
-        self.ego_vehicle = scenario.ego_vehicle
+        self.ego_vehicles = scenario.ego_vehicles
         self.other_actors = scenario.other_actors
 
-        CarlaDataProvider.register_actor(self.ego_vehicle)
+        CarlaDataProvider.register_actors(self.ego_vehicles)
         CarlaDataProvider.register_actors(self.other_actors)
         # To print the scenario tree uncomment the next line
         # py_trees.display.render_dot_tree(self.scenario_tree)
@@ -157,11 +157,10 @@ class ScenarioManager(object):
         self.end_system_time = None
         GameTime.restart()
 
-    def run_scenario(self, agent=None):
+    def run_scenario(self):
         """
         Trigger the start of the scenario and wait for it to finish/fail
         """
-        self.agent = agent
         print("ScenarioManager: Running scenario {}".format(self.scenario_tree.name))
         self.start_system_time = time.time()
         start_game_time = GameTime.get_time()
@@ -205,12 +204,6 @@ class ScenarioManager(object):
 
                 # Tick scenario
                 self.scenario_tree.tick_once()
-
-                if self.agent:
-                    # Invoke agent
-                    action = self.agent()
-                    action = self.scenario_class.change_control(action)
-                    self.ego_vehicle.apply_control(action)
 
                 if self._debug_mode:
                     print("\n")

--- a/srunner/scenarios/background_activity.py
+++ b/srunner/scenarios/background_activity.py
@@ -21,11 +21,13 @@ class BackgroundActivity(BasicScenario):
 
     """
     Implementation of a dummy scenario
+
+    This is a single ego vehicle scenario
     """
 
     category = "BackgroundActivity"
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, timeout=35 * 60):
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, timeout=35 * 60):
         """
         Setup all relevant parameters and create scenario
         """
@@ -35,7 +37,7 @@ class BackgroundActivity(BasicScenario):
         self.timeout = timeout  # Timeout of scenario in seconds
 
         super(BackgroundActivity, self).__init__("BackgroundActivity",
-                                                 ego_vehicle,
+                                                 ego_vehicles,
                                                  config,
                                                  world,
                                                  debug_mode,
@@ -63,7 +65,7 @@ class BackgroundActivity(BasicScenario):
 
         # Build behavior tree
         sequence = py_trees.composites.Sequence("Sequence Behavior")
-        check_jam = TrafficJamChecker(self.ego_vehicle, debug=self.debug)
+        check_jam = TrafficJamChecker(self.ego_vehicles[0], debug=self.debug)
         sequence.add_child(check_jam)
 
         return sequence

--- a/srunner/scenarios/basic_scenario.py
+++ b/srunner/scenarios/basic_scenario.py
@@ -108,10 +108,9 @@ class BasicScenario(object):
                                                              ego_vehicle_route,
                                                              start_location,
                                                              5)
-            else:
-                return InTimeToArrivalToLocation(self.ego_vehicles[0],
-                                                 2.0,
-                                                 start_location)
+            return InTimeToArrivalToLocation(self.ego_vehicles[0],
+                                             2.0,
+                                             start_location)
 
         return None
 

--- a/srunner/scenarios/control_loss.py
+++ b/srunner/scenarios/control_loss.py
@@ -60,7 +60,7 @@ class ControlLoss(BasicScenario):
         # Timeout of scenario in seconds
         self.timeout = timeout
         # The reference trigger for the control loss
-        self._reference_waypoint = self._map.get_waypoint(config.trigger_point.location)
+        self._reference_waypoint = self._map.get_waypoint(config.trigger_points[0].location)
         self.loc_list = []
         self.obj = []
         super(ControlLoss, self).__init__("ControlLoss",

--- a/srunner/scenarios/control_loss.py
+++ b/srunner/scenarios/control_loss.py
@@ -30,11 +30,13 @@ class ControlLoss(BasicScenario):
 
     """
     Implementation of "Control Loss Vehicle" (Traffic Scenario 01)
+
+    This is a single ego vehicle scenario
     """
 
     category = "ControlLoss"
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=60):
         """
         Setup all relevant parameters and create scenario
@@ -62,7 +64,7 @@ class ControlLoss(BasicScenario):
         self.loc_list = []
         self.obj = []
         super(ControlLoss, self).__init__("ControlLoss",
-                                          ego_vehicle,
+                                          ego_vehicles,
                                           config,
                                           world,
                                           debug_mode,
@@ -125,7 +127,7 @@ class ControlLoss(BasicScenario):
         # start condition
         start_end_parallel = py_trees.composites.Parallel("Jitter",
                                                           policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)
-        start_condition = InTriggerDistanceToLocation(self.ego_vehicle, self.first_loc_prev, self._trigger_dist)
+        start_condition = InTriggerDistanceToLocation(self.ego_vehicles[0], self.first_loc_prev, self._trigger_dist)
         for _ in range(self._no_of_jitter):
 
             # change the current noise to be applied
@@ -139,9 +141,9 @@ class ControlLoss(BasicScenario):
         jitter_action = py_trees.composites.Parallel("Jitter",
                                                      policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)
         # Abort jitter_sequence, if the vehicle is approaching an intersection
-        jitter_abort = InTriggerDistanceToNextIntersection(self.ego_vehicle, self._abort_distance_to_intersection)
+        jitter_abort = InTriggerDistanceToNextIntersection(self.ego_vehicles[0], self._abort_distance_to_intersection)
         # endcondition: Check if vehicle reached waypoint _end_distance from here:
-        end_condition = DriveDistance(self.ego_vehicle, self._end_distance)
+        end_condition = DriveDistance(self.ego_vehicles[0], self._end_distance)
         start_end_parallel.add_child(start_condition)
         start_end_parallel.add_child(end_condition)
 
@@ -152,9 +154,9 @@ class ControlLoss(BasicScenario):
         sequence.add_child(ActorTransformSetter(self.other_actors[2], self.third_transform, physics=False))
         jitter = py_trees.composites.Sequence("Jitter Behavior")
         jitter.add_child(turn)
-        jitter.add_child(InTriggerDistanceToLocation(self.ego_vehicle, self.sec_loc_prev, self._trigger_dist))
+        jitter.add_child(InTriggerDistanceToLocation(self.ego_vehicles[0], self.sec_loc_prev, self._trigger_dist))
         jitter.add_child(turn)
-        jitter.add_child(InTriggerDistanceToLocation(self.ego_vehicle, self.third_loc_prev, self._trigger_dist))
+        jitter.add_child(InTriggerDistanceToLocation(self.ego_vehicles[0], self.third_loc_prev, self._trigger_dist))
         jitter.add_child(turn)
         jitter_action.add_child(jitter)
         jitter_action.add_child(jitter_abort)
@@ -171,7 +173,7 @@ class ControlLoss(BasicScenario):
         """
         criteria = []
 
-        collision_criterion = CollisionTest(self.ego_vehicle)
+        collision_criterion = CollisionTest(self.ego_vehicles[0])
         criteria.append(collision_criterion)
 
         return criteria

--- a/srunner/scenarios/follow_leading_vehicle.py
+++ b/srunner/scenarios/follow_leading_vehicle.py
@@ -39,12 +39,14 @@ class FollowLeadingVehicle(BasicScenario):
     """
     This class holds everything required for a simple "Follow a leading vehicle"
     scenario involving two vehicles.  (Traffic Scenario 2)
+
+    This is a single ego vehicle scenario
     """
     category = "FollowLeadingVehicle"
 
     timeout = 120            # Timeout of scenario in seconds
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=60):
         """
         Setup all relevant parameters and create scenario
@@ -55,7 +57,7 @@ class FollowLeadingVehicle(BasicScenario):
         self._map = CarlaDataProvider.get_map()
         self._first_vehicle_location = 25
         self._first_vehicle_speed = 40
-        self._reference_waypoint = self._map.get_waypoint(config.trigger_point.location)
+        self._reference_waypoint = self._map.get_waypoint(config.trigger_points[0].location)
         self._other_actor_max_brake = 1.0
         self._other_actor_stop_in_front_intersection = 20
         self._other_actor_transform = None
@@ -63,7 +65,7 @@ class FollowLeadingVehicle(BasicScenario):
         self.timeout = timeout
 
         super(FollowLeadingVehicle, self).__init__("FollowVehicle",
-                                                   ego_vehicle,
+                                                   ego_vehicles,
                                                    config,
                                                    world,
                                                    debug_mode,
@@ -74,7 +76,7 @@ class FollowLeadingVehicle(BasicScenario):
 
             # Example code how to randomize start location
             # distance = random.randint(20, 80)
-            # new_location, _ = get_location_in_distance(self.ego_vehicle, distance)
+            # new_location, _ = get_location_in_distance(self.ego_vehicles[0], distance)
             # waypoint = CarlaDataProvider.get_map().get_waypoint(new_location)
             # waypoint.transform.location.z += 39
             # self.other_actors[0].set_transform(waypoint.transform)
@@ -129,10 +131,10 @@ class FollowLeadingVehicle(BasicScenario):
         endcondition = py_trees.composites.Parallel("Waiting for end position",
                                                     policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL)
         endcondition_part1 = InTriggerDistanceToVehicle(self.other_actors[0],
-                                                        self.ego_vehicle,
+                                                        self.ego_vehicles[0],
                                                         distance=20,
                                                         name="FinalDistance")
-        endcondition_part2 = StandStill(self.ego_vehicle, name="StandStill")
+        endcondition_part2 = StandStill(self.ego_vehicles[0], name="StandStill")
         endcondition.add_child(endcondition_part1)
         endcondition.add_child(endcondition_part2)
 
@@ -153,7 +155,7 @@ class FollowLeadingVehicle(BasicScenario):
         """
         criteria = []
 
-        collision_criterion = CollisionTest(self.ego_vehicle)
+        collision_criterion = CollisionTest(self.ego_vehicles[0])
 
         criteria.append(collision_criterion)
 
@@ -171,12 +173,14 @@ class FollowLeadingVehicleWithObstacle(BasicScenario):
     """
     This class holds a scenario similar to FollowLeadingVehicle
     but there is an obstacle in front of the leading vehicle
+
+    This is a single ego vehicle scenario
     """
     category = "FollowLeadingVehicle"
 
     timeout = 120            # Timeout of scenario in seconds
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True):
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True):
         """
         Setup all relevant parameters and create scenario
         """
@@ -185,13 +189,13 @@ class FollowLeadingVehicleWithObstacle(BasicScenario):
         self._second_actor_location = self._first_actor_location + 41
         self._first_actor_speed = 40
         self._second_actor_speed = 5
-        self._reference_waypoint = self._map.get_waypoint(config.trigger_point.location)
+        self._reference_waypoint = self._map.get_waypoint(config.trigger_points[0].location)
         self._other_actor_max_brake = 1.0
         self._first_actor_transform = None
         self._second_actor_transform = None
 
         super(FollowLeadingVehicleWithObstacle, self).__init__("FollowLeadingVehicleWithObstacle",
-                                                               ego_vehicle,
+                                                               ego_vehicles,
                                                                config,
                                                                world,
                                                                debug_mode,
@@ -272,10 +276,10 @@ class FollowLeadingVehicleWithObstacle(BasicScenario):
         endcondition = py_trees.composites.Parallel("Waiting for end position",
                                                     policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL)
         endcondition_part1 = InTriggerDistanceToVehicle(self.other_actors[0],
-                                                        self.ego_vehicle,
+                                                        self.ego_vehicles[0],
                                                         distance=20,
                                                         name="FinalDistance")
-        endcondition_part2 = StandStill(self.ego_vehicle, name="FinalSpeed")
+        endcondition_part2 = StandStill(self.ego_vehicles[0], name="FinalSpeed")
         endcondition.add_child(endcondition_part1)
         endcondition.add_child(endcondition_part2)
 
@@ -302,7 +306,7 @@ class FollowLeadingVehicleWithObstacle(BasicScenario):
         """
         criteria = []
 
-        collision_criterion = CollisionTest(self.ego_vehicle)
+        collision_criterion = CollisionTest(self.ego_vehicles[0])
 
         criteria.append(collision_criterion)
 

--- a/srunner/scenarios/freeride.py
+++ b/srunner/scenarios/freeride.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2019 Intel Corporation
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+"""
+Simple freeride scenario. No action, no triggers. Ego vehicle can simply cruise around.
+"""
+
+import py_trees
+
+from srunner.scenariomanager.atomic_scenario_behavior import *
+from srunner.scenariomanager.atomic_scenario_criteria import *
+from srunner.scenarios.basic_scenario import *
+
+FREERIDE_SCENARIOS = [
+    "FreeRide"
+]
+
+
+class FreeRide(BasicScenario):
+
+    """
+    Implementation of a simple free ride scenario
+    """
+
+    category = "FreeRide"
+
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
+                 timeout=10000000):
+        """
+        Setup all relevant parameters and create scenario
+        """
+        # Timeout of scenario in seconds
+        self.timeout = timeout
+        super(FreeRide, self).__init__("FreeRide",
+                                       ego_vehicles,
+                                       config,
+                                       world,
+                                       debug_mode,
+                                       criteria_enable=criteria_enable)
+
+    def _setup_scenario_trigger(self, config):
+        """
+        """
+        return None
+
+    def _create_behavior(self):
+        """
+        """
+        sequence = py_trees.composites.Sequence("Sequence Behavior")
+        sequence.add_child(Idle())
+        return sequence
+
+    def _create_test_criteria(self):
+        """
+        A list of all test criteria will be created that is later used
+        in parallel behavior tree.
+        """
+        criteria = []
+
+        for ego_vehicle in self.ego_vehicles:
+            collision_criterion = CollisionTest(ego_vehicle)
+            criteria.append(collision_criterion)
+
+        return criteria
+
+    def __del__(self):
+        """
+        Remove all actors upon deletion
+        """
+        self.remove_all_actors()

--- a/srunner/scenarios/maneuver_opposite_direction.py
+++ b/srunner/scenarios/maneuver_opposite_direction.py
@@ -49,7 +49,7 @@ class ManeuverOppositeDirection(BasicScenario):
         self._start_distance = self._first_vehicle_location * 0.9
         self._opposite_speed = 20   # km/h
         self._source_gap = 40   # m
-        self._reference_waypoint = self._map.get_waypoint(config.trigger_point.location)
+        self._reference_waypoint = self._map.get_waypoint(config.trigger_points[0].location)
         self._source_transform = None
         self._sink_location = None
         self._blackboard_queue_name = 'ManeuverOppositeDirection/actor_flow_queue'

--- a/srunner/scenarios/maneuver_opposite_direction.py
+++ b/srunner/scenarios/maneuver_opposite_direction.py
@@ -29,11 +29,13 @@ class ManeuverOppositeDirection(BasicScenario):
 
     """
     "Vehicle Maneuvering In Opposite Direction" (Traffic Scenario 06)
+
+    This is a single ego vehicle scenario
     """
 
     category = "ManeuverOppositeDirection"
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  obstacle_type='barrier', timeout=120):
         """
         Setup all relevant parameters and create scenario
@@ -61,7 +63,7 @@ class ManeuverOppositeDirection(BasicScenario):
 
         super(ManeuverOppositeDirection, self).__init__(
             "ManeuverOppositeDirection",
-            ego_vehicle,
+            ego_vehicles,
             config,
             world,
             debug_mode,
@@ -124,7 +126,7 @@ class ManeuverOppositeDirection(BasicScenario):
             self._world, ['vehicle.audi.tt', 'vehicle.tesla.model3', 'vehicle.nissan.micra'],
             self._source_transform, self._source_gap, self._blackboard_queue_name)
         actor_sink = ActorSink(self._world, self._sink_location, 10)
-        ego_drive_distance = DriveDistance(self.ego_vehicle, self._ego_vehicle_drive_distance)
+        ego_drive_distance = DriveDistance(self.ego_vehicles[0], self._ego_vehicle_drive_distance)
         waypoint_follower = WaypointFollower(
             self.other_actors[1], self._opposite_speed,
             blackboard_queue_name=self._blackboard_queue_name, avoid_collision=True)
@@ -156,7 +158,7 @@ class ManeuverOppositeDirection(BasicScenario):
         """
         criteria = []
 
-        collision_criterion = CollisionTest(self.ego_vehicle)
+        collision_criterion = CollisionTest(self.ego_vehicles[0])
         criteria.append(collision_criterion)
 
         return criteria

--- a/srunner/scenarios/master_scenario.py
+++ b/srunner/scenarios/master_scenario.py
@@ -23,12 +23,14 @@ class MasterScenario(BasicScenario):
 
     """
     Implementation of a  Master scenario that controls the route.
+
+    This is a single ego vehicle scenario
     """
 
     category = "Master"
     radius = 10.0           # meters
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=300):
         """
         Setup all relevant parameters and create scenario
@@ -48,7 +50,7 @@ class MasterScenario(BasicScenario):
         else:
             raise ValueError("Master scenario must have a route")
 
-        super(MasterScenario, self).__init__("MasterScenario", ego_vehicle=ego_vehicle, config=config,
+        super(MasterScenario, self).__init__("MasterScenario", ego_vehicles=ego_vehicles, config=config,
                                              world=world, debug_mode=debug_mode,
                                              terminate_on_failure=True, criteria_enable=criteria_enable)
 
@@ -75,23 +77,23 @@ class MasterScenario(BasicScenario):
         else:
             route = self.route
 
-        collision_criterion = CollisionTest(self.ego_vehicle, terminate_on_failure=True)
+        collision_criterion = CollisionTest(self.ego_vehicles[0], terminate_on_failure=True)
 
-        route_criterion = InRouteTest(self.ego_vehicle,
+        route_criterion = InRouteTest(self.ego_vehicles[0],
                                       radius=30.0,
                                       route=route,
                                       offroad_max=20,
                                       terminate_on_failure=True)
 
-        completion_criterion = RouteCompletionTest(self.ego_vehicle, route=route)
+        completion_criterion = RouteCompletionTest(self.ego_vehicles[0], route=route)
 
-        wrong_way_criterion = WrongLaneTest(self.ego_vehicle)
+        wrong_way_criterion = WrongLaneTest(self.ego_vehicles[0])
 
-        onsidewalk_criterion = OnSidewalkTest(self.ego_vehicle)
+        onsidewalk_criterion = OnSidewalkTest(self.ego_vehicles[0])
 
-        red_light_criterion = RunningRedLightTest(self.ego_vehicle)
+        red_light_criterion = RunningRedLightTest(self.ego_vehicles[0])
 
-        stop_criterion = RunningStopTest(self.ego_vehicle)
+        stop_criterion = RunningStopTest(self.ego_vehicles[0])
 
         parallel_criteria = py_trees.composites.Parallel("group_criteria",
                                                          policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)

--- a/srunner/scenarios/no_signal_junction_crossing.py
+++ b/srunner/scenarios/no_signal_junction_crossing.py
@@ -30,6 +30,8 @@ class NoSignalJunctionCrossing(BasicScenario):
     Implementation class for
     'Non-signalized junctions: crossing negotiation' scenario,
     (Traffic Scenario 10).
+
+    This is a single ego vehicle scenario
     """
 
     category = "NoSignalJunction"
@@ -42,7 +44,7 @@ class NoSignalJunctionCrossing(BasicScenario):
     _other_actor_max_brake = 1.0
     _other_actor_target_velocity = 15
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=0):
         """
         Setup all relevant parameters and create scenario
@@ -53,7 +55,7 @@ class NoSignalJunctionCrossing(BasicScenario):
         self.timeout = timeout
 
         super(NoSignalJunctionCrossing, self).__init__("NoSignalJunctionCrossing",
-                                                       ego_vehicle,
+                                                       ego_vehicles,
                                                        config,
                                                        world,
                                                        debug_mode,
@@ -86,16 +88,16 @@ class NoSignalJunctionCrossing(BasicScenario):
 
         # Creating leaf nodes
         start_other_trigger = InTriggerRegion(
-            self.ego_vehicle,
+            self.ego_vehicles[0],
             -80, -70,
             -75, -60)
 
         sync_arrival = SyncArrival(
-            self.other_actors[0], self.ego_vehicle,
+            self.other_actors[0], self.ego_vehicles[0],
             carla.Location(x=-74.63, y=-136.34))
 
         pass_through_trigger = InTriggerRegion(
-            self.ego_vehicle,
+            self.ego_vehicles[0],
             -90, -70,
             -124, -119)
 
@@ -113,7 +115,7 @@ class NoSignalJunctionCrossing(BasicScenario):
             self._other_actor_max_brake)
 
         end_condition = InTriggerRegion(
-            self.ego_vehicle,
+            self.ego_vehicles[0],
             -90, -70,
             -170, -156
         )
@@ -151,9 +153,9 @@ class NoSignalJunctionCrossing(BasicScenario):
         criteria = []
 
         # Adding checks for ego vehicle
-        collision_criterion_ego = CollisionTest(self.ego_vehicle)
+        collision_criterion_ego = CollisionTest(self.ego_vehicles[0])
         driven_distance_criterion = DrivenDistanceTest(
-            self.ego_vehicle, self._ego_vehicle_driven_distance)
+            self.ego_vehicles[0], self._ego_vehicle_driven_distance)
         criteria.append(collision_criterion_ego)
         criteria.append(driven_distance_criterion)
 

--- a/srunner/scenarios/object_crash_intersection.py
+++ b/srunner/scenarios/object_crash_intersection.py
@@ -66,9 +66,11 @@ class VehicleTurningRight(BasicScenario):
     The ego vehicle is passing through a road and encounters
     a cyclist after taking a right turn.
     (Traffic Scenario 4)
+
+    This is a single ego vehicle scenario
     """
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=60):
         """
         Setup all relevant parameters and create scenario
@@ -91,7 +93,7 @@ class VehicleTurningRight(BasicScenario):
         self._ego_route = CarlaDataProvider.get_ego_vehicle_route()
 
         super(VehicleTurningRight, self).__init__("VehicleTurningRight",
-                                                  ego_vehicle,
+                                                  ego_vehicles,
                                                   config,
                                                   world,
                                                   debug_mode,
@@ -161,10 +163,10 @@ class VehicleTurningRight(BasicScenario):
         lane_width = lane_width + (1.10 * lane_width * self._num_lane_changes)
 
         if self._ego_route is not None:
-            trigger_distance = InTriggerDistanceToLocationAlongRoute(self.ego_vehicle, self._ego_route,
+            trigger_distance = InTriggerDistanceToLocationAlongRoute(self.ego_vehicles[0], self._ego_route,
                                                                      self.other_actors[0].get_location(), 20)
         else:
-            trigger_distance = InTriggerDistanceToVehicle(self.other_actors[0], self.ego_vehicle, 20)
+            trigger_distance = InTriggerDistanceToVehicle(self.other_actors[0], self.ego_vehicles[0], 20)
 
         actor_velocity = KeepVelocity(self.other_actors[0], self._other_actor_target_velocity)
         actor_traverse = DriveDistance(self.other_actors[0], 0.30 * lane_width)
@@ -203,7 +205,7 @@ class VehicleTurningRight(BasicScenario):
         in parallel behavior tree.
         """
         criteria = []
-        collision_criterion = CollisionTest(self.ego_vehicle)
+        collision_criterion = CollisionTest(self.ego_vehicles[0])
         criteria.append(collision_criterion)
         return criteria
 
@@ -221,9 +223,11 @@ class VehicleTurningLeft(BasicScenario):
     with prior vehicle action involving a vehicle and a cyclist.
     The ego vehicle is passing through a road and encounters
     a cyclist after taking a left turn. Scenario 4
+
+    This is a single ego vehicle scenario
     """
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=60):
         """
         Setup all relevant parameters and create scenario
@@ -245,7 +249,7 @@ class VehicleTurningLeft(BasicScenario):
         self._ego_route = CarlaDataProvider.get_ego_vehicle_route()
 
         super(VehicleTurningLeft, self).__init__("VehicleTurningLeft",
-                                                 ego_vehicle,
+                                                 ego_vehicles,
                                                  config,
                                                  world,
                                                  debug_mode,
@@ -310,10 +314,10 @@ class VehicleTurningLeft(BasicScenario):
         lane_width = self._reference_waypoint.lane_width
         lane_width = lane_width + (1.10 * lane_width * self._num_lane_changes)
         if self._ego_route is not None:
-            trigger_distance = InTriggerDistanceToLocationAlongRoute(self.ego_vehicle, self._ego_route,
+            trigger_distance = InTriggerDistanceToLocationAlongRoute(self.ego_vehicles[0], self._ego_route,
                                                                      self.other_actors[0].get_location(), 20)
         else:
-            trigger_distance = InTriggerDistanceToVehicle(self.other_actors[0], self.ego_vehicle, 25)
+            trigger_distance = InTriggerDistanceToVehicle(self.other_actors[0], self.ego_vehicles[0], 25)
 
         actor_velocity = KeepVelocity(self.other_actors[0], self._other_actor_target_velocity)
         actor_traverse = DriveDistance(self.other_actors[0], 0.30 * lane_width)
@@ -353,7 +357,7 @@ class VehicleTurningLeft(BasicScenario):
         in parallel behavior tree.
         """
         criteria = []
-        collision_criterion = CollisionTest(self.ego_vehicle)
+        collision_criterion = CollisionTest(self.ego_vehicles[0])
 
         criteria.append(collision_criterion)
         return criteria

--- a/srunner/scenarios/object_crash_intersection.py
+++ b/srunner/scenarios/object_crash_intersection.py
@@ -79,8 +79,8 @@ class VehicleTurningRight(BasicScenario):
         self._other_actor_target_velocity = 10
         self.category = "VehicleTurning"
         self._wmap = CarlaDataProvider.get_map()
-        self._reference_waypoint = self._wmap.get_waypoint(config.trigger_point.location)
-        self._trigger_location = config.trigger_point.location
+        self._reference_waypoint = self._wmap.get_waypoint(config.trigger_points[0].location)
+        self._trigger_location = config.trigger_points[0].location
         self._other_actor_transform = None
         self._num_lane_changes = 0
         # Timeout of scenario in seconds
@@ -235,8 +235,8 @@ class VehicleTurningLeft(BasicScenario):
         self._other_actor_target_velocity = 10
         self.category = "VehicleTurning"
         self._wmap = CarlaDataProvider.get_map()
-        self._reference_waypoint = self._wmap.get_waypoint(config.trigger_point.location)
-        self._trigger_location = config.trigger_point.location
+        self._reference_waypoint = self._wmap.get_waypoint(config.trigger_points[0].location)
+        self._trigger_location = config.trigger_points[0].location
         self._other_actor_transform = None
         self._num_lane_changes = 0
         # Timeout of scenario in seconds

--- a/srunner/scenarios/object_crash_vehicle.py
+++ b/srunner/scenarios/object_crash_vehicle.py
@@ -82,7 +82,8 @@ class StationaryObjectCrossing(BasicScenario):
         """
         Only behavior here is to wait
         """
-        lane_width = self.ego_vehicles[0].get_world().get_map().get_waypoint(self.ego_vehicles[0].get_location()).lane_width
+        lane_width = self.ego_vehicles[0].get_world().get_map().get_waypoint(
+            self.ego_vehicles[0].get_location()).lane_width
         lane_width = lane_width + (1.25 * lane_width)
 
         # leaf nodes

--- a/srunner/scenarios/object_crash_vehicle.py
+++ b/srunner/scenarios/object_crash_vehicle.py
@@ -41,7 +41,7 @@ class StationaryObjectCrossing(BasicScenario):
         Setup all relevant parameters and create scenario
         """
         self._wmap = CarlaDataProvider.get_map()
-        self._reference_waypoint = self._wmap.get_waypoint(config.trigger_point.location)
+        self._reference_waypoint = self._wmap.get_waypoint(config.trigger_points[0].location)
         # ego vehicle parameters
         self._ego_vehicle_distance_driven = 40
 
@@ -144,7 +144,7 @@ class DynamicObjectCrossing(BasicScenario):
         """
         self._wmap = CarlaDataProvider.get_map()
 
-        self._reference_waypoint = self._wmap.get_waypoint(config.trigger_point.location)
+        self._reference_waypoint = self._wmap.get_waypoint(config.trigger_points[0].location)
         # ego vehicle parameters
         self._ego_vehicle_distance_driven = 40
         # other vehicle parameters
@@ -156,7 +156,7 @@ class DynamicObjectCrossing(BasicScenario):
         self._num_lane_changes = 1
         self.transform2 = None
         self.timeout = timeout
-        self._trigger_location = config.trigger_point.location
+        self._trigger_location = config.trigger_points[0].location
         # Total Number of attempts to relocate a vehicle before spawning
         self._number_of_attempts = 20
         # Number of attempts made so far
@@ -299,7 +299,7 @@ class DynamicObjectCrossing(BasicScenario):
         lane_width = lane_width + (1.25 * lane_width * self._num_lane_changes)
         # leaf nodes
         if self._ego_route is not None:
-            start_condition = InTriggerDistanceToLocationAlongRoute(self.ego_vehicles,
+            start_condition = InTriggerDistanceToLocationAlongRoute(self.ego_vehicles[0],
                                                                     self._ego_route,
                                                                     self.other_actors[0].get_location(),
                                                                     15)

--- a/srunner/scenarios/object_crash_vehicle.py
+++ b/srunner/scenarios/object_crash_vehicle.py
@@ -29,11 +29,13 @@ class StationaryObjectCrossing(BasicScenario):
     without prior vehicle action involving a vehicle and a cyclist.
     The ego vehicle is passing through a road and encounters
     a stationary cyclist.
+
+    This is a single ego vehicle scenario
     """
 
     category = "ObjectCrossing"
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=60):
         """
         Setup all relevant parameters and create scenario
@@ -49,7 +51,7 @@ class StationaryObjectCrossing(BasicScenario):
         self.timeout = timeout
 
         super(StationaryObjectCrossing, self).__init__("Stationaryobjectcrossing",
-                                                       ego_vehicle,
+                                                       ego_vehicles,
                                                        config,
                                                        world,
                                                        debug_mode,
@@ -80,13 +82,13 @@ class StationaryObjectCrossing(BasicScenario):
         """
         Only behavior here is to wait
         """
-        lane_width = self.ego_vehicle.get_world().get_map().get_waypoint(self.ego_vehicle.get_location()).lane_width
+        lane_width = self.ego_vehicles[0].get_world().get_map().get_waypoint(self.ego_vehicles[0].get_location()).lane_width
         lane_width = lane_width + (1.25 * lane_width)
 
         # leaf nodes
         actor_stand = TimeOut(15)
         actor_removed = ActorDestroy(self.other_actors[0])
-        end_condition = DriveDistance(self.ego_vehicle, self._ego_vehicle_distance_driven)
+        end_condition = DriveDistance(self.ego_vehicles[0], self._ego_vehicle_distance_driven)
 
         # non leaf nodes
         root = py_trees.composites.Parallel(
@@ -109,7 +111,7 @@ class StationaryObjectCrossing(BasicScenario):
         """
         criteria = []
 
-        collision_criterion = CollisionTest(self.ego_vehicle)
+        collision_criterion = CollisionTest(self.ego_vehicles[0])
         criteria.append(collision_criterion)
 
         return criteria
@@ -128,11 +130,13 @@ class DynamicObjectCrossing(BasicScenario):
     without prior vehicle action involving a vehicle and a cyclist/pedestrian,
     The ego vehicle is passing through a road,
     And encounters a cyclist/pedestrian crossing the road.
+
+    This is a single ego vehicle scenario
     """
 
     category = "ObjectCrossing"
 
-    def __init__(self, world, ego_vehicle, config, randomize=False,
+    def __init__(self, world, ego_vehicles, config, randomize=False,
                  debug_mode=False, criteria_enable=True, adversary_type=False, timeout=60):
         """
         Setup all relevant parameters and create scenario
@@ -160,7 +164,7 @@ class DynamicObjectCrossing(BasicScenario):
         self._ego_route = CarlaDataProvider.get_ego_vehicle_route()
 
         super(DynamicObjectCrossing, self).__init__("Dynamicobjectcrossing",
-                                                    ego_vehicle,
+                                                    ego_vehicles,
                                                     config,
                                                     world,
                                                     debug_mode,
@@ -216,7 +220,7 @@ class DynamicObjectCrossing(BasicScenario):
         x_static = x_ego + shift * (x_cycle - x_ego)
         y_static = y_ego + shift * (y_cycle - y_ego)
 
-        spawn_point_wp = self.ego_vehicle.get_world().get_map().get_waypoint(transform.location)
+        spawn_point_wp = self.ego_vehicles[0].get_world().get_map().get_waypoint(transform.location)
 
         self.transform2 = carla.Transform(carla.Location(x_static, y_static,
                                                          spawn_point_wp.transform.location.z + 0.3))
@@ -294,13 +298,13 @@ class DynamicObjectCrossing(BasicScenario):
         lane_width = lane_width + (1.25 * lane_width * self._num_lane_changes)
         # leaf nodes
         if self._ego_route is not None:
-            start_condition = InTriggerDistanceToLocationAlongRoute(self.ego_vehicle,
+            start_condition = InTriggerDistanceToLocationAlongRoute(self.ego_vehicles,
                                                                     self._ego_route,
                                                                     self.other_actors[0].get_location(),
                                                                     15)
         else:
             start_condition = InTimeToArrivalToVehicle(self.other_actors[0],
-                                                       self.ego_vehicle,
+                                                       self.ego_vehicles[0],
                                                        self._time_to_reach)
 
         actor_velocity = KeepVelocity(self.other_actors[0],
@@ -321,14 +325,14 @@ class DynamicObjectCrossing(BasicScenario):
         actor_stop_crossed_lane = StopVehicle(self.other_actors[0],
                                               self._other_actor_max_brake,
                                               name="walker stop")
-        ego_pass_machine = DriveDistance(self.ego_vehicle,
+        ego_pass_machine = DriveDistance(self.ego_vehicles[0],
                                          5,
                                          name="ego vehicle passed prop")
         actor_remove = ActorDestroy(self.other_actors[0],
                                     name="Destroying walker")
         static_remove = ActorDestroy(self.other_actors[1],
                                      name="Destroying Prop")
-        end_condition = DriveDistance(self.ego_vehicle,
+        end_condition = DriveDistance(self.ego_vehicles[0],
                                       self._ego_vehicle_distance_driven,
                                       name="End condition ego drive distance")
 
@@ -372,7 +376,7 @@ class DynamicObjectCrossing(BasicScenario):
         """
         criteria = []
 
-        collision_criterion = CollisionTest(self.ego_vehicle)
+        collision_criterion = CollisionTest(self.ego_vehicles[0])
         criteria.append(collision_criterion)
 
         return criteria

--- a/srunner/scenarios/opposite_vehicle_taking_priority.py
+++ b/srunner/scenarios/opposite_vehicle_taking_priority.py
@@ -37,6 +37,8 @@ class OppositeVehicleRunningRedLight(BasicScenario):
     in which an other vehicle takes priority from the ego
     vehicle, by running a red traffic light (while the ego
     vehicle has green) (Traffic Scenario 7)
+
+    This is a single ego vehicle scenario
     """
 
     category = "RunningRedLight"
@@ -55,7 +57,7 @@ class OppositeVehicleRunningRedLight(BasicScenario):
 
     _traffic_light = None
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=180):
         """
         Setup all relevant parameters and create scenario
@@ -68,13 +70,13 @@ class OppositeVehicleRunningRedLight(BasicScenario):
         self.timeout = timeout
 
         super(OppositeVehicleRunningRedLight, self).__init__("OppositeVehicleRunningRedLight",
-                                                             ego_vehicle,
+                                                             ego_vehicles,
                                                              config,
                                                              world,
                                                              debug_mode,
                                                              criteria_enable=criteria_enable)
 
-        self._traffic_light = CarlaDataProvider.get_next_traffic_light(self.ego_vehicle, False)
+        self._traffic_light = CarlaDataProvider.get_next_traffic_light(self.ego_vehicles[0], False)
 
         if self._traffic_light is None:
             print("No traffic light for the given location of the ego vehicle found")
@@ -117,11 +119,11 @@ class OppositeVehicleRunningRedLight(BasicScenario):
 
         If this does not happen within 120 seconds, a timeout stops the scenario
         """
-        crossing_point_dynamic = get_crossing_point(self.ego_vehicle)
+        crossing_point_dynamic = get_crossing_point(self.ego_vehicles[0])
 
         # start condition
         startcondition = InTriggerDistanceToLocation(
-            self.ego_vehicle,
+            self.ego_vehicles[0],
             crossing_point_dynamic,
             self._ego_distance_to_traffic_light,
             name="Waiting for start position")
@@ -130,10 +132,10 @@ class OppositeVehicleRunningRedLight(BasicScenario):
             "Synchronize arrival times",
             policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)
 
-        location_of_collision_dynamic = get_geometric_linear_intersection(self.ego_vehicle, self.other_actors[0])
+        location_of_collision_dynamic = get_geometric_linear_intersection(self.ego_vehicles[0], self.other_actors[0])
 
         sync_arrival = SyncArrival(
-            self.other_actors[0], self.ego_vehicle, location_of_collision_dynamic)
+            self.other_actors[0], self.ego_vehicles[0], location_of_collision_dynamic)
         sync_arrival_stop = InTriggerDistanceToNextIntersection(self.other_actors[0],
                                                                 5)
         sync_arrival_parallel.add_child(sync_arrival)
@@ -174,7 +176,7 @@ class OppositeVehicleRunningRedLight(BasicScenario):
 
         # finally wait that ego vehicle drove a specific distance
         wait = DriveDistance(
-            self.ego_vehicle,
+            self.ego_vehicles[0],
             self._ego_distance_to_drive,
             name="DriveDistance")
 
@@ -197,12 +199,12 @@ class OppositeVehicleRunningRedLight(BasicScenario):
         criteria = []
 
         max_velocity_criterion = MaxVelocityTest(
-            self.ego_vehicle,
+            self.ego_vehicles[0],
             self._ego_max_velocity_allowed,
             optional=True)
-        collision_criterion = CollisionTest(self.ego_vehicle)
+        collision_criterion = CollisionTest(self.ego_vehicles[0])
         driven_distance_criterion = DrivenDistanceTest(
-            self.ego_vehicle,
+            self.ego_vehicles[0],
             self._ego_expected_driven_distance)
 
         criteria.append(max_velocity_criterion)

--- a/srunner/scenarios/other_leading_vehicle.py
+++ b/srunner/scenarios/other_leading_vehicle.py
@@ -38,10 +38,12 @@ class OtherLeadingVehicle(BasicScenario):
     This class holds everything required for a simple "Other Leading Vehicle"
     scenario involving a user controlled vehicle and two other actors.
     Traffic Scenario 05
+
+    This is a single ego vehicle scenario
     """
     category = "OtherLeadingVehicle"
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=80):
         """
         Setup all relevant parameters and create scenario
@@ -61,7 +63,7 @@ class OtherLeadingVehicle(BasicScenario):
         self.timeout = timeout
 
         super(OtherLeadingVehicle, self).__init__("VehicleDeceleratingInMultiLaneSetUp",
-                                                  ego_vehicle,
+                                                  ego_vehicles,
                                                   config,
                                                   world,
                                                   debug_mode,
@@ -108,7 +110,7 @@ class OtherLeadingVehicle(BasicScenario):
         keep_velocity = py_trees.composites.Parallel("Trigger condition for deceleration",
                                                      policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)
         keep_velocity.add_child(WaypointFollower(self.other_actors[0], self._first_vehicle_speed, avoid_collision=True))
-        keep_velocity.add_child(InTriggerDistanceToVehicle(self.other_actors[0], self.ego_vehicle, 55))
+        keep_velocity.add_child(InTriggerDistanceToVehicle(self.other_actors[0], self.ego_vehicles[0], 55))
 
         # Decelerating actor sequence behavior
         decelerate = self._first_vehicle_speed / 3.2
@@ -116,7 +118,7 @@ class OtherLeadingVehicle(BasicScenario):
         leading_actor_sequence_behavior.add_child(WaypointFollower(self.other_actors[0], decelerate,
                                                                    avoid_collision=True))
         # end condition
-        ego_drive_distance = DriveDistance(self.ego_vehicle, self._ego_vehicle_drive_distance)
+        ego_drive_distance = DriveDistance(self.ego_vehicles[0], self._ego_vehicle_drive_distance)
 
         # Build behavior tree
         sequence = py_trees.composites.Sequence("Scenario behavior")
@@ -143,7 +145,7 @@ class OtherLeadingVehicle(BasicScenario):
         """
         criteria = []
 
-        collision_criterion = CollisionTest(self.ego_vehicle)
+        collision_criterion = CollisionTest(self.ego_vehicles[0])
         criteria.append(collision_criterion)
 
         return criteria

--- a/srunner/scenarios/other_leading_vehicle.py
+++ b/srunner/scenarios/other_leading_vehicle.py
@@ -55,7 +55,7 @@ class OtherLeadingVehicle(BasicScenario):
         self._ego_vehicle_drive_distance = self._first_vehicle_location * 4
         self._first_vehicle_speed = 55
         self._second_vehicle_speed = 45
-        self._reference_waypoint = self._map.get_waypoint(config.trigger_point.location)
+        self._reference_waypoint = self._map.get_waypoint(config.trigger_points[0].location)
         self._other_actor_max_brake = 1.0
         self._first_actor_transform = None
         self._second_actor_transform = None

--- a/srunner/scenarios/signalized_junction_left_turn.py
+++ b/srunner/scenarios/signalized_junction_left_turn.py
@@ -33,12 +33,14 @@ class SignalizedJunctionLeftTurn(BasicScenario):
     Implementation class for Hero
     Vehicle turning left at signalized junction scenario,
     Traffic Scenario 08.
+
+    This is a single ego vehicle scenario
     """
     category = "SignalizedJunctionLeftTurn"
 
     timeout = 80  # Timeout of scenario in seconds
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=80):
         """
         Setup all relevant parameters and create scenario
@@ -55,13 +57,13 @@ class SignalizedJunctionLeftTurn(BasicScenario):
         self._queue = Blackboard().set(self._blackboard_queue_name, Queue())
         self._initialized = True
         super(SignalizedJunctionLeftTurn, self).__init__("TurnLeftAtSignalizedJunction",
-                                                         ego_vehicle,
+                                                         ego_vehicles,
                                                          config,
                                                          world,
                                                          debug_mode,
                                                          criteria_enable=criteria_enable)
 
-        self._traffic_light = CarlaDataProvider.get_next_traffic_light(self.ego_vehicle, False)
+        self._traffic_light = CarlaDataProvider.get_next_traffic_light(self.ego_vehicles[0], False)
         traffic_light_other = CarlaDataProvider.get_next_traffic_light(self.other_actors[0], False)
         if self._traffic_light is None or traffic_light_other is None:
             raise RuntimeError("No traffic light for the given location found")
@@ -119,7 +121,7 @@ class SignalizedJunctionLeftTurn(BasicScenario):
         move_actor = WaypointFollower(self.other_actors[0], self._target_vel, plan=plan,
                                       blackboard_queue_name=self._blackboard_queue_name, avoid_collision=True)
         # wait
-        wait = DriveDistance(self.ego_vehicle, self._ego_distance)
+        wait = DriveDistance(self.ego_vehicles[0], self._ego_distance)
 
         # Behavior tree
         root = py_trees.composites.Parallel(
@@ -142,7 +144,7 @@ class SignalizedJunctionLeftTurn(BasicScenario):
         """
         criteria = []
 
-        collison_criteria = CollisionTest(self.ego_vehicle)
+        collison_criteria = CollisionTest(self.ego_vehicles[0])
         criteria.append(collison_criteria)
 
         return criteria

--- a/srunner/scenarios/signalized_junction_right_turn.py
+++ b/srunner/scenarios/signalized_junction_right_turn.py
@@ -34,10 +34,12 @@ class SignalizedJunctionRightTurn(BasicScenario):
     Implementation class for Hero
     Vehicle turning right at signalized junction scenario,
     Traffic Scenario 09.
+
+    This is a single ego vehicle scenario
     """
     category = "SignalizedJunctionLeftTurn"
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, criteria_enable=True,
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, criteria_enable=True,
                  timeout=80):
         """
         Setup all relevant parameters and create scenario
@@ -50,13 +52,13 @@ class SignalizedJunctionRightTurn(BasicScenario):
         # Timeout of scenario in seconds
         self.timeout = timeout
         super(SignalizedJunctionRightTurn, self).__init__("HeroActorTurningRightAtSignalizedJunction",
-                                                          ego_vehicle,
+                                                          ego_vehicles,
                                                           config,
                                                           world,
                                                           debug_mode,
                                                           criteria_enable=criteria_enable)
 
-        self._traffic_light = CarlaDataProvider.get_next_traffic_light(self.ego_vehicle, False)
+        self._traffic_light = CarlaDataProvider.get_next_traffic_light(self.ego_vehicles[0], False)
         if self._traffic_light is None:
             print("No traffic light for the given location of the ego vehicle found")
             sys.exit(-1)
@@ -92,10 +94,10 @@ class SignalizedJunctionRightTurn(BasicScenario):
         After 80 seconds, a timeout stops the scenario.
         """
 
-        location_of_collision_dynamic = get_geometric_linear_intersection(self.ego_vehicle, self.other_actors[0])
+        location_of_collision_dynamic = get_geometric_linear_intersection(self.ego_vehicles[0], self.other_actors[0])
         crossing_point_dynamic = get_crossing_point(self.other_actors[0])
         sync_arrival = SyncArrival(
-            self.other_actors[0], self.ego_vehicle, location_of_collision_dynamic)
+            self.other_actors[0], self.ego_vehicles[0], location_of_collision_dynamic)
         sync_arrival_stop = InTriggerDistanceToLocation(self.other_actors[0], crossing_point_dynamic, 5)
 
         sync_arrival_parallel = py_trees.composites.Parallel(
@@ -126,7 +128,7 @@ class SignalizedJunctionRightTurn(BasicScenario):
         # stop other actor
         stop = StopVehicle(self.other_actors[0], self._brake_value)
         # end condition
-        end_condition = DriveDistance(self.ego_vehicle, self._ego_distance)
+        end_condition = DriveDistance(self.ego_vehicles[0], self._ego_distance)
 
         # Behavior tree
         sequence = py_trees.composites.Sequence()
@@ -146,7 +148,7 @@ class SignalizedJunctionRightTurn(BasicScenario):
         """
         criteria = []
 
-        collison_criteria = CollisionTest(self.ego_vehicle)
+        collison_criteria = CollisionTest(self.ego_vehicles[0])
         criteria.append(collison_criteria)
 
         return criteria

--- a/srunner/scenarios/trafficlight_scenario.py
+++ b/srunner/scenarios/trafficlight_scenario.py
@@ -20,11 +20,13 @@ class TrafficLightScenario(BasicScenario):
     This scenario controls traffic lights at intersection to create interesting situations, e.g.:
       - vehicles running red lights
       - yielding to traffic
+
+    This is a single ego vehicle scenario
     """
 
     category = "TrafficLightScenario"
 
-    def __init__(self, world, ego_vehicle, config, randomize=False, debug_mode=False, timeout=35 * 60):
+    def __init__(self, world, ego_vehicles, config, randomize=False, debug_mode=False, timeout=35 * 60):
         """
         Setup all relevant parameters and create scenario
         """
@@ -34,7 +36,7 @@ class TrafficLightScenario(BasicScenario):
         self.timeout = timeout  # Timeout of scenario in seconds
 
         super(TrafficLightScenario, self).__init__("TrafficLightScenario",
-                                                   ego_vehicle,
+                                                   ego_vehicles,
                                                    config,
                                                    world,
                                                    debug_mode,
@@ -48,7 +50,7 @@ class TrafficLightScenario(BasicScenario):
 
         # Build behavior tree
         sequence = py_trees.composites.Sequence("Sequence Behavior")
-        traffic_manipulator = TrafficLightManipulator(self.ego_vehicle, debug=self.debug)
+        traffic_manipulator = TrafficLightManipulator(self.ego_vehicles[0], debug=self.debug)
         sequence.add_child(traffic_manipulator)
 
         return sequence

--- a/srunner/tools/config_parser.py
+++ b/srunner/tools/config_parser.py
@@ -85,7 +85,7 @@ class ActorConfiguration(ActorConfigurationData):
     - Model (e.g. Lincoln MKZ2017)
     """
 
-    def __init__(self, node):
+    def __init__(self, node, rolename):
 
         pos_x = float(set_attrib(node, 'x', 0))
         pos_y = float(set_attrib(node, 'y', 0))
@@ -107,7 +107,7 @@ class ActorConfiguration(ActorConfigurationData):
         super(ActorConfiguration, self).__init__(set_attrib(node, 'model', 'vehicle.*'),
                                                  carla.Transform(carla.Location(x=pos_x, y=pos_y, z=pos_z),
                                                  carla.Rotation(yaw=yaw)),
-                                                 set_attrib(node, 'rolename', 'other'),
+                                                 set_attrib(node, 'rolename', rolename),
                                                  autopilot, random_location, amount)
 
 
@@ -169,7 +169,7 @@ def parse_scenario_configuration(scenario_config_file, scenario_name):
         new_config.trigger_points = []
 
         for ego_vehicle in scenario.iter("ego_vehicle"):
-            new_config.ego_vehicles.append(ActorConfiguration(ego_vehicle))
+            new_config.ego_vehicles.append(ActorConfiguration(ego_vehicle, 'hero'))
             new_config.trigger_points.append(new_config.ego_vehicles[-1].transform)
 
         for target in scenario.iter("target"):
@@ -181,7 +181,7 @@ def parse_scenario_configuration(scenario_config_file, scenario_name):
             new_config.route = route_conf
 
         for other_actor in scenario.iter("other_actor"):
-            new_config.other_actors.append(ActorConfiguration(other_actor))
+            new_config.other_actors.append(ActorConfiguration(other_actor, 'scenario'))
 
         if single_scenario_only:
             if new_config.name == scenario_name:

--- a/srunner/tools/config_parser.py
+++ b/srunner/tools/config_parser.py
@@ -67,8 +67,9 @@ class ActorConfigurationData(object):
     This is a configuration base class to hold model and transform attributes
     """
 
-    def __init__(self, model, transform, autopilot=False, random=False, amount=1):
+    def __init__(self, model, transform, rolename='other', autopilot=False, random=False, amount=1):
         self.model = model
+        self.rolename = rolename
         self.transform = transform
         self.autopilot = autopilot
         self.random_location = random
@@ -106,6 +107,7 @@ class ActorConfiguration(ActorConfigurationData):
         super(ActorConfiguration, self).__init__(set_attrib(node, 'model', 'vehicle.*'),
                                                  carla.Transform(carla.Location(x=pos_x, y=pos_y, z=pos_z),
                                                  carla.Rotation(yaw=yaw)),
+                                                 set_attrib(node, 'rolename', 'other'),
                                                  autopilot, random_location, amount)
 
 
@@ -119,8 +121,8 @@ class ScenarioConfiguration(object):
     - type is the class of scenario (e.g. ControlLoss)
     """
 
-    trigger_point = None
-    ego_vehicle = None
+    trigger_points = []
+    ego_vehicles = []
     other_actors = []
     town = None
     name = None
@@ -163,10 +165,12 @@ def parse_scenario_configuration(scenario_config_file, scenario_name):
         new_config.name = set_attrib(scenario, 'name', None)
         new_config.type = set_attrib(scenario, 'type', None)
         new_config.other_actors = []
+        new_config.ego_vehicles = []
+        new_config.trigger_points = []
 
         for ego_vehicle in scenario.iter("ego_vehicle"):
-            new_config.ego_vehicle = ActorConfiguration(ego_vehicle)
-            new_config.trigger_point = new_config.ego_vehicle.transform
+            new_config.ego_vehicles.append(ActorConfiguration(ego_vehicle))
+            new_config.trigger_points.append(new_config.ego_vehicles[-1].transform)
 
         for target in scenario.iter("target"):
             new_config.target = TargetConfiguration(target)


### PR DESCRIPTION
#### Description
As one of CARLA's key features is the support for multiple ego vehicles, this PR brings in this feature also for the scenario execution. Multiple ego vehicles can be specified in the configuration file (XML) and identified via their unique role names. A simple example for a scenario using multiple ego vehicles is provided.

Other changes are:
* Added additional command line options for the scenario_runner.py
  - --waitForEgo: Wait and connect 
  - --outputDir: User defined output folder
  - --configFile: External XML file
  - --additionalScenario: External scenario definition (python class)

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

Fixes #291 (There is a new commandline option to disable reloading the CARLA world)

#### Where has this been tested?
  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.5
  * **CARLA version:** 0.9.5

#### Possible Drawbacks
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/301)
<!-- Reviewable:end -->
