### PR TITLE
Added a new criteria: ActorSpeedAboveThreshold

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -19,6 +19,7 @@
     - ChangeAutopilot now calls a TM instance, and allows to change its parameters
     - Added WaitUntilInFront behavior and InTimeToArrivalToVehicleSideLane trigger condition, useful for cut ins
     - Added new trigger condition, AtRightestLane, which checks if the actor is at the rightmost driving lane
+    - Added new criteria, ActorSpeedAboveThresholdTest, useful to check if the ego vehicle has been standing still for long periods of time.
 * Setting up actors in batch now also randomizes their colors
 
 ### :bug: Bug Fixes

--- a/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
@@ -420,6 +420,78 @@ class CollisionTest(Criterion):
             self.list_traffic_events.append(collision_event)
 
 
+class ActorSpeedAboveThresholdTest(Criterion):
+    """
+    This test will fail if the actor has had its linear velocity lower than a specific value for
+    a specific amount of time
+    Important parameters:
+    - actor: CARLA actor to be used for this test
+    - speed_threshold: speed required
+    - below_threshold_max_time: Maximum time (in seconds) the actor can remain under the speed threshold
+    - terminate_on_failure [optional]: If True, the complete scenario will terminate upon failure of this test
+    """
+
+    def __init__(self, actor, speed_threshold, below_threshold_max_time,
+                 name="ActorSpeedAboveThresholdTest", terminate_on_failure=False):
+        """
+        Class constructor.
+        """
+        super(ActorSpeedAboveThresholdTest, self).__init__(name, actor, 0, terminate_on_failure=terminate_on_failure)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self._actor = actor
+        self._speed_threshold = speed_threshold
+        self._below_threshold_max_time = below_threshold_max_time
+        self._time_last_valid_state = None
+
+    def update(self):
+        """
+        Check if the actor speed is above the speed_threshold
+        """
+        new_status = py_trees.common.Status.RUNNING
+
+        linear_speed = CarlaDataProvider.get_velocity(self._actor)
+        if linear_speed is not None:
+            if linear_speed < self._speed_threshold and self._time_last_valid_state:
+                if (GameTime.get_time() - self._time_last_valid_state) > self._below_threshold_max_time:
+                    # Game over. The actor has been "blocked" for too long
+                    self.test_status = "FAILURE"
+
+                    # record event
+                    vehicle_location = CarlaDataProvider.get_location(self._actor)
+                    blocked_event = TrafficEvent(event_type=TrafficEventType.VEHICLE_BLOCKED)
+                    ActorSpeedAboveThresholdTest._set_event_message(blocked_event, vehicle_location)
+                    ActorSpeedAboveThresholdTest._set_event_dict(blocked_event, vehicle_location)
+                    self.list_traffic_events.append(blocked_event)
+            else:
+                self._time_last_valid_state = GameTime.get_time()
+
+        if self._terminate_on_failure and (self.test_status == "FAILURE"):
+            new_status = py_trees.common.Status.FAILURE
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+
+        return new_status
+
+    @staticmethod
+    def _set_event_message(event, location):
+        """
+        Sets the message of the event
+        """
+
+        event.set_message('Agent got blocked at (x={}, y={}, z={})'.format(round(location.x, 3),
+                                                                               round(location.y, 3),
+                                                                               round(location.z, 3)))
+    @staticmethod
+    def _set_event_dict(event, location):
+        """
+        Sets the dictionary of the event
+        """
+        event.set_dict({
+            'x': location.x,
+            'y': location.y,
+            'z': location.z,
+          })
+
+
 class KeepLaneTest(Criterion):
 
     """

--- a/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
@@ -421,6 +421,7 @@ class CollisionTest(Criterion):
 
 
 class ActorSpeedAboveThresholdTest(Criterion):
+
     """
     This test will fail if the actor has had its linear velocity lower than a specific value for
     a specific amount of time
@@ -478,8 +479,9 @@ class ActorSpeedAboveThresholdTest(Criterion):
         """
 
         event.set_message('Agent got blocked at (x={}, y={}, z={})'.format(round(location.x, 3),
-                                                                               round(location.y, 3),
-                                                                               round(location.z, 3)))
+                                                                           round(location.y, 3),
+                                                                           round(location.z, 3)))
+
     @staticmethod
     def _set_event_dict(event, location):
         """
@@ -489,7 +491,7 @@ class ActorSpeedAboveThresholdTest(Criterion):
             'x': location.x,
             'y': location.y,
             'z': location.z,
-          })
+        })
 
 
 class KeepLaneTest(Criterion):

--- a/srunner/scenarios/master_scenario.py
+++ b/srunner/scenarios/master_scenario.py
@@ -17,7 +17,8 @@ from srunner.scenariomanager.scenarioatomics.atomic_criteria import (CollisionTe
                                                                      RouteCompletionTest,
                                                                      OutsideRouteLanesTest,
                                                                      RunningRedLightTest,
-                                                                     RunningStopTest)
+                                                                     RunningStopTest,
+                                                                     ActorSpeedAboveThresholdTest)
 from srunner.scenarios.basic_scenario import BasicScenario
 
 
@@ -93,6 +94,11 @@ class MasterScenario(BasicScenario):
 
         stop_criterion = RunningStopTest(self.ego_vehicles[0])
 
+        blocked_criterion = ActorSpeedAboveThresholdTest(self.ego_vehicles[0],
+                                                         speed_threshold=0.1,
+                                                         below_threshold_max_time=90.0,
+                                                         terminate_on_failure=True)
+
         parallel_criteria = py_trees.composites.Parallel("group_criteria",
                                                          policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ONE)
 
@@ -102,6 +108,7 @@ class MasterScenario(BasicScenario):
         parallel_criteria.add_child(outsidelane_criterion)
         parallel_criteria.add_child(red_light_criterion)
         parallel_criteria.add_child(stop_criterion)
+        parallel_criteria.add_child(blocked_criterion)
 
         return parallel_criteria
 


### PR DESCRIPTION
#### Description

This PR adds a new atomic criteria to routes, ActorSpeedAboveThreshold. This criteria checks if the ego-vehicle has been standing still for more that a given amount of time (currently set to 90 seconds) and if so, stops the simulation.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.8

#### Possible Drawbacks

None?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/505)
<!-- Reviewable:end -->
