### PR TITLE
Fixed spawn issue (collision with ground) for newer CARLA versions

### DIFF
--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -455,6 +455,8 @@ class CarlaActorPool(object):
                 actor = CarlaActorPool._world.try_spawn_actor(blueprint, spawn_point)
 
         else:
+            # slightly lift the actor to avoid collisions with ground when spawning the actor
+            spawn_point.location.z = spawn_point.location.z + 0.2
             actor = CarlaActorPool._world.try_spawn_actor(blueprint, spawn_point)
 
         if actor is None:


### PR DESCRIPTION
Newer CARLA versions can cause a collision upon vehicle spawning when
the spawn point is on ground level.

Fixes #305 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/307)
<!-- Reviewable:end -->
