### PR TITLE
Extended OSC support to handle right and left-hand coordinate systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
     - Added support for RoadCondition: Friction
     - Redundant rolename object property is no longer required
     - Added support for global parameters
+    - Fixed coordinate system to use right-hand as default. Left-hand CARLA system can be used by adding "CARLA:" at the start of the description in the FileHeader.
 * Fixes:
     - Avoided use of 'controller.ai.walker' as walker type in DynamicObjectCrossing scenario
     - Fixed WaypointFollower behavior to use m/s instead of km/h

--- a/Docs/openscenario_support.md
+++ b/Docs/openscenario_support.md
@@ -14,7 +14,9 @@ All scenarios based on OpenSCENARIO 0.9.5 have to follow this structure:
 
 <img src="images/OSC_main.png" width="300">
 
-The _FileHeader_ is only for informational purpose and does not influence any behavior. Nevertheless, providing a reasonable name is recommended. Then, there are four main components: _Catalogs_, _RoadNetwork_, _Entities_ and the _Storyboard_. In addition, parameters can be optionally declared inside the _ParameterDeclaration.
+The _FileHeader_ is for informational purpose. If you design the scenario specifically to work with CARLA coordinates (left-hand Unreal coordinate system), ensure that the description starts with "CARLA:". Otherwise, the default coordinate system for OpenSCENARIO, which is a right-hand system, will be assumed (in alignment to OpenDRIVE). Besides, providing a reasonable name is recommended.
+
+Then, there are four main components: _Catalogs_, _RoadNetwork_, _Entities_ and the _Storyboard_. In addition, parameters can be optionally declared inside the _ParameterDeclaration.
 
 ### ParameterDeclaration
 Parameters can be used according to the _OSCParameterDeclaration_. Therefore, the parameter has to be provided with a name, its value and the type (integer, double or string). Important: The parameter name has to start with '$'.
@@ -82,6 +84,7 @@ Please take a look into the provided example scenarios, for further details on t
 
 - All things in OpenSCENARIO happen in parallel, this includes stories, events, actions or conditions.
 - Sequences of actions or events can be created using an "AfterTermination" condition as StartCondition for the follow-up action or event
+- If you design the scenario specifically to work with CARLA coordinates (left-hand Unreal coordinate system), ensure that the description in the FileHeader starts with "CARLA:". Otherwise, the default coordinate system for OpenSCENARIO, which is a right-hand system, will be assumed (in alignment to OpenDRIVE).
 
 
 ## Overview of available features of OpenSCENARIO v0.9:

--- a/srunner/examples/CyclistCrossing.xosc
+++ b/srunner/examples/CyclistCrossing.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO>
-    <FileHeader revMajor="0" revMinor="9" date="2019-06-25" description="CyclistCrossing" author="" />
+    <FileHeader revMajor="0" revMinor="9" date="2019-06-25" description="CARLA:CyclistCrossing" author="" />
     <Catalogs>
         <VehicleCatalog>
             <Directory path="Catalogs/VehicleCatalogs" />

--- a/srunner/examples/FollowLeadingVehicle.xosc
+++ b/srunner/examples/FollowLeadingVehicle.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO>
-    <FileHeader revMajor="0" revMinor="9" date="2019-06-25" description="FollowLeadingVehicle" author="" />
+    <FileHeader revMajor="0" revMinor="9" date="2019-06-25" description="CARLA:FollowLeadingVehicle" author="" />
     <ParameterDeclaration>
     	<Parameter name="$leadingSpeed" type="double" value="2.0" />
     </ParameterDeclaration>

--- a/srunner/examples/LaneChangeSimple.xosc
+++ b/srunner/examples/LaneChangeSimple.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO>
-    <FileHeader revMajor="0" revMinor="9" date="2019-06-25" description="LaneChangeSimple" author="" />
+    <FileHeader revMajor="0" revMinor="9" date="2019-06-25" description="CARLA:LaneChangeSimple" author="" />
     <Catalogs>
         <VehicleCatalog>
             <Directory path="Catalogs/VehicleCatalogs" />

--- a/srunner/examples/PedestrianCrossingfront.xosc
+++ b/srunner/examples/PedestrianCrossingfront.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO>
-    <FileHeader revMajor="0" revMinor="9" date="2019-06-25" description="PedestrianCrossing" author="" />
+    <FileHeader revMajor="0" revMinor="9" date="2019-06-25" description="CARLA:PedestrianCrossing" author="" />
     <Catalogs>
         <VehicleCatalog>
             <Directory path="Catalogs/VehicleCatalogs" />

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -79,6 +79,9 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
         header = self.xml_tree.find("FileHeader")
         self.name = header.attrib.get('description', 'Unknown')
 
+        if self.name.startswith("CARLA:"):
+            OpenScenarioParser.set_use_carla_coordinate_system()
+
     def _set_carla_town(self):
         """
         Extract the CARLA town (level) from the RoadNetwork information from OpenSCENARIO

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -32,6 +32,17 @@ class OpenScenarioParser(object):
         "equal_to": operator.eq
     }
 
+    use_carla_coordinate_system = False
+
+    @staticmethod
+    def set_use_carla_coordinate_system():
+        """
+        CARLA internally uses a left-hand coordinate system (Unreal), but OpenSCENARIO and OpenDRIVE
+        are intended for right-hand coordinate system. Hence, we need to invert the coordinates, if
+        the scenario does not use CARLA coordinates, but instead right-hand coordinates.
+        """
+        OpenScenarioParser.use_carla_coordinate_system = True
+
     @staticmethod
     def convert_position_to_transform(position):
         """
@@ -51,6 +62,9 @@ class OpenScenarioParser(object):
             yaw = math.degrees(float(world_pos.attrib.get('h', 0)))
             pitch = math.degrees(float(world_pos.attrib.get('p', 0)))
             roll = math.degrees(float(world_pos.attrib.get('r', 0)))
+            if not OpenScenarioParser.use_carla_coordinate_system:
+                y = y * (-1.0)
+                yaw = yaw * (-1.0)
             return carla.Transform(carla.Location(x=x, y=y, z=z), carla.Rotation(yaw=yaw, pitch=pitch, roll=roll))
         elif (position.find('RelativeWorld') is not None) or (position.find('RelativeObject') is not None):
             rel_pos = position.find('RelativeWorld') or position.find('RelativeObject')
@@ -76,6 +90,10 @@ class OpenScenarioParser(object):
                 dyaw = math.degrees(float(orientation.attrib.get('h', 0)))
                 dpitch = math.degrees(float(orientation.attrib.get('p', 0)))
                 droll = math.degrees(float(orientation.attrib.get('r', 0)))
+
+            if not OpenScenarioParser.use_carla_coordinate_system:
+                dy = dy * (-1.0)
+                dyaw = dyaw * (-1.0)
 
             x = obj_actor.get_location().x + dx
             y = obj_actor.get_location().y + dy


### PR DESCRIPTION
OpenSCENARIO definition is for right-hand coordinate systems. CARLA however uses a left-hand system. Hence, a conversion is necessary. The default behavior will be to map from right-hand to left-hand. To avoid this mapping, the scenario name has to start with "CARLA:"

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated


#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.5
  * **CARLA version:** 0.9.6

#### Possible Drawbacks
If the OpenSCENARIO was designed for CARLA, and the name is not adjusted to start with "CARLA:" to positions will be wrong after this commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/396)
<!-- Reviewable:end -->
