### PR TITLE
Fixed spawn_point modification in CarlaActorPool.setup_actor()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     - Avoided use of 'controller.ai.walker' as walker type in DynamicObjectCrossing scenario
     - Fixed WaypointFollower behavior to use m/s instead of km/h
     - Fixed starting position of VehicleTurnLeft/Right scenarios
+    - Fixed spawn_point modification inside CarlaActorPool.setup_actor()
 
 ## CARLA Scenario_Runner 0.9.6
 **This is the _first_ release to work with CARLA 0.9.6**

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -478,8 +478,12 @@ class CarlaActorPool(object):
 
         else:
             # slightly lift the actor to avoid collisions with ground when spawning the actor
-            spawn_point.location.z = spawn_point.location.z + 0.2
-            actor = CarlaActorPool._world.try_spawn_actor(blueprint, spawn_point)
+            # DO NOT USE spawn_point directly, as this will modify spawn_point permanently
+            _spawn_point = carla.Transform(carla.Location(), spawn_point.rotation)
+            _spawn_point.location.x = spawn_point.location.x
+            _spawn_point.location.y = spawn_point.location.y
+            _spawn_point.location.z = spawn_point.location.z + 0.2
+            actor = CarlaActorPool._world.try_spawn_actor(blueprint, _spawn_point)
 
         if actor is None:
             raise RuntimeError(


### PR DESCRIPTION
The spawn_point parameter of CarlaActorPool.setup_actor() should be
const, but do to call-by-reference it was mistakenly modified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/358)
<!-- Reviewable:end -->
