### PR TITLE
Added sequence identifier for OpenSCENARIO

### DIFF
--- a/srunner/scenarios/open_scenario.py
+++ b/srunner/scenarios/open_scenario.py
@@ -331,7 +331,7 @@ class OpenScenario(BasicScenario):
                 policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL, name="Maneuvers")
 
             for sequence in act.iter("Sequence"):
-                sequence_behavior = py_trees.composites.Sequence()
+                sequence_behavior = py_trees.composites.Sequence(name="Seq:" + sequence.attrib.get('name'))
                 repetitions = sequence.attrib.get('numberOfExecutions', 1)
                 actor_ids = []
                 for actor in sequence.iter("Actors"):


### PR DESCRIPTION
To avoid that different sequences in OpenSCENARIO share the same
blackboard entry (to achieve a one-shot behavior), sequences are now
identified via their name plus a leading "Seq:" on the blackboard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/407)
<!-- Reviewable:end -->
