### PR TITLE
Fixed repetitions in OpenSCENARIO (Fixes #443)

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -48,6 +48,7 @@
     - Added support for MiscObjects (besides vehicles and pedestrians)
     - Reworked traffic signal handling: The name has to start now either with "id=" or "pos=" depending on whether the position or id is used as unique identifier
 ### :bug: Bug Fixes
+* Fixed #443: Repetitions in OpenSCENARIO were not properly working
 * Fixed bug causing RunningStopTest atomic criteria to trigger when lane changing near a STOP signal
 * Fixed bug causing RunningRedLightTest atomic criteria to occasionally not trigger
 * Fixed bug causing occasional frame_errors

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -66,6 +66,7 @@
 * Fixed usage of radians instead of degrees for OpenSCENARIO
 * Fixed ActorTransformSetter behavior to avoid vehicles not reaching the desired transform
 * Fixed spawning of debris for ControlLoss scenario (Scenario01)
+* Fixed CTRL+C termination of ScenarioRunner
 ### :ghost: Maintenance
 * Split of behaviors into behaviors and conditions
 * Moved atomics into new submodule scenarioatomics

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -192,7 +192,7 @@ class ScenarioRunner(object):
                                                                     vehicle.rolename,
                                                                     True,
                                                                     color=vehicle.color,
-                                                                    vehicle_category=vehicle.category))
+                                                                    actor_category=vehicle.category))
         else:
             ego_vehicle_missing = True
             while ego_vehicle_missing:

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -196,7 +196,7 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
                 for pedestrian in obj.iter("Pedestrian"):
                     model = pedestrian.attrib.get('model', "walker.*")
 
-                    new_actor = ActorConfigurationData(model, carla.Transform(), rolename)
+                    new_actor = ActorConfigurationData(model, carla.Transform(), rolename, category="pedestrian")
                     new_actor.transform = self._get_actor_transform(rolename)
 
                     self.other_actors.append(new_actor)
@@ -269,12 +269,11 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
                         for target in speed.iter('Target'):
                             for absolute in target.iter('Absolute'):
                                 speed = float(absolute.attrib.get('value', 0))
-                                if speed > 0:
+                                if speed >= 0:
                                     actor_speed = speed
                                 else:
-                                    raise(
-                                        """Warning: Speed value of actor {} must be positive.
-                                        Speed set to 0.""" .format(actor_name))
+                                    raise AttributeError(
+                                        "Warning: Speed value of actor {} must be positive. Speed set to 0.".format(actor_name))  # pylint: disable=line-too-long
         return actor_speed
 
     def _validate_result(self):

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -408,13 +408,13 @@ class CarlaActorPool(object):
 
     @staticmethod
     def setup_actor(model, spawn_point, rolename='scenario', hero=False, autopilot=False,
-                    random_location=False, color=None, vehicle_category="car"):
+                    random_location=False, color=None, actor_category="car"):
         """
         Function to setup the most relevant actor parameters,
         incl. spawn point and vehicle model.
         """
 
-        _vehicle_blueprint_categories = {
+        _actor_blueprint_categories = {
             'car': 'vehicle.tesla.model3',
             'van': 'vehicle.volkswagen.t2',
             'truck': 'vehicle.carlamotors.carlacola',
@@ -425,6 +425,7 @@ class CarlaActorPool(object):
             'bicycle': 'vehicle.diamondback.century',
             'train': '',
             'tram': '',
+            'pedestrian': 'walker.pedestrian.0001',
         }
 
         blueprint_library = CarlaActorPool._world.get_blueprint_library()
@@ -435,7 +436,7 @@ class CarlaActorPool(object):
         except IndexError:
             # The model is not part of the blueprint library. Let's take a default one for the given category
             bp_filter = "vehicle.*"
-            new_model = _vehicle_blueprint_categories[vehicle_category]
+            new_model = _actor_blueprint_categories[actor_category]
             if new_model != '':
                 bp_filter = new_model
             print("WARNING: Actor model {} not available. Using instead {}".format(model, new_model))
@@ -585,13 +586,13 @@ class CarlaActorPool(object):
 
     @staticmethod
     def request_new_actor(model, spawn_point, rolename='scenario', hero=False, autopilot=False,
-                          random_location=False, color=None, vehicle_category=None):
+                          random_location=False, color=None, actor_category=None):
         """
         This method tries to create a new actor. If this was
         successful, the new actor is returned, None otherwise.
         """
         actor = CarlaActorPool.setup_actor(
-            model, spawn_point, rolename, hero, autopilot, random_location, color, vehicle_category)
+            model, spawn_point, rolename, hero, autopilot, random_location, color, actor_category)
 
         if actor is None:
             return None

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -28,7 +28,6 @@ from srunner.scenariomanager.carla_data_provider import CarlaDataProvider
 from srunner.scenariomanager.timer import GameTime
 from srunner.tools.scenario_helper import get_distance_along_route
 
-# OpenScenarioParser.convert_position_to_transform
 import srunner.tools
 
 EPSILON = 0.001
@@ -164,8 +163,11 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
         new_status = py_trees.common.Status.RUNNING
 
         # calculate transform with method in openscenario_parser.py
-        osc_transform = srunner.tools.openscenario_parser.OpenScenarioParser.convert_position_to_transform(
-            self._osc_position)
+        try:
+            osc_transform = srunner.tools.openscenario_parser.OpenScenarioParser.convert_position_to_transform(
+                self._osc_position)
+        except AttributeError:
+            return py_trees.common.Status.FAILURE
         target_location = osc_transform.location
         actor_location = CarlaDataProvider.get_location(self._actor)
 

--- a/srunner/scenarios/basic_scenario.py
+++ b/srunner/scenarios/basic_scenario.py
@@ -86,7 +86,7 @@ class BasicScenario(object):
                                                          autopilot=actor.autopilot,
                                                          random_location=actor.random_location,
                                                          color=actor.color,
-                                                         vehicle_category=actor.category)
+                                                         actor_category=actor.category)
             if new_actor is None:
                 raise Exception("Error: Unable to add actor {} at {}".format(actor.model, actor.transform))
 

--- a/srunner/scenarios/open_scenario.py
+++ b/srunner/scenarios/open_scenario.py
@@ -194,7 +194,7 @@ class OpenScenario(BasicScenario):
                     if 'role_name' in carla_actor.attributes and carla_actor.attributes['role_name'] == rolename:
                         init_behavior = py_trees.composites.Parallel(
                             policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL, name="InitBehaviour")
-                        set_init_speed = SetOSCInitSpeed(actor, init_speed)
+                        set_init_speed = SetOSCInitSpeed(carla_actor, init_speed)
                         init_behavior.add_child(set_init_speed)
 
         return init_behavior

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -259,7 +259,7 @@ class OpenScenarioParser(object):
                     condition_value = ttc_condition.attrib.get('value')
                     condition_target = ttc_condition.find('Target')
 
-                    if condition_target.find('Position'):
+                    if condition_target.find('Position') is not None:
                         position = condition_target.find('Position')
                         atomic = InTimeToArrivalToOSCPosition(
                             trigger_actor, position, condition_value, condition_operator)


### PR DESCRIPTION
Repetitions in OpenSCENARIO were not properly working. Reworked the repetition
handling by three major changes:
- Not copy py_tree elements, this will cause problems due to references in Python
- Replaced get_py_tree_path with get_xml_path, as the first was not working properly
- Avoid using ":" in py_tree behavior names, as this may break py_trees

Fixes #443

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/447)
<!-- Reviewable:end -->
