### PR TITLE
Changed how SR reads the .py files

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -14,6 +14,7 @@
     - The spawning functions have been refactored. All the *setup* functions have been removed, and its functionalities moved to their *request* counterparts. For example, previously *request_new_actor* just called *setup_actor*, but now *setup_actor* no longer exists, and the spawning is done via *request_new_actor*. They have also been unified and are now more consistent.
     - Changed *ActorConfiguration* to *ActorConfigurationData.parse_from_node*
 * The BackgroundActivity functionality has been unchanged but some tweaks have been made, fixing a previous patch. As a result, the *amount* parameter at *ActorConfigurationData* has been removed.
+* Remade how ScenarioRunner reads the scenarios files. It now reads all scenarios inside the *srunner/scenarios* folder without needing to import them. Scenarios outside that folder will still need the *--additionalScenario* argument.
 * The new weather parameters (related to fog) are now correctly read when running scenarios outside routes.
 * Enable weather animation during scenario execution (requires ephem pip package)
 * OpenSCENARIO support:

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -35,21 +35,6 @@ from srunner.scenarioconfigs.openscenario_configuration import OpenScenarioConfi
 from srunner.scenarioconfigs.route_scenario_configuration import RouteScenarioConfiguration
 from srunner.scenariomanager.carla_data_provider import CarlaDataProvider
 from srunner.scenariomanager.scenario_manager import ScenarioManager
-# pylint: disable=unused-import
-# For the following includes the pylint check is disabled, as these are accessed via globals()
-# from srunner.scenarios.control_loss import ControlLoss
-# from srunner.scenarios.follow_leading_vehicle import FollowLeadingVehicle, FollowLeadingVehicleWithObstacle
-# from srunner.scenarios.maneuver_opposite_direction import ManeuverOppositeDirection
-# from srunner.scenarios.no_signal_junction_crossing import NoSignalJunctionCrossing
-# from srunner.scenarios.object_crash_intersection import VehicleTurningRight, VehicleTurningLeft
-# from srunner.scenarios.object_crash_vehicle import StationaryObjectCrossing, DynamicObjectCrossing
-# from srunner.scenarios.opposite_vehicle_taking_priority import OppositeVehicleRunningRedLight
-# from srunner.scenarios.other_leading_vehicle import OtherLeadingVehicle
-# from srunner.scenarios.signalized_junction_left_turn import SignalizedJunctionLeftTurn
-# from srunner.scenarios.signalized_junction_right_turn import SignalizedJunctionRightTurn
-# from srunner.scenarios.change_lane import ChangeLane
-# from srunner.scenarios.cut_in import CutIn
-# pylint: enable=unused-import
 from srunner.scenarios.open_scenario import OpenScenario
 from srunner.scenarios.route_scenario import RouteScenario
 from srunner.tools.scenario_config_parser import ScenarioConfigurationParser
@@ -107,13 +92,6 @@ class ScenarioRunner(object):
         if LooseVersion(dist.version) < LooseVersion('0.9.8'):
             raise ImportError("CARLA version 0.9.8 or newer required. CARLA version found: {}".format(dist))
 
-        # Load additional scenario definitions, if there are any
-        # If something goes wrong an exception will be thrown by importlib (ok here)
-        if self._args.additionalScenario != '':
-            module_name = os.path.basename(args.additionalScenario).split('.')[0]
-            sys.path.insert(0, os.path.dirname(args.additionalScenario))
-            self.additional_scenario_module = importlib.import_module(module_name)
-
         # Load agent if requested via command line args
         # If something goes wrong an exception will be thrown by importlib (ok here)
         if self._args.agent is not None:
@@ -161,28 +139,22 @@ class ScenarioRunner(object):
         Get scenario class by scenario name
         If scenario is not supported or not found, exit script
         """
-        
+
+        # Path of all scenario at "srunner/scenarios" folder + the path of the additional scenario argument
         scenarios_list = glob.glob("{}/srunner/scenarios/*.py".format(os.getenv('ROOT_SCENARIO_RUNNER', "./")))
+        scenarios_list.append(self._args.additionalScenario)
+
         for scenarios in scenarios_list:
 
+            # Get their module
             module_name = os.path.basename(scenarios).split('.')[0]
             sys.path.insert(0, os.path.dirname(scenarios))
             scenario_module = importlib.import_module(module_name)
 
+            # And their members of type class
             for member in inspect.getmembers(scenario_module, inspect.isclass):
                 if scenario in member:
                     return member[1]
-
-        # if scenario in globals():
-        #     return globals()[scenario]
-
-        module_name = os.path.basename(self._args.additionalScenario).split('.')[0]
-        sys.path.insert(0, os.path.dirname(self._args.additionalScenario))
-        additional_scenario_module = importlib.import_module(module_name)
-
-        for member in inspect.getmembers(additional_scenario_module, inspect.isclass):
-            if scenario in member:
-                return member[1]
 
         print("Scenario '{}' not supported ... Exiting".format(scenario))
         sys.exit(-1)

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -144,11 +144,11 @@ class ScenarioRunner(object):
         scenarios_list = glob.glob("{}/srunner/scenarios/*.py".format(os.getenv('ROOT_SCENARIO_RUNNER', "./")))
         scenarios_list.append(self._args.additionalScenario)
 
-        for scenarios in scenarios_list:
+        for scenario_file in scenarios_list:
 
             # Get their module
-            module_name = os.path.basename(scenarios).split('.')[0]
-            sys.path.insert(0, os.path.dirname(scenarios))
+            module_name = os.path.basename(scenario_file).split('.')[0]
+            sys.path.insert(0, os.path.dirname(scenario_file))
             scenario_module = importlib.import_module(module_name)
 
             # And their members of type class
@@ -156,8 +156,8 @@ class ScenarioRunner(object):
                 if scenario in member:
                     return member[1]
 
-        # Remove unused Python paths
-        sys.path.pop(0)
+            # Remove unused Python paths
+            sys.path.pop(0)
 
         print("Scenario '{}' not supported ... Exiting".format(scenario))
         sys.exit(-1)

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -156,6 +156,9 @@ class ScenarioRunner(object):
                 if scenario in member:
                     return member[1]
 
+        # Remove unused Python paths
+        sys.path.pop(0)
+
         print("Scenario '{}' not supported ... Exiting".format(scenario))
         sys.exit(-1)
 


### PR DESCRIPTION
### Description

This PR changes how ScenarioRunner reads the example scenarios

**Previously:** The scenario classes were imported at ScenarioRunner and read through _globals()_.

**Now:** Similar to how the configuration files at _srunner/examples_ are read, SR grabs all the files at the _srunner/scenarios_ folder, adds the path given by the _additionalScenario_ argument and checks if the scenario class is inside those folders.

**Improvements:** Two improvements derive from this change:

1. We no longer need to import the scenario classes at SR, as they are automatically read.
2. As all scenarios at the _srunner/scenarios_ folder will be automatically read, users can put their custome scenarios there and forget about the _additionalScenario_ argument.

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.9

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/532)
<!-- Reviewable:end -->
