### PR TITLE
Fixed issue due to pre-loading the map in OpenScenarioConfiguration

### DIFF
--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -99,10 +99,12 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
             self.town = tail[:-5]
 
         # workaround for relative positions during init
-        self.client.load_world(self.town)
         world = self.client.get_world()
-        CarlaDataProvider.set_world(world)
-        world.wait_for_tick()
+        if world is None or world.get_map().name != self.town:
+            self.client.load_world(self.town)
+            world = self.client.get_world()
+            CarlaDataProvider.set_world(world)
+            world.wait_for_tick()
 
     def _set_carla_weather(self):
         """


### PR DESCRIPTION
To support relative positioning of actors allowed by OpenSCENARIO, the
CARLA world is (pre)-loaded inside the OpenScenarioConfiguration()
constructor. However, if there are other clients already connected to
CARLA, this can cause issues. Therefore, the map is now only loaded, if
it is different from the current CARLA map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/410)
<!-- Reviewable:end -->
