### PR TITLE
Fixed simulation end freeze bug

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Fixed bug causing the GPS coordinates given to the agents to be wrongly calculated
 * Fixed bug when setting up actors in batch causing to ignore the spawn points given.
 * Fixed bug where CollisionTest was counting as multiple hits collisions that displaced the actor for a long distance.
+* Fixed bug causing the simulation to end after running in synchronous mode
 
 ## CARLA ScenarioRunner 0.9.8
 ### :rocket: New Features

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -154,7 +154,7 @@ class ScenarioRunner(object):
         if self.manager:
             self.manager.stop_scenario()
 
-            if self._args.agent:
+            if self._args.agent and self.manager.get_running_status():
                 settings = self.world.get_settings()
                 settings.synchronous_mode = False
                 settings.fixed_delta_seconds = None

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -187,7 +187,9 @@ class ScenarioRunner(object):
         """
         Remove and destroy all actors
         """
-        if self._args.agent and self.manager.get_running_status():
+        if self.world is not None and self.manager is not None \
+                and self._args.agent and self.manager.get_running_status():
+            # Reset to asynchronous mode
             settings = self.world.get_settings()
             settings.synchronous_mode = False
             settings.fixed_delta_seconds = None

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -187,10 +187,11 @@ class ScenarioRunner(object):
         """
         Remove and destroy all actors
         """
-        settings = self.world.get_settings()
-        settings.synchronous_mode = False
-        settings.fixed_delta_seconds = None
-        self.world.apply_settings(settings)
+        if self._args.agent and self.manager.get_running_status():
+            settings = self.world.get_settings()
+            settings.synchronous_mode = False
+            settings.fixed_delta_seconds = None
+            self.world.apply_settings(settings)
 
         self.client.stop_recorder()
         self.manager.cleanup()

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -153,13 +153,6 @@ class ScenarioRunner(object):
         self._shutdown_requested = True
         if self.manager:
             self.manager.stop_scenario()
-
-            if self._args.agent and self.manager.get_running_status():
-                settings = self.world.get_settings()
-                settings.synchronous_mode = False
-                settings.fixed_delta_seconds = None
-                self.world.apply_settings(settings)
-
             self._cleanup()
             if not self.manager.get_running_status():
                 raise RuntimeError("Timeout occured during scenario execution")
@@ -194,6 +187,10 @@ class ScenarioRunner(object):
         """
         Remove and destroy all actors
         """
+        settings = self.world.get_settings()
+        settings.synchronous_mode = False
+        settings.fixed_delta_seconds = None
+        self.world.apply_settings(settings)
 
         self.client.stop_recorder()
         self.manager.cleanup()
@@ -411,12 +408,6 @@ class ScenarioRunner(object):
 
             # Remove all actors
             scenario.remove_all_actors()
-
-            if self._args.agent:
-                settings = self.world.get_settings()
-                settings.synchronous_mode = False
-                settings.fixed_delta_seconds = None
-                self.world.apply_settings(settings)
 
             result = True
         except SensorConfigurationInvalid as e:

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -153,6 +153,13 @@ class ScenarioRunner(object):
         self._shutdown_requested = True
         if self.manager:
             self.manager.stop_scenario()
+
+            if self._args.agent:
+                settings = self.world.get_settings()
+                settings.synchronous_mode = False
+                settings.fixed_delta_seconds = None
+                self.world.apply_settings(settings)
+
             self._cleanup()
             if not self.manager.get_running_status():
                 raise RuntimeError("Timeout occured during scenario execution")
@@ -404,6 +411,13 @@ class ScenarioRunner(object):
 
             # Remove all actors
             scenario.remove_all_actors()
+
+            if self._args.agent:
+                settings = self.world.get_settings()
+                settings.synchronous_mode = False
+                settings.fixed_delta_seconds = None
+                self.world.apply_settings(settings)
+
             result = True
         except SensorConfigurationInvalid as e:
             self._cleanup()

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -730,7 +730,6 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
             actor, time, other_side_location, comparison_operator, name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
-
     def update(self):
         """
         Check if the ego vehicle can arrive at other actor within time


### PR DESCRIPTION
#### Description

**Problem:** Bug causing the simulation to freeze after running a route scenario.
**Solution:** Synchronous mode is now removed when the simulation ends (either normally or via manual interruption)

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.22
  * **CARLA version:** 0.9.8

#### Possible Drawbacks

None?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/486)
<!-- Reviewable:end -->
