### PR TITLE
Fixed usage of km/h instead of m/s for WaypointFollower behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Latest changes
 
+* Fixed WaypointFollower behavior to use m/s instead of km/h
 * Added get_transform() method for CarlaDataProvider
 * Added support for weather conditions
 * Added basic version check to ensure usage of correct CARLA version

--- a/srunner/scenariomanager/atomic_scenario_behavior.py
+++ b/srunner/scenariomanager/atomic_scenario_behavior.py
@@ -1086,7 +1086,7 @@ class WaypointFollower(AtomicBehavior):
         super(WaypointFollower, self).__init__(name)
         self._actor_list = []
         self._actor_list.append(actor)
-        self._target_speed = target_speed
+        self._target_speed = target_speed * 3.6  # Note: Conversion from m/s to km/h required
         self._local_planner_list = []
         self._plan = plan
         self._blackboard_queue_name = blackboard_queue_name

--- a/srunner/scenarios/follow_leading_vehicle.py
+++ b/srunner/scenarios/follow_leading_vehicle.py
@@ -56,7 +56,7 @@ class FollowLeadingVehicle(BasicScenario):
 
         self._map = CarlaDataProvider.get_map()
         self._first_vehicle_location = 25
-        self._first_vehicle_speed = 40
+        self._first_vehicle_speed = 10
         self._reference_waypoint = self._map.get_waypoint(config.trigger_points[0].location)
         self._other_actor_max_brake = 1.0
         self._other_actor_stop_in_front_intersection = 20
@@ -187,8 +187,8 @@ class FollowLeadingVehicleWithObstacle(BasicScenario):
         self._map = CarlaDataProvider.get_map()
         self._first_actor_location = 25
         self._second_actor_location = self._first_actor_location + 41
-        self._first_actor_speed = 40
-        self._second_actor_speed = 5
+        self._first_actor_speed = 10
+        self._second_actor_speed = 1.5
         self._reference_waypoint = self._map.get_waypoint(config.trigger_points[0].location)
         self._other_actor_max_brake = 1.0
         self._first_actor_transform = None
@@ -265,7 +265,7 @@ class FollowLeadingVehicleWithObstacle(BasicScenario):
         stop_near_intersection = py_trees.composites.Parallel(
             "Waiting for end position near Intersection",
             policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)
-        stop_near_intersection.add_child(WaypointFollower(self.other_actors[0], 35))
+        stop_near_intersection.add_child(WaypointFollower(self.other_actors[0], 10))
         stop_near_intersection.add_child(InTriggerDistanceToNextIntersection(self.other_actors[0], 20))
 
         driving_to_next_intersection.add_child(WaypointFollower(self.other_actors[0], self._first_actor_speed))

--- a/srunner/scenarios/maneuver_opposite_direction.py
+++ b/srunner/scenarios/maneuver_opposite_direction.py
@@ -47,7 +47,7 @@ class ManeuverOppositeDirection(BasicScenario):
         self._second_vehicle_location = self._first_vehicle_location + 60
         self._ego_vehicle_drive_distance = self._second_vehicle_location * 2
         self._start_distance = self._first_vehicle_location * 0.9
-        self._opposite_speed = 20   # km/h
+        self._opposite_speed = 5.56   # m/s
         self._source_gap = 40   # m
         self._reference_waypoint = self._map.get_waypoint(config.trigger_points[0].location)
         self._source_transform = None

--- a/srunner/scenarios/opposite_vehicle_taking_priority.py
+++ b/srunner/scenarios/opposite_vehicle_taking_priority.py
@@ -51,7 +51,7 @@ class OppositeVehicleRunningRedLight(BasicScenario):
     _ego_distance_to_drive = 40          # Allowed distance to drive
 
     # other vehicle
-    _other_actor_target_velocity = 35      # Target velocity of other vehicle
+    _other_actor_target_velocity = 10      # Target velocity of other vehicle
     _other_actor_max_brake = 1.0           # Maximum brake of other vehicle
     _other_actor_distance = 50             # Distance the other vehicle should drive
 

--- a/srunner/scenarios/signalized_junction_left_turn.py
+++ b/srunner/scenarios/signalized_junction_left_turn.py
@@ -48,7 +48,7 @@ class SignalizedJunctionLeftTurn(BasicScenario):
         self.category = "SignalizedJunctionLeftTurn"
         self._world = world
         self._map = CarlaDataProvider.get_map()
-        self._target_vel = 25
+        self._target_vel = 6.9
         self._brake_value = 0.5
         self._ego_distance = 110
         self._traffic_light = None

--- a/srunner/scenarios/signalized_junction_right_turn.py
+++ b/srunner/scenarios/signalized_junction_right_turn.py
@@ -44,7 +44,7 @@ class SignalizedJunctionRightTurn(BasicScenario):
         """
         Setup all relevant parameters and create scenario
         """
-        self._target_vel = 25
+        self._target_vel = 6.9
         self._brake_value = 0.5
         self._ego_distance = 40
         self._traffic_light = None


### PR DESCRIPTION
The interface of the WaypointFollower behavior used km/h instead of m/s

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

Fixes #339 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.5
  * **CARLA version:** 0.9.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/343)
<!-- Reviewable:end -->
