### PR TITLE
Updated LaneChange distance for OpenSCENARIO

### DIFF
--- a/srunner/examples/LaneChangeSimple.xosc
+++ b/srunner/examples/LaneChangeSimple.xosc
@@ -169,7 +169,7 @@
                                 <Private>
                                     <Lateral>
                                         <LaneChange>
-                                            <Dynamics distance="10" shape="linear" />
+                                            <Dynamics distance="25" shape="linear" />
                                             <Target>
                                                 <Relative object="adversary" value="-1" />
                                             </Target>

--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -863,6 +863,7 @@ class LaneChange(WaypointFollower):
     - direction: 'right' or 'left', depending on which lane to change
     - distance_same_lane: straight distance before lane change, in m
     - distance_other_lane: straight distance after lane change, in m
+    - distance_lane_change: straight distance for the lane change itself, in m
 
     The total distance driven is greater than the sum of distance_same_lane and distance_other_lane.
     It results from the lane change distance plus the distance_same_lane plus distance_other_lane.
@@ -874,12 +875,13 @@ class LaneChange(WaypointFollower):
     """
 
     def __init__(self, actor, speed=10, direction='left',
-                 distance_same_lane=5, distance_other_lane=100, name='LaneChange'):
+                 distance_same_lane=5, distance_other_lane=100, distance_lane_change=25, name='LaneChange'):
 
         self._actor = actor
         self._direction = direction
         self._distance_same_lane = distance_same_lane
         self._distance_other_lane = distance_other_lane
+        self._distance_lane_change = distance_lane_change
 
         self._target_lane_id = None
         self._distance_new_lane = 0
@@ -895,7 +897,7 @@ class LaneChange(WaypointFollower):
         # calculate plan with scenario_helper function
         self._plan, self._target_lane_id = generate_target_waypoint_list_multilane(
             position_actor, self._direction, self._distance_same_lane,
-            self._distance_other_lane, check='true')
+            self._distance_other_lane, self._distance_lane_change, check='true')
         super(LaneChange, self).initialise()
 
     def update(self):

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -355,9 +355,9 @@ class OpenScenarioParser(object):
                     target_lane_rel = float(lat_maneuver.find("Target").find("Relative").attrib.get('value', 0))
                     distance = float(lat_maneuver.find("Dynamics").attrib.get('distance', float("inf")))
                     atomic = LaneChange(actor,
-                                        5.0,
+                                        None,
                                         direction="left" if target_lane_rel < 0 else "right",
-                                        distance_same_lane=distance,
+                                        distance_lane_change=distance,
                                         name=maneuver_name)
                 else:
                     raise AttributeError("Unknown lateral action")

--- a/srunner/tools/scenario_helper.py
+++ b/srunner/tools/scenario_helper.py
@@ -257,7 +257,9 @@ def generate_target_waypoint_list(waypoint, turn=0):
 
 
 def generate_target_waypoint_list_multilane(waypoint, change='left',
-                                            distance_same_lane=10, distance_other_lane=25, check='true'):
+                                            distance_same_lane=10,
+                                            distance_other_lane=25,
+                                            total_lane_change_distance=25, check='true'):
     """
     This methods generates a waypoint list which leads the vehicle to a parallel lane.
     The change input must be 'left' or 'right', depending on which lane you want to change.
@@ -291,13 +293,13 @@ def generate_target_waypoint_list_multilane(waypoint, change='left',
         # go left
         wp_left = plan[-1][0].get_left_lane()
         target_lane_id = wp_left.lane_id
-        next_wp = wp_left.next(25)
+        next_wp = wp_left.next(total_lane_change_distance)
         plan.append((next_wp[0], RoadOption.LANEFOLLOW))
     elif change == 'right':
         # go right
         wp_right = plan[-1][0].get_right_lane()
         target_lane_id = wp_right.lane_id
-        next_wp = wp_right.next(25)
+        next_wp = wp_right.next(total_lane_change_distance)
         plan.append((next_wp[0], RoadOption.LANEFOLLOW))
     else:
         # ERROR, input value for change must be 'left' or 'right'


### PR DESCRIPTION
The distance parameter for the LaneChange action corresponds to the total length of the lane change (from lane a to lane b). This was updated in this PR.

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary (--> not required here)
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated (--> not required here)

#### Where has this been tested?
  * **Platform(s):**  Ubuntu 16.04
  * **Python version(s):** 2.7 and 3.5
  * **CARLA version:** 0.9.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/402)
<!-- Reviewable:end -->
