### PR TITLE
Aftertermination rules

### DIFF
--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -178,14 +178,15 @@ class AfterTerminationCondition(AtomicBehavior):
     The condition terminates with SUCCESS, when the named story element ends
     """
 
-    def __init__(self, element_type, element_name):
+    def __init__(self, element_type, element_name, rule):
         """
         Setup element details
         """
         super(AfterTerminationCondition, self).__init__("AfterTerminationCondition")
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
-        self._element_type = element_type
+        self._element_type = element_type.upper()
         self._element_name = element_name
+        self._rule = rule.upper()
         self._start_time = None
         self._blackboard = py_trees.blackboard.Blackboard()
 
@@ -201,11 +202,17 @@ class AfterTerminationCondition(AtomicBehavior):
         Check if the specified story element has ended since the beginning of the condition
         """
         new_status = py_trees.common.Status.RUNNING
+        if self._rule == "ANY":
+            rules = ["END", "CANCEL"]
+        else:
+            rules = [self._rule]
 
-        blackboard_variable_name = "({}){}-{}".format(self._element_type.upper(), self._element_name, "END")
-        element_start_time = self._blackboard.get(blackboard_variable_name)
-        if element_start_time and element_start_time >= self._start_time:
-            new_status = py_trees.common.Status.SUCCESS
+        for rule in rules:
+            if new_status == py_trees.common.Status.RUNNING:
+                blackboard_variable_name = "({}){}-{}".format(self._element_type, self._element_name, rule)
+                element_start_time = self._blackboard.get(blackboard_variable_name)
+                if element_start_time and element_start_time >= self._start_time:
+                    new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -223,8 +223,8 @@ class OpenScenarioParser(object):
             elif state_condition.find('AfterTermination') is not None:
                 element_type = state_condition.find('AfterTermination').attrib.get('type')
                 element_name = state_condition.find('AfterTermination').attrib.get('name')
-                # condition_rule = state_condition.find('rule')
-                atomic = AfterTerminationCondition(element_type, element_name)
+                condition_rule = state_condition.find('rule')
+                atomic = AfterTerminationCondition(element_type, element_name, condition_rule)
             elif state_condition.find('Command') is not None:
                 raise NotImplementedError("ByState Command conditions are not yet supported")
             elif state_condition.find('Signal') is not None:

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -223,7 +223,7 @@ class OpenScenarioParser(object):
             elif state_condition.find('AfterTermination') is not None:
                 element_type = state_condition.find('AfterTermination').attrib.get('type')
                 element_name = state_condition.find('AfterTermination').attrib.get('name')
-                condition_rule = state_condition.find('rule')
+                condition_rule = state_condition.find('AfterTermination').attrib.get('rule')
                 atomic = AfterTerminationCondition(element_type, element_name, condition_rule)
             elif state_condition.find('Command') is not None:
                 raise NotImplementedError("ByState Command conditions are not yet supported")


### PR DESCRIPTION
AfterTermination rule attributes are now respected
When an element ends, it tries to accurately determine whether it ended or cancelled (or in some cases, both)
The conditions will wait for the correct type of termination before evaluating as true

Addresses #378

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/380)
<!-- Reviewable:end -->
