### PR TITLE
Fixed adversary start transform in VehicleTurningRight/Left (TS04) scenarios

### DIFF
--- a/srunner/scenarios/object_crash_intersection.py
+++ b/srunner/scenarios/object_crash_intersection.py
@@ -164,7 +164,7 @@ class VehicleTurningRight(BasicScenario):
 
         if self._ego_route is not None:
             trigger_distance = InTriggerDistanceToLocationAlongRoute(self.ego_vehicles[0], self._ego_route,
-                                                                     self.other_actors[0].get_location(), 20)
+                                                                     self._other_actor_transform, 20)
         else:
             trigger_distance = InTriggerDistanceToVehicle(self.other_actors[0], self.ego_vehicles[0], 20)
 
@@ -315,7 +315,7 @@ class VehicleTurningLeft(BasicScenario):
         lane_width = lane_width + (1.10 * lane_width * self._num_lane_changes)
         if self._ego_route is not None:
             trigger_distance = InTriggerDistanceToLocationAlongRoute(self.ego_vehicles[0], self._ego_route,
-                                                                     self.other_actors[0].get_location(), 20)
+                                                                     self._other_actor_transform, 20)
         else:
             trigger_distance = InTriggerDistanceToVehicle(self.other_actors[0], self.ego_vehicles[0], 25)
 


### PR DESCRIPTION
Adversary was not moving due to wrong start location of the trigger
condition.

Addresses #323 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/347)
<!-- Reviewable:end -->
