### PR TITLE
Fixed bug at BasicScenario's _initialize_actors

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -26,6 +26,7 @@
     - UpdateRoadFriction to update the road friction while running
 ### :bug: Bug Fixes
 * Fixed initial speed of vehicles using OpenSCENARIO
+* Fixed bug causing an exception when calling BasicScenario's *_initialize_actors* with no other_actors.
 
 
 ## CARLA ScenarioRunner 0.9.9

--- a/srunner/scenarios/basic_scenario.py
+++ b/srunner/scenarios/basic_scenario.py
@@ -110,7 +110,7 @@ class BasicScenario(object):
         Default initialization of other actors.
         Override this method in child class to provide custom initialization.
         """
-        if len(config.other_actors) > 0:
+        if config.other_actors:
             new_actors = CarlaDataProvider.request_new_actors(config.other_actors)
             if not new_actors:
                 raise Exception("Error: Unable to add actors")

--- a/srunner/scenarios/basic_scenario.py
+++ b/srunner/scenarios/basic_scenario.py
@@ -110,13 +110,13 @@ class BasicScenario(object):
         Default initialization of other actors.
         Override this method in child class to provide custom initialization.
         """
+        if len(config.other_actors) > 0:
+            new_actors = CarlaDataProvider.request_new_actors(config.other_actors)
+            if not new_actors:
+                raise Exception("Error: Unable to add actors")
 
-        new_actors = CarlaDataProvider.request_new_actors(config.other_actors)
-        if not new_actors:
-            raise Exception("Error: Unable to add actors")
-
-        for new_actor in new_actors:
-            self.other_actors.append(new_actor)
+            for new_actor in new_actors:
+                self.other_actors.append(new_actor)
 
     def _setup_scenario_trigger(self, config):
         """


### PR DESCRIPTION
#### Description

Fixed a bug at BasicScenario. A length check has been added to the *_initialize_actors* to avoid raising the exceptions when no other actors are present (for example, running routes with no background activity).

#### Where has this been tested?

  * **Platform(s):** Ubutnu 18.04
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/530)
<!-- Reviewable:end -->
