### PR TITLE
Fixed spawning of debris for ControlLoss scenario (Scenario01)

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -61,6 +61,7 @@
 * Fixed randomness of route-based scenarios
 * Fixed usage of radians instead of degrees for OpenSCENARIO
 * Fixed ActorTransformSetter behavior to avoid vehicles not reaching the desired transform
+* Fixed spawning of debris for ControlLoss scenario (Scenario01)
 ### :ghost: Maintenance
 * Split of behaviors into behaviors and conditions
 * Moved atomics into new submodule scenarioatomics

--- a/srunner/scenarios/control_loss.py
+++ b/srunner/scenarios/control_loss.py
@@ -102,6 +102,10 @@ class ControlLoss(BasicScenario):
         second_debris = CarlaActorPool.request_new_actor('static.prop.dirtdebris01', self.sec_transform)
         third_debris = CarlaActorPool.request_new_actor('static.prop.dirtdebris01', self.third_transform)
 
+        first_debris.set_transform(self.first_transform)
+        second_debris.set_transform(self.sec_transform)
+        third_debris.set_transform(self.third_transform)
+
         self.obj.extend([first_debris, second_debris, third_debris])
         for debris in self.obj:
             debris.set_simulate_physics(False)


### PR DESCRIPTION
Transform of debris is set to default position right after actor
creation to avoid getting stuck behind a "flying" debris


#### Where has this been tested?

  * **Platform(s):**  Ubuntu
  * **Python version(s):** 2.7 / 3.5
  * **CARLA version:** 0.9.7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/441)
<!-- Reviewable:end -->
