### PR TITLE
Fixed bugs scenario VehicleTurning

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -12,7 +12,8 @@
     - Added support for position with Lane information  (roadId and laneId)
     - Added support for TimeOfDay tag
 ### :bug: Bug Fixes
-* Fixed spawning bugs for scenario DynamicObjectCrossing when it was part of a route
+* Fixed spawning bugs for scenario DynamicObjectCrossing when it is part of a route
+* Fixed spawning bugs for scenarios VehicleTurningRight, VehicleTurningLeft when they are part of a route
 
 ## CARLA ScenarioRunner 0.9.8
 ### :rocket: New Features

--- a/srunner/scenarios/object_crash_intersection.py
+++ b/srunner/scenarios/object_crash_intersection.py
@@ -80,6 +80,7 @@ def get_right_driving_lane(waypoint):
 
     return waypoint, lane_changes
 
+
 def is_lane_a_parking(waypoint):
     """
     This function filters false negative Shoulder which are in reality Parking lanes.

--- a/srunner/tools/scenario_helper.py
+++ b/srunner/tools/scenario_helper.py
@@ -350,8 +350,8 @@ def generate_target_waypoint_in_route(waypoint, route):
 
     # Get the route location
     shortest_distance = float('inf')
-    for index in range(len(route)):
-        wp = route[index][0]
+    for index, route_pos in enumerate(route):
+        wp = route_pos[0]
         trigger_location = waypoint.transform.location
 
         distance = math.sqrt(((trigger_location.x - wp.x) ** 2) + ((trigger_location.y - wp.y) ** 2))

--- a/srunner/tools/scenario_helper.py
+++ b/srunner/tools/scenario_helper.py
@@ -354,10 +354,10 @@ def generate_target_waypoint_in_route(waypoint, route):
         wp = route_pos[0]
         trigger_location = waypoint.transform.location
 
-        distance = math.sqrt(((trigger_location.x - wp.x) ** 2) + ((trigger_location.y - wp.y) ** 2))
-        if distance <= shortest_distance:
+        dist_to_route = trigger_location.distance(wp)
+        if dist_to_route <= shortest_distance:
             closest_index = index
-            shortest_distance = distance
+            shortest_distance = dist_to_route
 
     route_location = route[closest_index][0]
     index = closest_index

--- a/srunner/tools/scenario_helper.py
+++ b/srunner/tools/scenario_helper.py
@@ -324,33 +324,59 @@ def generate_target_waypoint(waypoint, turn=0):
     sampling_radius = 1
     reached_junction = False
     wp_list = []
-    threshold = math.radians(0.1)
     while True:
 
         wp_choice = waypoint.next(sampling_radius)
         #   Choose path at intersection
-        if len(wp_choice) > 1:
+        if not reached_junction and (len(wp_choice) > 1 or wp_choice[0].is_junction):
             reached_junction = True
             waypoint = choose_at_junction(waypoint, wp_choice, turn)
         else:
             waypoint = wp_choice[0]
         wp_list.append(waypoint)
         #   End condition for the behavior
-        if turn != 0 and reached_junction and len(wp_list) >= 3:
-            v_1 = vector(
-                wp_list[-2].transform.location,
-                wp_list[-1].transform.location)
-            v_2 = vector(
-                wp_list[-3].transform.location,
-                wp_list[-2].transform.location)
-            vec_dots = np.dot(v_1, v_2)
-            cos_wp = vec_dots / abs((np.linalg.norm(v_1) * np.linalg.norm(v_2)))
-            angle_wp = math.acos(min(1.0, cos_wp))  # COS can't be larger than 1, it can happen due to float imprecision
-            if angle_wp < threshold:
-                break
-        elif reached_junction and not wp_list[-1].is_intersection:
+        if reached_junction and not wp_list[-1].is_junction:
             break
     return wp_list[-1]
+
+
+def generate_target_waypoint_in_route(waypoint, route):
+    """
+    This method follow waypoints to a junction
+    @returns a waypoint list according to turn input
+    """
+    wmap = CarlaDataProvider.get_map()
+    reached_junction = False
+
+    # Get the route location
+    shortest_distance = float('inf')
+    for index in range(len(route)):
+        wp = route[index][0]
+        trigger_location = waypoint.transform.location
+
+        distance = math.sqrt(((trigger_location.x - wp.x) ** 2) + ((trigger_location.y - wp.y) ** 2))
+        if distance <= shortest_distance:
+            closest_index = index
+            shortest_distance = distance
+
+    route_location = route[closest_index][0]
+    index = closest_index
+
+    while True:
+        # Get the next route location
+        index = min(index + 1, len(route))
+        route_location = route[index][0]
+        road_option = route[index][1]
+
+        # Enter the junction
+        if not reached_junction and (road_option in (RoadOption.LEFT, RoadOption.RIGHT, RoadOption.STRAIGHT)):
+            reached_junction = True
+
+        # End condition for the behavior, at the end of the junction
+        if reached_junction and (road_option not in (RoadOption.LEFT, RoadOption.RIGHT, RoadOption.STRAIGHT)):
+            break
+
+    return wmap.get_waypoint(route_location)
 
 
 def choose_at_junction(current_waypoint, next_choices, direction=0):


### PR DESCRIPTION
#### Description

_Problems:_

Spawning bugs of the bicycles at VehicleTurning, when part of a route.

_Previous Behavior:_
- From the trigger position, advance until after the junction
- Get the rightest lane
- Advance a certain distance from this trigger position
- Calculate spawn point of the bycicle, given by an offset
- Spawn actors

_Changes_:
- Removed a condition that caused the junction loop to not correctly stop after a junction.
- This loop has been changes for routes. Now this loop follows the route, instead of calculating the next waypoint.
- Now the advancement is done before the rightest lane is searched as junction waypoints (and those very nearby) have no right lanes.
- For consistency, now the rightest driving / parking lane is calculated, which helps simplify the offset calculus. This loop has also been placed inside a junction to avoid repeated code.
- Removed _z_ offset, as it is already present in the spawn function and was causing problem with low bushes / fences (the spawn point was considered valid but when spawned, bicycles crashed against them).
- Trigger distance now scales with the number of lanes between the vehicle and the spawn point.
- Added HandBrake behavior to avoid bycicle from moving when standing by.
- Lots of code cleaning to make the 3 versions consistent with each other.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.22
  * **CARLA version:** 0.9.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/488)
<!-- Reviewable:end -->
