### PR TITLE
Routes now have their weather as a possible parameter

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -21,8 +21,7 @@
     - Added new trigger condition, AtRightestLane, which checks if the actor is at the rightmost driving lane
     - Added new criteria, ActorSpeedAboveThresholdTest, useful to check if the ego vehicle has been standing still for long periods of time.
 * Setting up actors in batch now also randomizes their colors
-* When running routes, the weather parameters can now be changed at will. To do so, go to the .xml file describing the route and add the weather attribute as a child of the route, along with the desired parameters values (e.g. 
-`<weather cloudiness="50"/>`) By default the weather is now a sunny midday.
+* When running routes, the weather parameters can now be changed at will. To do so, go to the .xml file describing the route and add the weather attribute as a child of the route, along with the desired parameters values (for an example, check the first route at srunner/challenge/routes_training.xml). By default the weather is now a sunny midday.
 
 ### :bug: Bug Fixes
 * Fixed spawning bugs for scenario DynamicObjectCrossing when it is part of a route

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -21,7 +21,8 @@
     - Added new trigger condition, AtRightestLane, which checks if the actor is at the rightmost driving lane
     - Added new criteria, ActorSpeedAboveThresholdTest, useful to check if the ego vehicle has been standing still for long periods of time.
 * Setting up actors in batch now also randomizes their colors
-* When running routes, the weather parameters can now be changed at will. To do so, go to the .xml file describing the route and add the weather attribute as a child of the route, along with the desired parameters values (e.g. <weather cloudiness="50"/>) By default they are all set to 0.
+* When running routes, the weather parameters can now be changed at will. To do so, go to the .xml file describing the route and add the weather attribute as a child of the route, along with the desired parameters values (e.g. 
+`<weather cloudiness="50"/>`) By default the weather is now a sunny midday.
 
 ### :bug: Bug Fixes
 * Fixed spawning bugs for scenario DynamicObjectCrossing when it is part of a route

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -21,6 +21,7 @@
     - Added new trigger condition, AtRightestLane, which checks if the actor is at the rightmost driving lane
     - Added new criteria, ActorSpeedAboveThresholdTest, useful to check if the ego vehicle has been standing still for long periods of time.
 * Setting up actors in batch now also randomizes their colors
+* When running routes, the weather parameters can now be changed at will. To do so, go to the .xml file describing the route and add the weather attribute as a child of the route, along with the desired parameters values (e.g. <weather cloudiness="50"/>) By default they are all set to 0.
 
 ### :bug: Bug Fixes
 * Fixed spawning bugs for scenario DynamicObjectCrossing when it is part of a route

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -372,18 +372,7 @@ class ScenarioRunner(object):
             return False
 
         # Set the appropriate weather conditions
-        weather = carla.WeatherParameters(
-            cloudiness=config.weather.cloudiness,
-            precipitation=config.weather.precipitation,
-            precipitation_deposits=config.weather.precipitation_deposits,
-            wind_intensity=config.weather.wind_intensity,
-            sun_azimuth_angle=config.weather.sun_azimuth_angle,
-            sun_altitude_angle=config.weather.sun_altitude_angle,
-            fog_density=config.weather.fog_density,
-            fog_distance=config.weather.fog_distance,
-            wetness=config.weather.wetness
-        )
-        self.world.set_weather(weather)
+        self.world.set_weather(config.weather)
 
         # Set the appropriate road friction
         if config.friction is not None:
@@ -514,7 +503,7 @@ class ScenarioRunner(object):
                     profile = weather_profiles[repetition % len(weather_profiles)]
                     config.weather = profile[0]
                     config.weather.sun_azimuth_angle = -1
-                    config.weather.sun_altitude = -1
+                    config.weather.sun_altitude_angle = -1
 
                 result = self._load_and_run_scenario(config)
                 self._cleanup()

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -513,7 +513,7 @@ class ScenarioRunner(object):
                 if self._args.challenge:
                     profile = weather_profiles[repetition % len(weather_profiles)]
                     config.weather = profile[0]
-                    config.weather.sun_azimuth = -1
+                    config.weather.sun_azimuth_angle = -1
                     config.weather.sun_altitude = -1
 
                 result = self._load_and_run_scenario(config)

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -377,8 +377,8 @@ class ScenarioRunner(object):
             precipitation=config.weather.precipitation,
             precipitation_deposits=config.weather.precipitation_deposits,
             wind_intensity=config.weather.wind_intensity,
-            sun_azimuth_angle=config.weather.sun_azimuth,
-            sun_altitude_angle=config.weather.sun_altitude,
+            sun_azimuth_angle=config.weather.sun_azimuth_angle,
+            sun_altitude_angle=config.weather.sun_altitude_angle,
             fog_density=config.weather.fog_density,
             fog_distance=config.weather.fog_distance,
             wetness=config.weather.wetness

--- a/srunner/challenge/routes_training.xml
+++ b/srunner/challenge/routes_training.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes>
    <route id="0" map="Town01">
-		<weather 
-			cloudiness="0"
-			precipitation="0"
-			precipitation_deposits="0"
-			wind_intensity="0"
-			sun_azimuth_angle="0"
-			sun_altitude_angle="70"
-			fog_density="0"
-			fog_distance="0"
-			wetness="0"
-		/>
+      <weather 
+         cloudiness="0"
+         precipitation="0"
+         precipitation_deposits="0"
+         wind_intensity="0"
+         sun_azimuth_angle="0"
+         sun_altitude_angle="70"
+         fog_density="0"
+         fog_distance="0"
+         wetness="0"
+      />
       <waypoint pitch="360.0" roll="0.0" x="338.7027893066406" y="226.75003051757812" yaw="269.9790954589844" z="0.0" />
       <waypoint pitch="360.0" roll="0.0" x="321.98931884765625" y="194.67242431640625" yaw="179.83230590820312" z="0.0" />
       <waypoint pitch="360.0" roll="0.0" x="283.6903991699219" y="194.78451538085938" yaw="179.83230590820312" z="0.0" />

--- a/srunner/challenge/routes_training.xml
+++ b/srunner/challenge/routes_training.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes>
    <route id="0" map="Town01">
+		<weather 
+			cloudiness="0"
+			precipitation="0"
+			precipitation_deposits="0"
+			wind_intensity="0"
+			sun_azimuth_angle="0"
+			sun_altitude_angle="70"
+			fog_density="0"
+			fog_distance="0"
+			wetness="0"
+		/>
       <waypoint pitch="360.0" roll="0.0" x="338.7027893066406" y="226.75003051757812" yaw="269.9790954589844" z="0.0" />
       <waypoint pitch="360.0" roll="0.0" x="321.98931884765625" y="194.67242431640625" yaw="179.83230590820312" z="0.0" />
       <waypoint pitch="360.0" roll="0.0" x="283.6903991699219" y="194.78451538085938" yaw="179.83230590820312" z="0.0" />

--- a/srunner/examples/ChangeLane.xml
+++ b/srunner/examples/ChangeLane.xml
@@ -5,7 +5,7 @@
 	<!-- spawn actors-->
 	<other_actor x="264.4" y="16.3" z="-500" yaw="-179" model="vehicle.tesla.model3" />
 	<other_actor x="184.4" y="14.9" z="-500" yaw="-176" model="vehicle.volkswagen.t2" />
-        <weather cloudiness="0" precipitation="0" precipitation_deposits="0" wind_intensity="0" sun_azimuth="0" sun_altitude="75" />
+        <weather cloudiness="0" precipitation="0" precipitation_deposits="0" wind_intensity="0" sun_azimuth_angle="0" sun_altitude_angle="75" />
     </scenario>
     <scenario name="ChangeLane_2" type="ChangeLane" town="Town01">
         <ego_vehicle x="107" y="133.5" z="0.5" yaw="0" model="vehicle.lincoln.mkz2017" />

--- a/srunner/examples/CutIn.xml
+++ b/srunner/examples/CutIn.xml
@@ -4,11 +4,11 @@
     <scenario name="CutInFrom_left_Lane" type="CutIn" town="Town04">
         <ego_vehicle x="284.4" y="16.4" z="2.5" yaw="180" model="vehicle.lincoln.mkz2017" />
 	    <other_actor x="324.2" y="20.7" z="-100" yaw="180" model="vehicle.tesla.model3" />
-        <weather cloudiness="0" precipitation="0" precipitation_deposits="0" wind_intensity="0" sun_azimuth="0" sun_altitude="75" />
+        <weather cloudiness="0" precipitation="0" precipitation_deposits="0" wind_intensity="0" sun_azimuth_angle="0" sun_altitude_angle="75" />
     </scenario>
     <scenario name="CutInFrom_right_Lane" type="CutIn" town="Town04">
         <ego_vehicle x="284.4" y="16.4" z="2.5" yaw="180" model="vehicle.lincoln.mkz2017" />
 	    <other_actor x="336.6" y="14.4" z="-100" yaw="180" model="vehicle.tesla.model3" />
-        <weather cloudiness="0" precipitation="0" precipitation_deposits="0" wind_intensity="0" sun_azimuth="0" sun_altitude="75" />
+        <weather cloudiness="0" precipitation="0" precipitation_deposits="0" wind_intensity="0" sun_azimuth_angle="0" sun_altitude_angle="75" />
     </scenario>
 </scenarios>

--- a/srunner/examples/FollowLeadingVehicle.xml
+++ b/srunner/examples/FollowLeadingVehicle.xml
@@ -2,7 +2,7 @@
 <scenarios>
     <scenario name="FollowLeadingVehicle_1" type="FollowLeadingVehicle" town="Town01">
         <ego_vehicle x="107" y="133" z="0.5" yaw="0" model="vehicle.lincoln.mkz2017" />
-        <weather cloudiness="0" precipitation="0" precipitation_deposits="0" wind_intensity="0" sun_azimuth="0" sun_altitude="75" />
+        <weather cloudiness="0" precipitation="0" precipitation_deposits="0" wind_intensity="0" sun_azimuth_angle="0" sun_altitude_angle="75" />
     </scenario>
     <scenario name="FollowLeadingVehicleWithObstacle_1" type="FollowLeadingVehicleWithObstacle" town="Town01">
         <ego_vehicle x="107" y="133.5" z="0.5" yaw="0" model="vehicle.lincoln.mkz2017" />

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -191,8 +191,8 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
 
         weather = environment.find("Weather")
         sun = weather.find("Sun")
-        self.weather.sun_azimuth = math.degrees(float(sun.attrib.get('azimuth', 0)))
-        self.weather.sun_altitude = math.degrees(float(sun.attrib.get('elevation', 0)))
+        self.weather.sun_azimuth_angle = math.degrees(float(sun.attrib.get('azimuth', 0)))
+        self.weather.sun_altitude_angle = math.degrees(float(sun.attrib.get('elevation', 0)))
         self.weather.cloudiness = 100 - float(sun.attrib.get('intensity', 0)) * 100
         fog = weather.find("Fog")
         self.weather.fog_distance = float(fog.attrib.get('visualRange', 'inf'))
@@ -215,10 +215,10 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
         dtime = datetime.datetime.strptime(time, "%Y-%m-%dT%H:%M:%S")
 
         if dtime.hour >= 22 or dtime.hour <= 4:
-            self.weather.sun_altitude = -90
+            self.weather.sun_altitude_angle = -90
         elif dtime.hour >= 20 and dtime.hour < 22 or \
                 dtime.hour <= 6 and dtime.hour > 4:
-            self.weather.sun_altitude = 10
+            self.weather.sun_altitude_angle = 10
 
     def _set_carla_friction(self):
         """

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -22,7 +22,7 @@ import xmlschema
 import carla
 
 # pylint: disable=line-too-long
-from srunner.scenarioconfigs.scenario_configuration import ActorConfigurationData, ScenarioConfiguration, WeatherConfiguration
+from srunner.scenarioconfigs.scenario_configuration import ActorConfigurationData, ScenarioConfiguration
 # pylint: enable=line-too-long
 from srunner.scenariomanager.carla_data_provider import CarlaDataProvider  # workaround
 from srunner.tools.openscenario_parser import OpenScenarioParser
@@ -48,7 +48,7 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
         self.other_actors = []
         self.ego_vehicles = []
         self.trigger_points = []
-        self.weather = WeatherConfiguration()
+        self.weather = carla.WeatherParameters()
 
         self.storyboard = self.xml_tree.find("Storyboard")
         self.story = self.storyboard.find("Story")

--- a/srunner/scenarioconfigs/route_scenario_configuration.py
+++ b/srunner/scenarioconfigs/route_scenario_configuration.py
@@ -71,5 +71,6 @@ class RouteScenarioConfiguration(ScenarioConfiguration):
         self.name = "RouteScenario_{}".format(route_description['id'])
         self.town = route_description['town_name']
         self.route_description = route_description
+        self.weather = route_description['weather']
 
         self.scenario_file = scenario_file

--- a/srunner/scenarioconfigs/scenario_configuration.py
+++ b/srunner/scenarioconfigs/scenario_configuration.py
@@ -67,23 +67,6 @@ class ActorConfiguration(ActorConfigurationData):
                                                  autopilot, random_location, amount)
 
 
-class WeatherConfiguration(object):
-
-    """
-    This class provides basic weather configuration values
-    """
-
-    cloudiness = -1
-    precipitation = -1
-    precipitation_deposits = -1
-    wind_intensity = -1
-    sun_azimuth_angle = -1
-    sun_altitude_angle = -1
-    wetness = -1
-    fog_distance = -1
-    fog_density = -1
-
-
 class ScenarioConfiguration(object):
 
     """
@@ -103,7 +86,7 @@ class ScenarioConfiguration(object):
     target = None
     route = None
     agent = None
-    weather = WeatherConfiguration()
+    weather = carla.WeatherParameters()
     friction = None
     subtype = None
     route_var_name = None

--- a/srunner/scenarioconfigs/scenario_configuration.py
+++ b/srunner/scenarioconfigs/scenario_configuration.py
@@ -77,8 +77,8 @@ class WeatherConfiguration(object):
     precipitation = -1
     precipitation_deposits = -1
     wind_intensity = -1
-    sun_azimuth = -1
-    sun_altitude = -1
+    sun_azimuth_angle = -1
+    sun_altitude_angle = -1
     wetness = -1
     fog_distance = -1
     fog_density = -1

--- a/srunner/tools/route_parser.py
+++ b/srunner/tools/route_parser.py
@@ -57,6 +57,7 @@ class RouteParser(object):
         for route in tree.iter("route"):
             route_town = route.attrib['map']
             route_id = route.attrib['id']
+            route_weather = RouteParser.parse_weather(route)
             if single_route and route_id != single_route:
                 continue
 
@@ -71,10 +72,48 @@ class RouteParser(object):
             list_route_descriptions.append({
                 'id': route_id,
                 'town_name': route_town,
-                'trajectory': waypoint_list
+                'trajectory': waypoint_list,
+                'weather': route_weather
             })
 
         return list_route_descriptions
+
+    @staticmethod
+    def parse_weather(route):
+        """
+        Returns a carla.WeatherParameters with the corresponding weather for that route. If the route
+        has no weather attribute, the default one is triggered.
+        """
+
+        route_weather = route.find("weather")
+        if route_weather is None:
+
+            weather = carla.WeatherParameters(sun_altitude_angle = 70)
+
+        else:
+            weather = carla.WeatherParameters()
+            for weather_attrib in route.iter("weather"):
+
+                if 'cloudiness' in weather_attrib.attrib:
+                    weather.cloudiness = float(weather_attrib.attrib['cloudiness']) 
+                if 'precipitation' in weather_attrib.attrib:
+                    weather.precipitation = float(weather_attrib.attrib['precipitation'])
+                if 'precipitation_deposits' in weather_attrib.attrib:
+                    weather.precipitation_deposits =float(weather_attrib.attrib['precipitation_deposits'])
+                if 'wind_intensity' in weather_attrib.attrib:
+                    weather.wind_intensity = float(weather_attrib.attrib['wind_intensity'])
+                if 'sun_azimuth_angle' in weather_attrib.attrib:
+                    weather.sun_azimuth_angle = float(weather_attrib.attrib['sun_azimuth_angle'])
+                if 'sun_altitude_angle' in weather_attrib.attrib:
+                    weather.sun_altitude_angle = float(weather_attrib.attrib['sun_altitude_angle'])
+                if 'wetness' in weather_attrib.attrib:
+                    weather.wetness = float(weather_attrib.attrib['wetness'])
+                if 'fog_distance' in weather_attrib.attrib:
+                    weather.fog_distance = float(weather_attrib.attrib['fog_distance'])
+                if 'fog_density' in weather_attrib.attrib:
+                    weather.fog_density = float(weather_attrib.attrib['fog_density'])
+
+        return weather
 
     @staticmethod
     def check_trigger_position(new_trigger, existing_triggers):

--- a/srunner/tools/route_parser.py
+++ b/srunner/tools/route_parser.py
@@ -88,18 +88,18 @@ class RouteParser(object):
         route_weather = route.find("weather")
         if route_weather is None:
 
-            weather = carla.WeatherParameters(sun_altitude_angle = 70)
+            weather = carla.WeatherParameters(sun_altitude_angle=70)
 
         else:
             weather = carla.WeatherParameters()
             for weather_attrib in route.iter("weather"):
 
                 if 'cloudiness' in weather_attrib.attrib:
-                    weather.cloudiness = float(weather_attrib.attrib['cloudiness']) 
+                    weather.cloudiness = float(weather_attrib.attrib['cloudiness'])
                 if 'precipitation' in weather_attrib.attrib:
                     weather.precipitation = float(weather_attrib.attrib['precipitation'])
                 if 'precipitation_deposits' in weather_attrib.attrib:
-                    weather.precipitation_deposits =float(weather_attrib.attrib['precipitation_deposits'])
+                    weather.precipitation_deposits = float(weather_attrib.attrib['precipitation_deposits'])
                 if 'wind_intensity' in weather_attrib.attrib:
                     weather.wind_intensity = float(weather_attrib.attrib['wind_intensity'])
                 if 'sun_azimuth_angle' in weather_attrib.attrib:

--- a/srunner/tools/scenario_config_parser.py
+++ b/srunner/tools/scenario_config_parser.py
@@ -58,8 +58,8 @@ class ScenarioConfigurationParser(object):
                 new_config.weather.precipitation = float(weather.attrib.get("precipitation", 0))
                 new_config.weather.precipitation_deposits = float(weather.attrib.get("precipitation_deposits", 0))
                 new_config.weather.wind_intensity = float(weather.attrib.get("wind_intensity", 0.35))
-                new_config.weather.sun_azimuth = float(weather.attrib.get("sun_azimuth", 0.0))
-                new_config.weather.sun_altitude = float(weather.attrib.get("sun_altitude", 15.0))
+                new_config.weather.sun_azimuth_angle = float(weather.attrib.get("sun_azimuth_angle", 0.0))
+                new_config.weather.sun_altitude_angle = float(weather.attrib.get("sun_altitude_angle", 15.0))
 
             for ego_vehicle in scenario.iter("ego_vehicle"):
                 new_config.ego_vehicles.append(ActorConfiguration(ego_vehicle, 'hero'))


### PR DESCRIPTION
#### Description

The way routes compute the weather of the simulation has been changed to allow the user to decide the weather of each route.

To do so, the _weather_ attribute has to be added to the .xml file of the route, as a child of the _route_ attribute, along with the parameter values:
![Weather](https://user-images.githubusercontent.com/58212725/78785231-0cd4e680-79a7-11ea-9ba0-6eda3fa8b9c0.png)

If none is chosen by the user, the default is a sunny midday (instead of the map's default one)

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.8

#### Possible Drawbacks

None?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/508)
<!-- Reviewable:end -->
