### PR TITLE
Enabled use of fully qualified path for roadnetwork in OpenSCENARIO

### DIFF
--- a/Docs/openscenario_support.md
+++ b/Docs/openscenario_support.md
@@ -23,7 +23,7 @@ Catalogs in OpenSCENARIO are a mean to import predefined information, for exampl
 Currently Catalogs are *NOT* supported.
 
 ### RoadNetwork
-The RoadNetwork points to the _Logic_ (OpenDRIVE) and _SceneGraph_ (OpenSceneGraph) files that the scenario makes use of. Currently, our implementation does not use and OpenSceneGraph information, and hence this flag is not parsed. For the Logic of the RoadNetwork, it is important to provide only the name of the CARLA town, e.g. Town01 and not the full path.
+The RoadNetwork points to the _Logic_ (OpenDRIVE) and _SceneGraph_ (OpenSceneGraph) files that the scenario makes use of. Currently, our implementation does not use OpenSceneGraph information, and hence this flag is not parsed. For the Logic of the RoadNetwork, either the name of the CARLA town, e.g. Town01 can be provided or the fully qualified path (e.g. /x/y/Town01.xodr).
 
 <img src="images/OSC_roadnetwork.png" width="200">
 

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -88,6 +88,10 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
         for logic in xml_tree.find("RoadNetwork").findall("Logics"):
             self.town = logic.attrib.get('filepath', None)
 
+        if self.town is not None and ".xodr" in self.town:
+            (_, tail) = os.path.split(self.town)
+            self.town = tail[:-5]
+
     def _set_carla_weather(self, xml_tree):
         """
         Extract weather information from OpenSCENARIO config


### PR DESCRIPTION
Instead of only providing the CARLA town name, it is also now possible to use
the fully qualified path. This brings us closer to the standard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/391)
<!-- Reviewable:end -->
