### PR TITLE
Reworked weather and road friction handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
             - python-pip
       before_install:
         - pip2 install --user pylint==1.9.4
-        - pip2 install --user py_trees==0.8.3 networkx==2.2 psutil shapely numpy xmlschema==1.0.18 opencv-python
+        - pip2 install --user py_trees==0.8.3 networkx==2.2 psutil shapely numpy xmlschema==1.0.18 opencv-python ephem
       script:
         - pylint --version
         - static_code_quality_passed=1

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -10,11 +10,17 @@
 
 ## Latest Changes
 ### :rocket: New Features
+* Enable weather animation during scenario execution (requires ephem pip package)
 * OpenSCENARIO support:
     - Added initial speed support for pedestrians for OpenSCENARIO
+    - Support for EnvironmentActions within Story (before only within Init). This allows changing weather conditions during scenario execution
+    - Extended FollowLeadingVehicle example to illustrate weather changes
+* Atomics:
+    - WeatherBehavior to simulate weather over time
+    - UpdateWeather to update weather to a new setting, e.g. sun to rain
+    - UpdateRoadFriction to update the road friction while running
 ### :bug: Bug Fixes
 * Fixed initial speed of vehicles using OpenSCENARIO
-
 
 
 ## CARLA ScenarioRunner 0.9.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Shapely
 psutil
 xmlschema==1.0.18
 carla
+ephem

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -301,7 +301,6 @@ class ScenarioRunner(object):
             self.world.tick()
         else:
             self.world.wait_for_tick()
-
         if CarlaDataProvider.get_map().name != town and CarlaDataProvider.get_map().name != "OpenDriveMap":
             print("The CARLA server uses the wrong map: {}".format(CarlaDataProvider.get_map().name))
             print("This scenario requires to use map: {}".format(town))
@@ -356,23 +355,6 @@ class ScenarioRunner(object):
             print(exception)
             self._cleanup()
             return False
-
-        # Set the appropriate weather conditions
-        self.world.set_weather(config.weather)
-
-        # Set the appropriate road friction
-        if config.friction is not None:
-            friction_bp = self.world.get_blueprint_library().find('static.trigger.friction')
-            extent = carla.Location(1000000.0, 1000000.0, 1000000.0)
-            friction_bp.set_attribute('friction', str(config.friction))
-            friction_bp.set_attribute('extent_x', str(extent.x))
-            friction_bp.set_attribute('extent_y', str(extent.y))
-            friction_bp.set_attribute('extent_z', str(extent.z))
-
-            # Spawn Trigger Friction
-            transform = carla.Transform()
-            transform.location = carla.Location(-10000.0, -10000.0, 0.0)
-            self.world.spawn_actor(friction_bp, transform)
 
         try:
             # Load scenario and run it

--- a/srunner/examples/ChangingWeather.xosc
+++ b/srunner/examples/ChangingWeather.xosc
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSCENARIO>
+    <FileHeader revMajor="1" revMinor="0" date="2020-03-20" description="CARLA:ChangingWeatherExample" author="" />
+    <ParameterDeclarations/>
+    <CatalogLocations/>
+    <RoadNetwork>
+        <LogicFile filepath="Town01" />
+        <SceneGraphFile filepath="" />
+    </RoadNetwork>
+    <Entities>
+        <ScenarioObject name="hero">
+            <Vehicle name="vehicle.lincoln.mkz2017" vehicleCategory="car">
+                <ParameterDeclarations/>
+                <Performance maxSpeed="69.444" maxAcceleration="200" maxDeceleration="10.0"/>
+                <BoundingBox>
+                    <Center x="1.5" y="0.0" z="0.9" />
+                    <Dimensions width="2.1" length="4.5" height="1.8"/>
+                </BoundingBox>
+                <Axles>
+                    <FrontAxle maxSteering="0.5" wheelDiameter="0.6" trackWidth="1.8" positionX="3.1" positionZ="0.3" />
+                    <RearAxle maxSteering="0.0" wheelDiameter="0.6" trackWidth="1.8" positionX="0.0" positionZ="0.3" />
+                </Axles>
+                <Properties>
+                    <Property name="type" value="ego_vehicle" />
+                    <Property name="color" value="0,0,255" />
+                </Properties>
+            </Vehicle>
+        </ScenarioObject>
+    </Entities>
+    <Storyboard>
+        <Init>
+            <Actions>         
+                <GlobalAction>
+                    <EnvironmentAction>
+                        <Environment name="Environment1">
+                            <TimeOfDay animation="true" dateTime="2020-01-01T12:00:00"/>
+                            <Weather cloudState="free">
+                                <Sun intensity="0.85" azimuth="0" elevation="1.31" />
+                                <Fog visualRange="100000.0" />
+                                <Precipitation precipitationType="dry" intensity="0.0" />
+                            </Weather>
+                            <RoadCondition frictionScaleFactor="1.0" />
+                        </Environment>
+                    </EnvironmentAction>
+                </GlobalAction>
+                <Private entityRef="hero">
+                    <PrivateAction>
+                        <TeleportAction>
+                            <Position>
+                                <LanePosition roadId="4" laneId="-1" offset="1.0" s="48.58" />
+                            </Position>
+                        </TeleportAction>
+                    </PrivateAction>
+                </Private>
+            </Actions>
+        </Init>
+        <Story name="MyStory">
+            <Act name="Behavior">
+                <ManeuverGroup name="ManeuverSequence" maximumExecutionCount="1">
+                    <Actors selectTriggeringEntities="false"/>
+                    <Maneuver name="WeatherChange">
+                        <Event name="WeatherChangeEvent" priority="overwrite">
+			                <Action name="WeatherChangeAction">
+			                <GlobalAction>
+			                    <EnvironmentAction>
+			                        <Environment name="Environment1">
+			                            <TimeOfDay animation="true" dateTime="2020-01-01T22:00:00"/>
+			                            <Weather cloudState="free">
+			                                <Sun intensity="0.05" azimuth="0" elevation="1.31" />
+			                                <Fog visualRange="100000.0" />
+			                                <Precipitation precipitationType="rain" intensity="0.9" />
+			                            </Weather>
+			                            <RoadCondition frictionScaleFactor="1.0" />
+			                        </Environment>
+			                    </EnvironmentAction>
+			                </GlobalAction>
+			                </Action>
+                            <StartTrigger>
+                                <ConditionGroup>
+                                    <Condition name="WeatherChangeStartTime" delay="0" conditionEdge="rising">
+                                        <ByValueCondition>
+                                            <SimulationTimeCondition value="20" rule="greaterThan" />
+                                        </ByValueCondition>
+                                    </Condition>
+                                </ConditionGroup>
+                            </StartTrigger>
+                        </Event>
+                    </Maneuver>
+                    <Maneuver name="DummyManeuver">
+                        <Event name="DummyManeuver" priority="overwrite">
+			                <Action name="DummyManeuver"/>
+                            <StartTrigger>
+                                <ConditionGroup>
+                                    <Condition name="DummyManeuverStartTime" delay="0" conditionEdge="rising">
+                                        <ByValueCondition>
+                                            <SimulationTimeCondition value="10000000" rule="greaterThan" />
+                                        </ByValueCondition>
+                                    </Condition>
+                                </ConditionGroup>
+                            </StartTrigger>
+                        </Event>
+                    </Maneuver>
+                </ManeuverGroup>
+                    <StartTrigger>
+                        <ConditionGroup>
+                            <Condition name="StartTime" delay="0" conditionEdge="rising">
+                                <ByValueCondition>
+                                    <SimulationTimeCondition value="5" rule="greaterThan" />
+                                </ByValueCondition>
+                            </Condition>
+                        </ConditionGroup>
+                    </StartTrigger>
+                    <StopTrigger/>
+            </Act>
+        </Story>
+        <StopTrigger/>
+    </Storyboard>
+</OpenSCENARIO>

--- a/srunner/scenariomanager/scenario_manager.py
+++ b/srunner/scenariomanager/scenario_manager.py
@@ -19,6 +19,7 @@ import py_trees
 from srunner.autoagents.agent_wrapper import AgentWrapper
 from srunner.scenariomanager.carla_data_provider import CarlaDataProvider, CarlaActorPool
 from srunner.scenariomanager.result_writer import ResultOutputProvider
+from srunner.scenariomanager.weather_sim import WeatherBehavior
 from srunner.scenariomanager.timer import GameTime, TimeOut
 from srunner.scenariomanager.watchdog import Watchdog
 
@@ -64,6 +65,7 @@ class Scenario(object):
         if behavior is not None:
             self.scenario_tree.add_child(self.behavior)
         self.scenario_tree.add_child(self.timeout_node)
+        self.scenario_tree.add_child(WeatherBehavior())
         if criteria is not None:
             self.scenario_tree.add_child(self.criteria_tree)
         self.scenario_tree.setup(timeout=1)

--- a/srunner/scenariomanager/weather_sim.py
+++ b/srunner/scenariomanager/weather_sim.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020 Intel Corporation
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+"""
+This module provides a weather class and py_trees behavior
+to simulate weather in CARLA according to the astronomic
+behavior of the sun.
+"""
+
+import datetime
+import math
+import operator
+
+import ephem
+import py_trees
+import carla
+
+from srunner.scenariomanager.carla_data_provider import CarlaDataProvider
+from srunner.scenariomanager.timer import GameTime
+
+
+class Weather(object):
+
+    """
+    Class to simulate weather in CARLA according to the astronomic behavior of the sun
+
+    The sun position (azimuth and altitude angles) is obtained by calculating its
+    astronomic position for the CARLA reference position (x=0, y=0, z=0) using the ephem
+    library.
+
+    Args:
+        carla_weather (carla.WeatherParameters): Initial weather settings.
+        dtime (datetime): Initial date and time in UTC (required for animation only).
+            Defaults to None.
+        animation (bool): Flag to allow animating the sun position over time.
+            Defaults to False.
+
+    Attributes:
+        carla_weather (carla.WeatherParameters): Weather parameters for CARLA.
+        animation (bool): Flag to allow animating the sun position over time.
+        _sun (ephem.Sun): The sun as astronomic entity.
+        _observer_location (ephem.Observer): Holds the geographical position (lat/lon/altitude)
+            for which the sun position is obtained.
+        _datetime (datetime): Date and time in UTC (required for animation only).
+    """
+
+    def __init__(self, carla_weather, dtime=None, animation=False):
+        """
+        Class constructor
+        """
+        self.carla_weather = carla_weather
+        self.animation = animation
+
+        self._sun = ephem.Sun()  # pylint: disable=no-member
+        self._observer_location = ephem.Observer()
+        geo_location = CarlaDataProvider.get_map().transform_to_geolocation(carla.Location(0, 0, 0))
+        self._observer_location.lon = str(geo_location.longitude)
+        self._observer_location.lat = str(geo_location.latitude)
+
+        #@TODO This requires the time to be in UTC to be accurate
+        self._datetime = dtime
+        if self._datetime:
+            self._observer_location.date = self._datetime
+
+        self.update()
+
+    def update(self, delta_time=0):
+        """
+        If the weather animation is true, the new sun position is calculated w.r.t delta_time
+
+        Nothing happens if animation or _datetime are None.
+
+        Args:
+            delta_time (float): Time passed since self._datetime [seconds].
+        """
+        if not self.animation or not self._datetime:
+            return
+
+        self._datetime = self._datetime + datetime.timedelta(seconds=delta_time)
+        self._observer_location.date = self._datetime
+
+        self._sun.compute(self._observer_location)
+        self.carla_weather.sun_altitude_angle = math.degrees(self._sun.alt)
+        self.carla_weather.sun_azimuth_angle = math.degrees(self._sun.az)
+
+
+class WeatherBehavior(py_trees.behaviour.Behaviour):
+
+    """
+    Atomic to read weather settings from the blackboard and apply these in CARLA.
+    Used in combination with UpdateWeather() to have a continuous weather simulation.
+
+    This behavior is always in a running state and must never terminate.
+    The user must not add this behavior. It is automatically added by the ScenarioManager.
+
+    Args:
+        name (string): Name of the behavior.
+            Defaults to 'WeatherBehavior'.
+
+    Attributes:
+        _weather (srunner.scenariomanager.weather_sim.Weather): Weather settings.
+        _current_time (float): Current CARLA time [seconds].
+    """
+
+    def __init__(self, name="WeatherBehavior"):
+        """
+        Setup parameters
+        """
+        super(WeatherBehavior, self).__init__(name)
+        self._weather = None
+        self._current_time = None
+
+    def initialise(self):
+        """
+        Set current time to current CARLA time
+        """
+        self._current_time = GameTime.get_time()
+
+    def update(self):
+        """
+        Check if new weather settings are available on the blackboard, and if yes fetch these
+        into the _weather attribute.
+
+        Apply the weather settings from _weather to CARLA.
+
+        Note:
+            To minimize CARLA server interactions, the weather is only updated, when the blackboard
+            is updated, or if the weather animation flag is true. In the latter case, the update
+            frequency is 1 Hz.
+
+        returns:
+            RUNNING
+        """
+
+        weather = None
+
+        try:
+            check_weather = operator.attrgetter("CarlaWeather")
+            weather = check_weather(py_trees.blackboard.Blackboard())
+        except AttributeError:
+            pass
+
+        if weather:
+            self._weather = weather
+            delattr(py_trees.blackboard.Blackboard(), "CarlaWeather")
+            CarlaDataProvider.get_world().set_weather(self._weather.carla_weather)
+
+        if self._weather and self._weather.animation:
+            new_time = GameTime.get_time()
+            delta_time = new_time - self._current_time
+
+            if delta_time > 1:
+                self._weather.update(delta_time)
+                self._current_time = new_time
+                CarlaDataProvider.get_world().set_weather(self._weather.carla_weather)
+
+        return py_trees.common.Status.RUNNING

--- a/srunner/scenarios/basic_scenario.py
+++ b/srunner/scenarios/basic_scenario.py
@@ -13,6 +13,8 @@ from __future__ import print_function
 
 import py_trees
 
+import carla
+
 import srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions as conditions
 from srunner.scenariomanager.carla_data_provider import CarlaActorPool, CarlaDataProvider
 from srunner.scenariomanager.scenario_manager import Scenario
@@ -44,6 +46,8 @@ class BasicScenario(object):
         self.name = name
         self.config = config
         self.terminate_on_failure = terminate_on_failure
+
+        self._initialize_environment(world)
 
         # Initializing adversarial actors
         self._initialize_actors(config)
@@ -77,6 +81,29 @@ class BasicScenario(object):
             behavior_seq.add_child(end_behavior)
 
         self.scenario = Scenario(behavior_seq, criteria, self.name, self.timeout, self.terminate_on_failure)
+
+    def _initialize_environment(self, world):
+        """
+        Default initialization of weather and road friction.
+        Override this method in child class to provide custom initialization.
+        """
+
+        # Set the appropriate weather conditions
+        world.set_weather(self.config.weather)
+
+        # Set the appropriate road friction
+        if self.config.friction is not None:
+            friction_bp = world.get_blueprint_library().find('static.trigger.friction')
+            extent = carla.Location(1000000.0, 1000000.0, 1000000.0)
+            friction_bp.set_attribute('friction', str(self.config.friction))
+            friction_bp.set_attribute('extent_x', str(extent.x))
+            friction_bp.set_attribute('extent_y', str(extent.y))
+            friction_bp.set_attribute('extent_z', str(extent.z))
+
+            # Spawn Trigger Friction
+            transform = carla.Transform()
+            transform.location = carla.Location(-10000.0, -10000.0, 0.0)
+            world.spawn_actor(friction_bp, transform)
 
     def _initialize_actors(self, config):
         """

--- a/srunner/scenarios/open_scenario.py
+++ b/srunner/scenarios/open_scenario.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 import itertools
 import py_trees
 
-from srunner.scenariomanager.scenarioatomics.atomic_behaviors import SetOSCInitSpeed
+from srunner.scenariomanager.scenarioatomics.atomic_behaviors import SetOSCInitSpeed, UpdateWeather, UpdateRoadFriction
 from srunner.scenariomanager.timer import GameTime
 from srunner.scenarios.basic_scenario import BasicScenario
 from srunner.tools.openscenario_parser import OpenScenarioParser
@@ -187,6 +187,27 @@ class OpenScenario(BasicScenario):
                                            world=world, debug_mode=debug_mode,
                                            terminate_on_failure=False, criteria_enable=criteria_enable)
 
+    def _initialize_environment(self, world):
+        """
+        Initialization of weather and road friction.
+        """
+        pass
+
+    def _create_environment_behavior(self):
+        # Set the appropriate weather conditions
+
+        env_behavior = py_trees.composites.Parallel(
+            policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL, name="EnvironmentBehavior")
+
+        weather_update = UpdateWeather(
+            OpenScenarioParser.get_weather_from_env_action(self.config.init, self.config.catalogs))
+        road_friction = UpdateRoadFriction(
+            OpenScenarioParser.get_friction_from_env_action(self.config.init, self.config.catalogs))
+        env_behavior.add_child(oneshot_behavior(variable_name="InitialWeather", behaviour=weather_update))
+        env_behavior.add_child(oneshot_behavior(variable_name="InitRoadFriction", behaviour=road_friction))
+
+        return env_behavior
+
     def _create_init_behavior(self):
 
         init_behavior = None
@@ -214,7 +235,7 @@ class OpenScenario(BasicScenario):
         story_behavior = py_trees.composites.Parallel(
             policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL, name="Story")
 
-        joint_actor_list = self.other_actors + self.ego_vehicles
+        joint_actor_list = self.other_actors + self.ego_vehicles + [None]
 
         for act in self.config.story.iter("Act"):
 
@@ -246,6 +267,7 @@ class OpenScenario(BasicScenario):
 
                     if not actor_ids:
                         print("Warning: Maneuvergroup does not use reference actors!")
+                        actor_ids.append(len(joint_actor_list) - 1)
 
                    # Collect catalog reference maneuvers in order to process them at the same time as normal maneuvers
                     catalog_maneuver_list = []
@@ -269,12 +291,11 @@ class OpenScenario(BasicScenario):
                                 if child.tag == "Action":
                                     for actor_id in actor_ids:
                                         maneuver_behavior = OpenScenarioParser.convert_maneuver_to_atomic(
-                                            child, joint_actor_list[actor_id])
+                                            child, joint_actor_list[actor_id], self.config.catalogs)
                                         maneuver_behavior = StoryElementStatusToBlackboard(
                                             maneuver_behavior, "ACTION", child.attrib.get('name'))
-
                                         parallel_actions.add_child(
-                                            oneshot_behavior(variable_name=  # See note in get_xml_path
+                                            oneshot_behavior(variable_name=# See note in get_xml_path
                                                              get_xml_path(self.config.story, sequence) + '>' + \
                                                              get_xml_path(maneuver, child),
                                                              behaviour=maneuver_behavior))
@@ -297,7 +318,7 @@ class OpenScenario(BasicScenario):
                             maneuver_parallel, "MANEUVER", maneuver.attrib.get('name'))
                         single_sequence_iteration.add_child(
                             oneshot_behavior(variable_name=get_xml_path(self.config.story, sequence) + '>' +
-                                             get_xml_path(maneuver, maneuver),  # See get_xml_path
+                                             maneuver.attrib.get('name'),  # See get_xml_path
                                              behaviour=maneuver_parallel))
 
                     # OpenSCENARIO refers to Sequences as Scenes in this instance
@@ -343,6 +364,11 @@ class OpenScenario(BasicScenario):
         # Build behavior tree
         behavior = py_trees.composites.Parallel(
             policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL, name="behavior")
+
+        env_behavior = self._create_environment_behavior()
+        if env_behavior is not None:
+            behavior.add_child(oneshot_behavior(variable_name=get_xml_path(
+                self.config.init, self.config.init), behaviour=env_behavior))
 
         init_behavior = self._create_init_behavior()
         if init_behavior is not None:


### PR DESCRIPTION
* Enabled weather simulation/animation
* Reworked handling of weather and road friction:
  - Moved from scenario_runner into BasicScenario class, as these are
    scenario dependent features

* ScenarioManager update:
  - WeatherBehavior as new parallel behavior among timeout and the
    desired scenario behavior itself
  - Added WeatherSim module to allow animating the sun position over time
    w.r.t the CARLA reference position and the provide datetime in UTC

* New behavior atomics:
  - WeatherBehavior to simulate weather over time
  - UpdateWeather to update weather to a new setting, e.g. sun to rain
  - UpdateRoadFriction to update the road friction while running

* BasicScenario class update:
  - Added _initialize_environment() method, which can be overloaded in
    user-defined scenarios

* OpenSCENARIO 1.0 extensions:
  - Support for EnvironmentActions in Init and Story
  - Extended openscenario_parser with new functions to map
    EnvironmentActions to scenario atomics
   - get_friction_from_env_action()
   - get_weather_from_env_action()
  - Removed weather and road friction settings from
    openscenario_configuration, i.e. removed:
   - _set_carla_weather()
   - _set_carla_friction()
  - Extended FollowLeadingVehicle example to illustrate weather changes


#### Where has this been tested?

  * **Platform(s):**  Ubuntu 16.04
  * **Python version(s):** 2.7
  * **CARLA version:** 0.9.9

#### Possible Drawbacks
Could affect the weather setting of the leaderboard, if this commit is cherry-picked to leaderboard branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/520)
<!-- Reviewable:end -->
