### PR TITLE
Add support to set/change weather conditions for a scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest changes
 
+* Added support for weather conditions
 * Added basic version check to ensure usage of correct CARLA version
 * Extended OpenScenario support
     - Full support for SimulationTime condition

--- a/Docs/openscenario_support.md
+++ b/Docs/openscenario_support.md
@@ -36,7 +36,7 @@ An example for a supported scenario based on OpenScenario is available [here](..
        * [ ] AquirePosition
     * [x] Command (Support for command 'Idle')
     * [ ] Script
-    * [ ] SetEnvironment
+    * [ ] SetEnvironment (Weather is supported)
     * [ ] Entity
     * [ ] Parameter
     * [ ] Traffic

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -258,6 +258,18 @@ class ScenarioRunner(object):
         Load and run the given scenario
         """
 
+        # Set the appropriate weather conditions
+        weather = carla.WeatherParameters(
+            cloudyness=config.weather.cloudyness,
+            precipitation=config.weather.precipitation,
+            precipitation_deposits=config.weather.precipitation_deposits,
+            wind_intensity=config.weather.wind_intensity,
+            sun_azimuth_angle=config.weather.sun_azimuth,
+            sun_altitude_angle=config.weather.sun_altitude
+        )
+
+        self.world.set_weather(weather)
+
         # Load scenario and run it
         self.manager.load_scenario(scenario)
         self.manager.run_scenario()

--- a/srunner/configs/CyclistCrossing.xosc
+++ b/srunner/configs/CyclistCrossing.xosc
@@ -83,7 +83,7 @@
                                 <Date day="25" month="6" year="2019" />
                             </TimeOfDay>
                             <Weather cloudState="free">
-                                <Sun intensity="1.0" azimuth="0.0" elevation="1.571" />
+                                <Sun intensity="1.0" azimuth="0.0" elevation="1.31" />
                                 <Fog visualRange="100000.0" />
                                 <Precipitation type="dry" intensity="0.0" />
                             </Weather>

--- a/srunner/configs/FollowLeadingVehicle.xml
+++ b/srunner/configs/FollowLeadingVehicle.xml
@@ -2,6 +2,7 @@
 <scenarios>
     <scenario name="FollowLeadingVehicle_1" type="FollowLeadingVehicle" town="Town01">
         <ego_vehicle x="107" y="133" z="0.5" yaw="0" model="vehicle.lincoln.mkz2017" />
+        <weather cloudyness="0" precipitation="0" precipitation_deposits="0" wind_intensity="0" sun_azimuth="0" sun_altitude="75" />
     </scenario>
     <scenario name="FollowLeadingVehicleWithObstacle_1" type="FollowLeadingVehicleWithObstacle" town="Town01">
         <ego_vehicle x="107" y="133.5" z="0.5" yaw="0" model="vehicle.lincoln.mkz2017" />

--- a/srunner/configs/FollowLeadingVehicle.xosc
+++ b/srunner/configs/FollowLeadingVehicle.xosc
@@ -83,7 +83,7 @@
                                 <Date day="25" month="6" year="2019" />
                             </TimeOfDay>
                             <Weather cloudState="free">
-                                <Sun intensity="1.0" azimuth="0.0" elevation="1.571" />
+                                <Sun intensity="1.0" azimuth="0.0" elevation="1.31" />
                                 <Fog visualRange="100000.0" />
                                 <Precipitation type="dry" intensity="0.0" />
                             </Weather>

--- a/srunner/scenarios/open_scenario.py
+++ b/srunner/scenarios/open_scenario.py
@@ -5,7 +5,7 @@
 # For a copy, see <https://opensource.org/licenses/MIT>.
 
 """
-Basic scenario class using the OpenScenario definition
+Basic scenario class using the OpenSCENARIO definition
 """
 
 import py_trees
@@ -24,7 +24,7 @@ def oneshot_behavior(name, variable_name, behaviour):
     """
     This is taken from py_trees.idiom.oneshot. However, we use a different
     clearing policy to work around some issues for setting up StartConditions
-    of OpenScenario
+    of OpenSCENARIO
     """
     subtree_root = py_trees.composites.Selector(name=name)
     check_flag = py_trees.blackboard.CheckBlackboardVariable(
@@ -53,7 +53,7 @@ def oneshot_behavior(name, variable_name, behaviour):
 class OpenScenario(BasicScenario):
 
     """
-    Implementation of a  Master scenario that controls the route.
+    Implementation of the OpenSCENARIO scenario
 
     This is a single ego vehicle scenario
     """

--- a/srunner/tools/config_parser.py
+++ b/srunner/tools/config_parser.py
@@ -111,6 +111,20 @@ class ActorConfiguration(ActorConfigurationData):
                                                  autopilot, random_location, amount)
 
 
+class WeatherConfiguration(object):
+
+    """
+    This class provides basic weather configuration values
+    """
+
+    cloudyness = 0
+    precipitation = 0
+    precipitation_deposits = 0
+    wind_intensity = 0
+    sun_azimuth = 360
+    sun_altitude = 0
+
+
 class ScenarioConfiguration(object):
 
     """
@@ -129,6 +143,7 @@ class ScenarioConfiguration(object):
     type = None
     target = None
     route = None
+    weather = WeatherConfiguration()
 
 
 def parse_scenario_configuration(scenario_config_file, scenario_name):
@@ -159,6 +174,14 @@ def parse_scenario_configuration(scenario_config_file, scenario_name):
         new_config.other_actors = []
         new_config.ego_vehicles = []
         new_config.trigger_points = []
+
+        for weather in scenario.iter("weather"):
+            new_config.weather.cloudyness = float(weather.attrib.get("cloudyness", 0))
+            new_config.weather.precipitation = float(weather.attrib.get("precipitation", 0))
+            new_config.weather.precipitation_deposits = float(weather.attrib.get("precipitation_deposits", 0))
+            new_config.weather.wind_intensity = float(weather.attrib.get("wind_intensity", 0))
+            new_config.weather.sun_azimuth = float(weather.attrib.get("sun_azimuth", 360))
+            new_config.weather.sun_altitude = float(weather.attrib.get("sun_altitude", 0))
 
         for ego_vehicle in scenario.iter("ego_vehicle"):
             new_config.ego_vehicles.append(ActorConfiguration(ego_vehicle, 'hero'))


### PR DESCRIPTION
Weather conditions can now be set in OpenSCENARIO or through
scenarios defined in Python (via XML)

Example for old XML style is provided in FollowLeadingVehicle.xml

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.5
  * **CARLA version:** 0.9.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/332)
<!-- Reviewable:end -->
