### PR TITLE
Fix to scenarios running faster than real time

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -30,7 +30,7 @@
 * Fixed bug where CollisionTest was counting as multiple hits collisions that displaced the actor for a long distance.
 * Fixed bug causing the simulation to end after running in synchronous mode
 * Fixed bug when using the WaypointFollower atomic to create new LocalPlanners for on-the-fly created actors (#502)
-* Fixed bug causing the scenarios to run faster than real time when --reloadWorld argument was active.
+* Fixed bug causing the scenarios to run faster than real time.
 
 ## CARLA ScenarioRunner 0.9.8
 ### :rocket: New Features

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Fixed bug where CollisionTest was counting as multiple hits collisions that displaced the actor for a long distance.
 * Fixed bug causing the simulation to end after running in synchronous mode
 * Fixed bug when using the WaypointFollower atomic to create new LocalPlanners for on-the-fly created actors (#502)
+* Fixed bug causing the scenarios to run faster than real time when --reloadWorld argument was active.
 
 ## CARLA ScenarioRunner 0.9.8
 ### :rocket: New Features

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -301,13 +301,10 @@ class ScenarioRunner(object):
         CarlaActorPool.set_world(self.world)
         CarlaDataProvider.set_world(self.world)
 
-        settings = self.world.get_settings()
-        settings.fixed_delta_seconds = 1.0 / self.frame_rate
-        self.world.apply_settings(settings)
-
         if self._args.agent:
             settings = self.world.get_settings()
             settings.synchronous_mode = True
+            settings.fixed_delta_seconds = 1.0 / self.frame_rate
             self.world.apply_settings(settings)
 
         # Wait for the world to be ready

--- a/srunner/examples/FollowLeadingVehicle.xosc
+++ b/srunner/examples/FollowLeadingVehicle.xosc
@@ -155,16 +155,6 @@
                 </ManeuverGroup>
                     <StartTrigger>
                         <ConditionGroup>
-                            <Condition name="StandStillCondition" delay="0" conditionEdge="rising">
-                                <ByEntityCondition>
-                                    <TriggeringEntities triggeringEntitiesRule="any">
-                                        <EntityRef entityRef="hero" />
-                                    </TriggeringEntities>
-                                    <EntityCondition>
-                                        <StandStillCondition duration="10.0" />
-                                    </EntityCondition>
-                                </ByEntityCondition>
-                            </Condition>
                             <Condition name="OverallStartCondition" delay="0" conditionEdge="rising">
                                 <ByEntityCondition>
                                     <TriggeringEntities triggeringEntitiesRule="any">

--- a/srunner/examples/LaneChangeSimple.xosc
+++ b/srunner/examples/LaneChangeSimple.xosc
@@ -167,16 +167,6 @@
         </ManeuverGroup>
         <StartTrigger>
           <ConditionGroup>
-            <Condition name="StandStillCondition" delay="0" conditionEdge="rising">
-              <ByEntityCondition>
-                <TriggeringEntities triggeringEntitiesRule="any">
-                  <EntityRef entityRef="hero"/>
-                </TriggeringEntities>
-                <EntityCondition>
-                  <StandStillCondition duration="10.0"/>
-                </EntityCondition>
-              </ByEntityCondition>
-            </Condition>
             <Condition name="OverallStartCondition" delay="0" conditionEdge="rising">
               <ByEntityCondition>
                 <TriggeringEntities triggeringEntitiesRule="any">


### PR DESCRIPTION
#### Description

`setting.fixed_delta_seconds = 1.0 / self.frame_rate` has been moved inside the agent check, as it was being set even in asynchronous mode, causing the simulation to run faster than in real time.

Fixes #494

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/509)
<!-- Reviewable:end -->
