### PR TITLE
Fixed oneshot behavior in route scenarios (#422)

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -20,7 +20,7 @@
     - Challenge can be executed with the ScenarioRunner
 * Extended OpenScenario support:
     - Added init speed behavior for vehicles
-	- Added support for relative velocities
+    - Added support for relative velocities
     - Extentended convert_position_to_transform with RelativeWorld, RelativeObject and RelativeLane osc_positions
     - Added new trigger atomics InTriggerDistanceToOSCPosition and InTimeToArrivalToOSCPosition to support relative osc_positions
     - Added new atomic behaviour ActorTransformSetterToOSCPosition

--- a/srunner/scenarios/route_scenario.py
+++ b/srunner/scenarios/route_scenario.py
@@ -533,11 +533,13 @@ class RouteScenario(BasicScenario):
         subbehavior = py_trees.composites.Parallel(name="Behavior",
                                                    policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL)
 
-        for scenario in self.list_scenarios:
+        for i in range(len(self.list_scenarios)):
+            scenario = self.list_scenarios[i]
             if scenario.scenario.behavior is not None and scenario.scenario.behavior.name != "MasterScenario":
+                name = "{} - {}".format(i, scenario.scenario.behavior.name)
                 oneshot_idiom = oneshot_behavior(
-                    name=scenario.scenario.behavior.name,
-                    variable_name=scenario.scenario.behavior.name,
+                    name=name,
+                    variable_name=name,
                     behaviour=scenario.scenario.behavior)
 
                 subbehavior.add_child(oneshot_idiom)


### PR DESCRIPTION
Having multiple scenarios with the same name along a route caused the
issue that all scenarios with the same name were terminated, once the
first of these scenarios finished (Issue #422)

To fix this issue, unique oneshot-ids are now used.

Fixes #422

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/423)
<!-- Reviewable:end -->
