### PR TITLE
Extended OpenSCENARIO position handling with roadID and laneID

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -7,6 +7,9 @@
 * [CARLA ScenarioRunner 0.9.2](#carla-scenariorunner-092)
 
 ## Latest Changes
+### :rocket: New Features
+* OpenSCENARIO support:
+    - Added support for position with Lane information  (roadId and laneId)
 
 ## CARLA ScenarioRunner 0.9.8
 ### :rocket: New Features
@@ -14,7 +17,7 @@
 * Scenario updates:
     - Changed traffic light behavior of scenarios 7, 8 and 9. The new sequence is meant to greatly improve the chances of the ego vehicle having to interact at junctions.
 * OpenSCENARIO support:
-    - Add initial support for Catalogs (Vehicle, Pedestrian, Environment, Maneuver, and and MiscObject types only)
+    - Added initial support for Catalogs (Vehicle, Pedestrian, Environment, Maneuver, and and MiscObject types only)
 ### :bug: Bug Fixes
 * Fixed #471: Handling of weather parameter (cloudyness -> cloudiness adaption)
 * Fixed #472: Spawning issue of pedestrians in OpenSCENARIO

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ branch contains the latest fixes and features, and may be required to use the la
 
 It is important to also consider the release version that has to match the CARLA version.
 
+* [Version 0.9.8](https://github.com/carla-simulator/scenario_runner/releases/tag/v0.9.8) and the 0.9.8 Branch: Compatible with [CARLA 0.9.8](https://github.com/carla-simulator/carla/releases/tag/0.9.8)
 * [Version 0.9.7](https://github.com/carla-simulator/scenario_runner/releases/tag/v0.9.7) and the 0.9.7 Branch: Compatible with [CARLA 0.9.7](https://github.com/carla-simulator/carla/releases/tag/0.9.7) but not with the later release patch versions. For these please use the current master of ScenarioRunner.
 * [Version 0.9.6](https://github.com/carla-simulator/scenario_runner/releases/tag/v0.9.6) and the 0.9.6 Branch: Compatible with [CARLA 0.9.6](https://github.com/carla-simulator/carla/releases/tag/0.9.6)
 * [Version 0.9.5](https://github.com/carla-simulator/scenario_runner/releases/tag/v0.9.5) and [Version 0.9.5.1](https://github.com/carla-simulator/scenario_runner/releases/tag/v0.9.5.1): Compatible with [CARLA 0.9.5](https://github.com/carla-simulator/carla/releases/tag/0.9.5)

--- a/srunner/examples/FollowLeadingVehicle.xosc
+++ b/srunner/examples/FollowLeadingVehicle.xosc
@@ -97,7 +97,7 @@
                 <Private object="hero">
                     <Action>
                         <Position>
-                            <World x="150" y="133" z="0" h="0" />
+                            <Lane roadId="4" laneId="-1" offset="1.0" s="48.58" />
                         </Position>
                     </Action>
                 </Private>

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -153,6 +153,8 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
             world = self.client.get_world()
             CarlaDataProvider.set_world(world)
             world.wait_for_tick()
+        else:
+            CarlaDataProvider.set_world(world)
 
     def _set_carla_weather(self):
         """


### PR DESCRIPTION
Positions can now be set with the help of OpenDRIVE roadID and laneID,
offset and s.

Requires CARLA 0.9.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/483)
<!-- Reviewable:end -->
