### PR TITLE
Fixed waitForEgo bug when reloadWorld was active

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fixed initial speed of vehicles using OpenSCENARIO
 * Fixed bug causing an exception when calling BasicScenario's *_initialize_actors* with no other_actors.
 * Fixed bug causing the route to be downsampled (introduced by mistake at 0.9.9)
+* Fixed bug causing the *waitForEgo* argument to function incorrectly when *reloadWorld* was active
 
 
 ## CARLA ScenarioRunner 0.9.9

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -266,22 +266,22 @@ class ScenarioRunner(object):
 
         if self._args.reloadWorld:
             self.world = self.client.load_world(town)
-        else:
-            # if the world should not be reloaded, wait at least until all ego vehicles are ready
+
+        # Wait until all ego vehicles are ready
+        if self._args.waitForEgo:
             ego_vehicle_found = False
-            if self._args.waitForEgo:
-                while not ego_vehicle_found and not self._shutdown_requested:
-                    vehicles = self.client.get_world().get_actors().filter('vehicle.*')
-                    for ego_vehicle in ego_vehicles:
-                        ego_vehicle_found = False
-                        for vehicle in vehicles:
-                            if vehicle.attributes['role_name'] == ego_vehicle.rolename:
-                                ego_vehicle_found = True
-                                break
-                        if not ego_vehicle_found:
-                            print("Not all ego vehicles ready. Waiting ... ")
-                            time.sleep(1)
+            while not ego_vehicle_found and not self._shutdown_requested:
+                vehicles = self.client.get_world().get_actors().filter('vehicle.*')
+                for ego_vehicle in ego_vehicles:
+                    ego_vehicle_found = False
+                    for vehicle in vehicles:
+                        if vehicle.attributes['role_name'] == ego_vehicle.rolename:
+                            ego_vehicle_found = True
                             break
+                    if not ego_vehicle_found:
+                        print("Not all ego vehicles ready. Waiting ... ")
+                        time.sleep(1)
+                        break
 
         self.world = self.client.get_world()
 
@@ -299,6 +299,7 @@ class ScenarioRunner(object):
             self.world.tick()
         else:
             self.world.wait_for_tick()
+
         if CarlaDataProvider.get_map().name != town and CarlaDataProvider.get_map().name != "OpenDriveMap":
             print("The CARLA server uses the wrong map: {}".format(CarlaDataProvider.get_map().name))
             print("This scenario requires to use map: {}".format(town))


### PR DESCRIPTION
#### Description

This PR fixes the waitForEgo argument, which had some issues due to the reloadWorld one.

This was caused at the *load_and_wait_for_world()* function, which only waited for the ego vehicle if reloadWorld wasn't active. This caused the CarlaDataProvider to have no record of the ego vehicle, which in turn, resulted in the scenario never being activated, as *InTimeToArrivalToLocation* never succeeded.

By taking the waitForEgo check out of the reloadWorld one, this is resolved

Fixes #534 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.9

#### Possible Drawbacks

None?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/536)
<!-- Reviewable:end -->
