### PR TITLE
Glopez/frame error fix

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -47,6 +47,7 @@
     - Added support for MiscObjects (besides vehicles and pedestrians)
     - Reworked traffic signal handling: The name has to start now either with "id=" or "pos=" depending on whether the position or id is used as unique identifier
 ### :bug: Bug Fixes
+* Fixed bug causing occasional frame_errors
 * Fixed #426: Avoid underground vehicles fall forever by disabling physics when spawning underground.
 * Fixed #427: Removed unnecessary warnings when using get_next_traffic_light() with non-cached locations
 * Fixed missing ego_vehicle: compare actor IDs instead of object in CarlaDataProvider in get_velocity, get_transform and get_location

--- a/srunner/scenariomanager/scenario_manager.py
+++ b/srunner/scenariomanager/scenario_manager.py
@@ -182,7 +182,6 @@ class ScenarioManager(object):
         Load a new scenario
         """
         self._reset()
-        self._callback_id = CarlaDataProvider.get_world().on_tick(self._tick_scenario)
         self._agent = AgentWrapper(agent, self._challenge_mode) if agent else None
         self.scenario_class = scenario
         self.scenario = scenario.scenario
@@ -212,7 +211,7 @@ class ScenarioManager(object):
         self._running = True
 
         while self._running:
-            time.sleep(0.5)
+            self._tick_scenario(CarlaDataProvider.get_world().get_snapshot().timestamp)
 
         self.end_system_time = time.time()
         end_game_time = GameTime.get_time()
@@ -237,7 +236,7 @@ class ScenarioManager(object):
         """
 
         with self._my_lock:
-            if self._running and self._timestamp_last_run < timestamp.elapsed_seconds:
+            if self._timestamp_last_run < timestamp.elapsed_seconds:
                 self._timestamp_last_run = timestamp.elapsed_seconds
 
                 if self._debug_mode:

--- a/srunner/scenariomanager/scenario_manager.py
+++ b/srunner/scenariomanager/scenario_manager.py
@@ -151,14 +151,12 @@ class ScenarioManager(object):
 
         # Register the scenario tick as callback for the CARLA world
         # Use the callback_id inside the signal handler to allow external interrupts
-        self._callback_id = None
         signal.signal(signal.SIGINT, self._signal_handler)
 
     def _signal_handler(self, signum, frame):
         """
         Terminate scenario ticking when receiving a signal interrupt
         """
-        CarlaDataProvider.get_world().remove_on_tick(self._callback_id)
         with self._my_lock:
             self._running = False
 
@@ -172,9 +170,6 @@ class ScenarioManager(object):
         self.scenario_duration_game = 0.0
         self.start_system_time = None
         self.end_system_time = None
-        if self._callback_id:
-            CarlaDataProvider.get_world().remove_on_tick(self._callback_id)
-            self._callback_id = None
         GameTime.restart()
 
     def load_scenario(self, scenario, agent=None):
@@ -274,11 +269,6 @@ class ScenarioManager(object):
         """
         This function triggers a proper termination of a scenario
         """
-        with self._my_lock:
-            if self._callback_id:
-                CarlaDataProvider.get_world().remove_on_tick(self._callback_id)
-                self._callback_id = None
-
         if self.scenario is not None:
             self.scenario.terminate()
 


### PR DESCRIPTION
#### Description

Fixed a bug causing occasional frame errors due to runtime_errors, by changing how scenarios tick.

Exact error: frame == _episode->GetState()->GetTimestamp().frame);

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.22
  * **CARLA version:** 0.9.7

#### Possible Drawbacks

None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/434)
<!-- Reviewable:end -->
