### PR TITLE
Fixed bugs scenario DynamicObjectCrossing

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -11,6 +11,8 @@
 * OpenSCENARIO support:
     - Added support for position with Lane information  (roadId and laneId)
     - Added support for TimeOfDay tag
+### :bug: Bug Fixes
+* Fixed spawning bugs for scenario DynamicObjectCrossing when it was part of a route
 
 ## CARLA ScenarioRunner 0.9.8
 ### :rocket: New Features

--- a/srunner/scenarios/object_crash_vehicle.py
+++ b/srunner/scenarios/object_crash_vehicle.py
@@ -263,9 +263,6 @@ class DynamicObjectCrossing(BasicScenario):
                 _start_distance += 1.5
                 waypoint = wp_next
 
-        # There are some false-negatives for Parkings, which are considered Shoulders
-        # They can be differentiated because they are adjacent to a Sidewalk and are as wide as a normal lane
-
         while True:  # We keep trying to spawn avoiding props
 
             try:

--- a/srunner/scenarios/object_crash_vehicle.py
+++ b/srunner/scenarios/object_crash_vehicle.py
@@ -321,12 +321,14 @@ class DynamicObjectCrossing(BasicScenario):
             policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE, name="OccludedObjectCrossing")
         lane_width = self._reference_waypoint.lane_width
         lane_width = lane_width + (1.25 * lane_width * self._num_lane_changes)
+
+        dist_to_trigger = 12 + self._num_lane_changes
         # leaf nodes
         if self._ego_route is not None:
             start_condition = InTriggerDistanceToLocationAlongRoute(self.ego_vehicles[0],
                                                                     self._ego_route,
                                                                     self.transform.location,
-                                                                    15)
+                                                                    dist_to_trigger)
         else:
             start_condition = InTimeToArrivalToVehicle(self.other_actors[0],
                                                        self.ego_vehicles[0],

--- a/srunner/scenarios/object_crash_vehicle.py
+++ b/srunner/scenarios/object_crash_vehicle.py
@@ -244,7 +244,6 @@ class DynamicObjectCrossing(BasicScenario):
         """
         Custom initialization
         """
-        world = CarlaDataProvider.get_world()
         # cyclist transform
         _start_distance = 12
         # We start by getting and waypoint in the closest sidewalk.
@@ -259,11 +258,6 @@ class DynamicObjectCrossing(BasicScenario):
                 if wp_next.lane_width > 2:
                     _start_distance += 1.5
                     waypoint = wp_next
-                    world.debug.draw_point(waypoint.transform.location+carla.Location(z=3),
-                        size=0.4,
-                        color=carla.Color(0, 0, 0),
-                        life_time=10000
-                    )
                 break
             else:
                 _start_distance += 1.5

--- a/srunner/tools/scenario_helper.py
+++ b/srunner/tools/scenario_helper.py
@@ -186,7 +186,7 @@ def get_location_in_distance(actor, distance):
     return waypoint.transform.location, traveled_distance
 
 
-def get_location_in_distance_from_wp(waypoint, distance):
+def get_location_in_distance_from_wp(waypoint, distance, stop_at_junction=True):
     """
     Obtain a location in a given distance from the current actor's location.
     Note: Search is stopped on first intersection.
@@ -194,7 +194,7 @@ def get_location_in_distance_from_wp(waypoint, distance):
     @return obtained location and the traveled distance
     """
     traveled_distance = 0
-    while not waypoint.is_intersection and traveled_distance < distance:
+    while not (waypoint.is_intersection and stop_at_junction) and traveled_distance < distance:
         wp_next = waypoint.next(1.0)
         if wp_next:
             waypoint_new = wp_next[-1]


### PR DESCRIPTION
#### Description

_Problems:_

Spawning problem of the vending machines at DynamicObjectCrossing, partially spawning inside the driving lanes

_Previous Behavior:_
- From the trigger position, get the rightest lane (loop at __initialize_actors_)
- Advance a certain distance from this trigger position (_get_location_in_distance_from_wp_ at _scenario_helper_)
- Calculate spawn point of the vending machine + pedestrian, given by an offset (__calculate_base_transform_)
- Spawn both actors

_Changes:
- For consistency, now the rightest driving / parking lane is calculated, which helps simplify the offset calculus. 
- This advancement was previously stopped by junctions. This caused problems at false junction (barns at rural areas of Town07 and 09, so a flag has been added)
- Modified a constant _k_ of the offset, from 0.1 to 1, resulting in the vending machine being further from the road
- Vending machine spawn now takes into account the rotation too
- Trigger distance now scales with the number of lanes between the vehicle and the spawn point


#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.22
  * **CARLA version:** 0.9.8

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/487)
<!-- Reviewable:end -->
