### PR TITLE
Fixed walker selection in DynamicObjectCrossing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,17 @@
 * Split of behaviors into behaviors and conditions
 * Moved atomics into new submodule scenarioatomics
 * Updated documentation for all behaviors, conditions and test criteria
-* Fixed WaypointFollower behavior to use m/s instead of km/h
-* Added get_transform() method for CarlaDataProvider
-* Added support for weather conditions
-* Added basic version check to ensure usage of correct CARLA version
-* Extended OpenScenario support
+* New Features:
+    - Added get_transform() method for CarlaDataProvider
+    - Added support for weather conditions
+    - Added basic version check to ensure usage of correct CARLA version
+* Extended OpenScenario support:
     - Added support for pedestrians
     - Full support for SimulationTime condition
+    - Added weather support
+* Fixes:
+    - Avoided use of 'controller.ai.walker' as walker type in DynamicObjectCrossing scenario
+    - Fixed WaypointFollower behavior to use m/s instead of km/h
 
 ## CARLA Scenario_Runner 0.9.6
 **This is the _first_ release to work with CARLA 0.9.6**

--- a/srunner/scenarios/object_crash_vehicle.py
+++ b/srunner/scenarios/object_crash_vehicle.py
@@ -166,7 +166,7 @@ class DynamicObjectCrossing(BasicScenario):
 
         self._ego_route = CarlaDataProvider.get_ego_vehicle_route()
 
-        super(DynamicObjectCrossing, self).__init__("Dynamicobjectcrossing",
+        super(DynamicObjectCrossing, self).__init__("DynamicObjectCrossing",
                                                     ego_vehicles,
                                                     config,
                                                     world,
@@ -199,7 +199,7 @@ class DynamicObjectCrossing(BasicScenario):
         if self._adversary_type is False:
             self._walker_yaw = orientation_yaw
             self._other_actor_target_velocity = 3 + (0.4 * self._num_lane_changes)
-            walker = CarlaActorPool.request_new_actor('walker*', transform)
+            walker = CarlaActorPool.request_new_actor('walker.*', transform)
             adversary = walker
         else:
             self._other_actor_target_velocity = self._other_actor_target_velocity * self._num_lane_changes


### PR DESCRIPTION
Instead of requesting an actor of type walker* the type walker.* has to
be used to avoid using the 'controller.ai.walker' by accident.

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

Fixes #349 

#### Where has this been tested?
  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.5
  * **CARLA version:** 0.9.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/351)
<!-- Reviewable:end -->
