### PR TITLE
Fixed wrong actor rolename access in OSC init_behavior

### DIFF
--- a/srunner/scenarios/open_scenario.py
+++ b/srunner/scenarios/open_scenario.py
@@ -317,12 +317,12 @@ class OpenScenario(BasicScenario):
                 rolename = actor.rolename
                 init_speed = actor.speed
 
-        for actor in self.other_actors:
-            if 'role_name' in actor.attributes and actor.attributes['role_name'] == rolename:
-                init_behavior = py_trees.composites.Parallel(
-                    policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL, name="InitBehaviour")
-                set_init_speed = SetOSCInitSpeed(actor, init_speed)
-                init_behavior.add_child(set_init_speed)
+                for carla_actor in self.other_actors:
+                    if 'role_name' in carla_actor.attributes and carla_actor.attributes['role_name'] == rolename:
+                        init_behavior = py_trees.composites.Parallel(
+                            policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL, name="InitBehaviour")
+                        set_init_speed = SetOSCInitSpeed(actor, init_speed)
+                        init_behavior.add_child(set_init_speed)
 
         return init_behavior
 


### PR DESCRIPTION
The access to the CARLA actor attributes (here: rolename) has only
to happen, if there is an initial speed provided for this actor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/416)
<!-- Reviewable:end -->
