### PR TITLE
Added watchdog to ScenarioManager to handle timeouts and CARLA crashes

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -7,12 +7,18 @@
 * [CARLA ScenarioRunner 0.9.2](#carla-scenariorunner-092)
 
 ## Latest Changes
+### :rocket: New Features
+* Added "--timeout" command line parameter to set a user-defined timeout value
+* OpenSCENARIO support:
+    - Add initial support for Catalogs (Vehicle, Pedestrian, Environment, Maneuver, and and MiscObject types only)
 ### :bug: Bug Fixes
 * Fixed #471: Handling of weather parameter (cloudyness -> cloudiness adaption)
 * Fixed #472: Spawning issue of pedestrians in OpenSCENARIO
 * Fixed #374: Usage of evaluation critieria with multiple ego vehicles in OpenSCENARIO
-* Fixed #459: Add initial support for Catalogs (Vehicle, Pedestrian, Environment, Maneuver, and and MiscObject types only)
 * Fixed wrong StandStill behavior which return SUCCESS immediatly on a standing actor
+### :ghost: Maintenance
+* Added watchdog to ScenarioManager to handle timeouts and CARLA crashes
+* Added timeout for CARLA tick() calls to avoid blocking CARLA server calls
 
 
 ## CARLA ScenarioRunner 0.9.7

--- a/srunner/challenge/autoagents/agent_wrapper.py
+++ b/srunner/challenge/autoagents/agent_wrapper.py
@@ -117,7 +117,7 @@ class AgentWrapper(object):
         while not self._agent.all_sensors_ready():
             if debug_mode:
                 print(" waiting for one data reading from sensors...")
-            CarlaDataProvider.get_world().tick()
+            CarlaDataProvider.perform_carla_tick()
 
     def _validate_sensor_configuration(self):
         """

--- a/srunner/scenariomanager/watchdog.py
+++ b/srunner/scenariomanager/watchdog.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020 Intel Corporation
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+"""
+This module provides a simple watchdog timer to detect timeouts
+It is for example used in the ScenarioManager
+"""
+from __future__ import print_function
+
+from threading import Timer
+try:
+    import thread
+except ImportError:
+    import _thread as thread
+
+
+class Watchdog(object):
+
+    """
+    Simple watchdog timer to detect timeouts
+
+    Args:
+        timeout (float): Timeout value of the watchdog [seconds].
+            If it is not reset before exceeding this value, a KayboardInterrupt is raised.
+
+    Attributes:
+        _timeout (float): Timeout value of the watchdog [seconds].
+        _failed (bool):   True if watchdog exception occured, false otherwise
+    """
+
+    def __init__(self, timeout=1.0):
+        """
+        Class constructor
+        """
+        self._timeout = timeout + 1.0  # Let's add one second here to avoid overlap with other CARLA timeouts
+        self._failed = False
+        self._timer = None
+
+    def start(self):
+        """
+        Start the watchdog
+        """
+        self._timer = Timer(self._timeout, self._event)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def update(self):
+        """
+        Reset watchdog.
+        """
+        self.stop()
+        self.start()
+
+    def _event(self):
+        """
+        This method is called when the timer triggers. A KayboardInterrupt
+        is generated on the main thread and the watchdog is stopped.
+        """
+        print('Watchdog exception - Timeout of {} seconds occured'.format(self._timeout))
+        self._failed = True
+        self.stop()
+        thread.interrupt_main()
+
+    def stop(self):
+        """
+        Stops the watchdog.
+        """
+        self._timer.cancel()
+
+    def get_status(self):
+        """
+        returns:
+           bool:  False if watchdog exception occured, True otherwise
+        """
+        return not self._failed

--- a/srunner/scenarios/basic_scenario.py
+++ b/srunner/scenarios/basic_scenario.py
@@ -47,7 +47,7 @@ class BasicScenario(object):
         # Initializing adversarial actors
         self._initialize_actors(config)
         if world.get_settings().synchronous_mode:
-            world.tick()
+            CarlaDataProvider.perform_carla_tick()
         else:
             world.wait_for_tick()
 

--- a/srunner/scenarios/route_scenario.py
+++ b/srunner/scenarios/route_scenario.py
@@ -445,7 +445,7 @@ class RouteScenario(BasicScenario):
                 if scenario_number % scenarios_per_tick == 0:
                     sync_mode = world.get_settings().synchronous_mode
                     if sync_mode:
-                        world.tick()
+                        CarlaDataProvider.perform_carla_tick()
                     else:
                         world.wait_for_tick()
 


### PR DESCRIPTION
A watchdog is added to the ScenarioManager to detect and handle internal
timeouts as well as CARLA/Unreal crashes. Upon these a KeyboardInterrupt
is raised to trigger a clean shutdown of ScenarioRunner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/475)
<!-- Reviewable:end -->
