### PR TITLE
OpenSCENARIO Support for TimeOfDay

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### :rocket: New Features
 * OpenSCENARIO support:
     - Added support for position with Lane information  (roadId and laneId)
+    - Added support for TimeOfDay tag
 
 ## CARLA ScenarioRunner 0.9.8
 ### :rocket: New Features

--- a/Docs/openscenario_support.md
+++ b/Docs/openscenario_support.md
@@ -123,7 +123,7 @@ Please take a look into the provided example scenarios, for further details on t
        * [ ] AquirePosition
     * [x] Command (Support for command 'Idle')
     * [x] Script (The script file has to be fully qualified and contain the interpreter as well as arguments: Example: python /path/to/script.py --arg1)
-    * [ ] SetEnvironment (Weather is supported)
+    * [x] SetEnvironment
     * [ ] Entity
     * [ ] Parameter
     * [ ] Traffic

--- a/srunner/examples/CatalogExample.xosc
+++ b/srunner/examples/CatalogExample.xosc
@@ -57,7 +57,7 @@
             <Actions>
                 <Global>
                     <SetEnvironment>
-                        <CatalogReference catalogName="EnvironmentCatalog" entryName="ClearNoon" />
+                        <CatalogReference catalogName="EnvironmentCatalog" entryName="ClearMidnight" />
                     </SetEnvironment>
                 </Global>
                 <Private object="hero">

--- a/srunner/examples/catalogs/EnvironmentCatalog.xosc
+++ b/srunner/examples/catalogs/EnvironmentCatalog.xosc
@@ -15,6 +15,18 @@
             </Weather>
             <RoadCondition frictionScale="1.0" />
         </Environment>
+        <Environment name="ClearMidnight">
+            <TimeOfDay animation="false">
+                <Time hour="0" min="0" sec="0.0" />
+                <Date day="0" month="0" year="2020" />
+            </TimeOfDay>
+            <Weather cloudState="free">
+                <Sun intensity="1.0" azimuth="0.0" elevation="1.5" />
+                <Fog visualRange="10000.0" />
+                <Precipitation type="dry" intensity="0.0" />
+            </Weather>
+            <RoadCondition frictionScale="1.0" />
+        </Environment>
     </Catalog>
 </OpenSCENARIO>
 

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -192,11 +192,11 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
             raise AttributeError("CARLA does not support snow precipitation")
 
         time_of_day = environment.find("TimeOfDay")
-        time = time_of_day.find("Time") # 22-4: night; 4-6: sunrise; 6-20: day; 20-22: sunset
+        time = time_of_day.find("Time")  # 22-4: night; 4-6: sunrise; 6-20: day; 20-22: sunset
         if int(time.attrib.get('hour')) >= 22 or int(time.attrib.get('hour')) <= 4:
             self.weather.sun_altitude = -90
         elif int(time.attrib.get('hour')) >= 20 and int(time.attrib.get('hour')) < 22 or \
-             int(time.attrib.get('hour')) <= 6 and int(time.attrib.get('hour')) > 4:
+                int(time.attrib.get('hour')) <= 6 and int(time.attrib.get('hour')) > 4:
             self.weather.sun_altitude = 10
 
     def _set_carla_friction(self):

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -191,6 +191,14 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
         elif precepitation.attrib.get('type') == "snow":
             raise AttributeError("CARLA does not support snow precipitation")
 
+        time_of_day = environment.find("TimeOfDay")
+        time = time_of_day.find("Time") # 22-4: night; 4-6: sunrise; 6-20: day; 20-22: sunset
+        if int(time.attrib.get('hour')) >= 22 or int(time.attrib.get('hour')) <= 4:
+            self.weather.sun_altitude = -90
+        elif int(time.attrib.get('hour')) >= 20 and int(time.attrib.get('hour')) < 22 or \
+             int(time.attrib.get('hour')) <= 6 and int(time.attrib.get('hour')) > 4:
+            self.weather.sun_altitude = 10
+
     def _set_carla_friction(self):
         """
         Extract road friction information from OpenSCENARIO config


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

This takes advantage of the new nighttime setting in CARLA 0.9.8. If the TimeOfDay tag is set between 22:00 and 4:00, it will be nighttime. 4-6 and 20-22 are sunset, and everything in between is normal daytime.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6.9
  * **Unreal Engine version(s):** 4.22
  * **CARLA version:** 0.9.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/485)
<!-- Reviewable:end -->
