### PR TITLE
Added actor controllers for OSC

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -19,10 +19,12 @@
 * The new weather parameters (related to fog) are now correctly read when running scenarios outside routes.
 * Enable weather animation during scenario execution (requires ephem pip package)
 * OpenSCENARIO support:
+    - Added support for controllers and provided default implementations for vehicles and pedestrians. This required changing the handling of actors, which results in that now all actors are controlled by an OSC controller.
     - Added initial speed support for pedestrians for OpenSCENARIO
     - Support for EnvironmentActions within Story (before only within Init). This allows changing weather conditions during scenario execution
-    - Extended FollowLeadingVehicle example to illustrate weather changes
+    - Created example scenarios to illustrate usage of controllers and weather changes
 * Atomics:
+    - Several new atomics to enable usage of OSC controllers
     - WeatherBehavior to simulate weather over time
     - UpdateWeather to update weather to a new setting, e.g. sun to rain
     - UpdateRoadFriction to update the road friction while running

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -23,6 +23,9 @@
     - Added initial speed support for pedestrians for OpenSCENARIO
     - Support for EnvironmentActions within Story (before only within Init). This allows changing weather conditions during scenario execution
     - Created example scenarios to illustrate usage of controllers and weather changes
+    - Reworked the handling of Catalogs to make it compliant to the 1.0 version (relative paths have to be relative to the scenario file)
+    - The RoadNetwork can be defined as global Parameter
+    - Fixed handling of relative positions with negative offset
 * Atomics:
     - Several new atomics to enable usage of OSC controllers
     - WeatherBehavior to simulate weather over time

--- a/Docs/openscenario_support.md
+++ b/Docs/openscenario_support.md
@@ -234,6 +234,16 @@ contains of submodules, which are not listed, the support status applies to all 
 <td>&#10060;</td>
 <td></td>
 <tr>
+<td><code>ActivateControllerAction</code></td>
+<td>&#10060;</td>
+<td>&#9989;</td>
+<td>Can be used to activate/deactive the CARLA autopilot</td>
+<tr>
+<td><code>ControllerAction</code></td>
+<td>&#9989;</td>
+<td>&#9989;</td>
+<td>AssignControllerAction is supported, but a Python module has to be provided for the controller implementation, and in OverrideControllerValueAction all values need to be 'False'</td>
+<tr>
 <td><code>TeleportAction</code></td>
 <td>&#9989;</td>
 <td>&#9989;</td>

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -168,7 +168,7 @@ class ScenarioRunner(object):
         """
         # Simulation still running and in synchronous mode?
         if self.manager is not None and self.manager.get_running_status() \
-                and self.world is not None and self.world.get_settings().synchronous_mode:
+                and self.world is not None and self._args.sync:
             # Reset to asynchronous mode
             settings = self.world.get_settings()
             settings.synchronous_mode = False
@@ -225,7 +225,10 @@ class ScenarioRunner(object):
                 self.ego_vehicles[i].set_transform(ego_vehicles[i].transform)
 
         # sync state
-        CarlaDataProvider.get_world().tick()
+        if CarlaDataProvider.is_sync_mode():
+            self.world.tick()
+        else:
+            self.world.wait_for_tick()
 
     def _analyze_scenario(self, config):
         """

--- a/srunner/examples/CatalogExample.xosc
+++ b/srunner/examples/CatalogExample.xosc
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <OpenSCENARIO>
-  <FileHeader revMajor="1" revMinor="0" date="2020-03-24" description="CARLA:PedestrianCrossing" author=""/>
+  <FileHeader revMajor="1" revMinor="0" date="2020-03-24T12:00:00" description="CARLA:PedestrianCrossing" author=""/>
   <CatalogLocations>
     <VehicleCatalog>
       <Directory path="./srunner/examples/catalogs/VehicleCatalog.xosc"/>
@@ -51,6 +51,25 @@
                 <WorldPosition x="170" y="55" z="0" h="3.14159265359"/>
               </Position>
             </TeleportAction>
+          </PrivateAction>
+          <PrivateAction>
+            <ControllerAction>
+              <AssignControllerAction>
+                <Controller name="HeroAgent">
+                  <Properties>
+                    <Property name="module" value="external_control"/>
+                  </Properties>
+                </Controller>
+              </AssignControllerAction>
+              <OverrideControllerValueAction>
+                <Throttle value="0" active="false"/>
+                <Brake value="0" active="false"/>
+                <Clutch value="0" active="false"/>
+                <ParkingBrake value="0" active="false"/>
+                <SteeringWheel value="0" active="false"/>
+                <Gear number="0" active="false"/>
+              </OverrideControllerValueAction>
+            </ControllerAction>
           </PrivateAction>
         </Private>
         <Private entityRef="vehicle">

--- a/srunner/examples/CatalogExample.xosc
+++ b/srunner/examples/CatalogExample.xosc
@@ -3,19 +3,19 @@
   <FileHeader revMajor="1" revMinor="0" date="2020-03-24T12:00:00" description="CARLA:PedestrianCrossing" author=""/>
   <CatalogLocations>
     <VehicleCatalog>
-      <Directory path="./srunner/examples/catalogs/VehicleCatalog.xosc"/>
+      <Directory path="catalogs"/>
     </VehicleCatalog>
     <PedestrianCatalog>
-      <Directory path="./srunner/examples/catalogs/PedestrianCatalog.xosc"/>
+      <Directory path="catalogs"/>
     </PedestrianCatalog>
     <MiscObjectCatalog>
-      <Directory path="./srunner/examples/catalogs/MiscObjectCatalog.xosc"/>
+      <Directory path="catalogs"/>
     </MiscObjectCatalog>
     <EnvironmentCatalog>
-      <Directory path="./srunner/examples/catalogs/EnvironmentCatalog.xosc"/>
+      <Directory path="catalogs"/>
     </EnvironmentCatalog>
     <ManeuverCatalog>
-      <Directory path="./srunner/examples/catalogs/ManeuverCatalog.xosc"/>
+      <Directory path="catalogs"/>
     </ManeuverCatalog>
   </CatalogLocations>
   <RoadNetwork>

--- a/srunner/examples/ChangingWeather.xosc
+++ b/srunner/examples/ChangingWeather.xosc
@@ -1,118 +1,137 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO>
-    <FileHeader revMajor="1" revMinor="0" date="2020-03-20" description="CARLA:ChangingWeatherExample" author="" />
-    <ParameterDeclarations/>
-    <CatalogLocations/>
-    <RoadNetwork>
-        <LogicFile filepath="Town01" />
-        <SceneGraphFile filepath="" />
-    </RoadNetwork>
-    <Entities>
-        <ScenarioObject name="hero">
-            <Vehicle name="vehicle.lincoln.mkz2017" vehicleCategory="car">
-                <ParameterDeclarations/>
-                <Performance maxSpeed="69.444" maxAcceleration="200" maxDeceleration="10.0"/>
-                <BoundingBox>
-                    <Center x="1.5" y="0.0" z="0.9" />
-                    <Dimensions width="2.1" length="4.5" height="1.8"/>
-                </BoundingBox>
-                <Axles>
-                    <FrontAxle maxSteering="0.5" wheelDiameter="0.6" trackWidth="1.8" positionX="3.1" positionZ="0.3" />
-                    <RearAxle maxSteering="0.0" wheelDiameter="0.6" trackWidth="1.8" positionX="0.0" positionZ="0.3" />
-                </Axles>
-                <Properties>
-                    <Property name="type" value="ego_vehicle" />
-                    <Property name="color" value="0,0,255" />
-                </Properties>
-            </Vehicle>
-        </ScenarioObject>
-    </Entities>
-    <Storyboard>
-        <Init>
-            <Actions>         
+  <FileHeader revMajor="1" revMinor="0" date="2020-03-20T12:00:00" description="CARLA:ChangingWeatherExample" author=""/>
+  <ParameterDeclarations/>
+  <CatalogLocations/>
+  <RoadNetwork>
+    <LogicFile filepath="Town01"/>
+    <SceneGraphFile filepath=""/>
+  </RoadNetwork>
+  <Entities>
+    <ScenarioObject name="hero">
+      <Vehicle name="vehicle.lincoln.mkz2017" vehicleCategory="car">
+        <ParameterDeclarations/>
+        <Performance maxSpeed="69.444" maxAcceleration="200" maxDeceleration="10.0"/>
+        <BoundingBox>
+          <Center x="1.5" y="0.0" z="0.9"/>
+          <Dimensions width="2.1" length="4.5" height="1.8"/>
+        </BoundingBox>
+        <Axles>
+          <FrontAxle maxSteering="0.5" wheelDiameter="0.6" trackWidth="1.8" positionX="3.1" positionZ="0.3"/>
+          <RearAxle maxSteering="0.0" wheelDiameter="0.6" trackWidth="1.8" positionX="0.0" positionZ="0.3"/>
+        </Axles>
+        <Properties>
+          <Property name="type" value="ego_vehicle"/>
+          <Property name="color" value="0,0,255"/>
+        </Properties>
+      </Vehicle>
+    </ScenarioObject>
+  </Entities>
+  <Storyboard>
+    <Init>
+      <Actions>
+        <GlobalAction>
+          <EnvironmentAction>
+            <Environment name="Environment1">
+              <TimeOfDay animation="true" dateTime="2020-01-01T12:00:00"/>
+              <Weather cloudState="free">
+                <Sun intensity="0.85" azimuth="0" elevation="1.31"/>
+                <Fog visualRange="100000.0"/>
+                <Precipitation precipitationType="dry" intensity="0.0"/>
+              </Weather>
+              <RoadCondition frictionScaleFactor="1.0"/>
+            </Environment>
+          </EnvironmentAction>
+        </GlobalAction>
+        <Private entityRef="hero">
+          <PrivateAction>
+            <TeleportAction>
+              <Position>
+                <LanePosition roadId="4" laneId="-1" offset="1.0" s="48.58"/>
+              </Position>
+            </TeleportAction>
+          </PrivateAction>
+          <PrivateAction>
+            <ControllerAction>
+              <AssignControllerAction>
+                <Controller name="HeroAgent">
+                  <Properties>
+                    <Property name="module" value="external_control"/>
+                  </Properties>
+                </Controller>
+              </AssignControllerAction>
+              <OverrideControllerValueAction>
+                <Throttle value="0" active="false"/>
+                <Brake value="0" active="false"/>
+                <Clutch value="0" active="false"/>
+                <ParkingBrake value="0" active="false"/>
+                <SteeringWheel value="0" active="false"/>
+                <Gear number="0" active="false"/>
+              </OverrideControllerValueAction>
+            </ControllerAction>
+          </PrivateAction>
+        </Private>
+      </Actions>
+    </Init>
+    <Story name="MyStory">
+      <Act name="Behavior">
+        <ManeuverGroup name="ManeuverSequence" maximumExecutionCount="1">
+          <Actors selectTriggeringEntities="false"/>
+          <Maneuver name="WeatherChange">
+            <Event name="WeatherChangeEvent" priority="overwrite">
+              <Action name="WeatherChangeAction">
                 <GlobalAction>
-                    <EnvironmentAction>
-                        <Environment name="Environment1">
-                            <TimeOfDay animation="true" dateTime="2020-01-01T12:00:00"/>
-                            <Weather cloudState="free">
-                                <Sun intensity="0.85" azimuth="0" elevation="1.31" />
-                                <Fog visualRange="100000.0" />
-                                <Precipitation precipitationType="dry" intensity="0.0" />
-                            </Weather>
-                            <RoadCondition frictionScaleFactor="1.0" />
-                        </Environment>
-                    </EnvironmentAction>
+                  <EnvironmentAction>
+                    <Environment name="Environment1">
+                      <TimeOfDay animation="true" dateTime="2020-01-01T22:00:00"/>
+                      <Weather cloudState="free">
+                        <Sun intensity="0.05" azimuth="0" elevation="1.31"/>
+                        <Fog visualRange="100000.0"/>
+                        <Precipitation precipitationType="rain" intensity="0.9"/>
+                      </Weather>
+                      <RoadCondition frictionScaleFactor="1.0"/>
+                    </Environment>
+                  </EnvironmentAction>
                 </GlobalAction>
-                <Private entityRef="hero">
-                    <PrivateAction>
-                        <TeleportAction>
-                            <Position>
-                                <LanePosition roadId="4" laneId="-1" offset="1.0" s="48.58" />
-                            </Position>
-                        </TeleportAction>
-                    </PrivateAction>
-                </Private>
-            </Actions>
-        </Init>
-        <Story name="MyStory">
-            <Act name="Behavior">
-                <ManeuverGroup name="ManeuverSequence" maximumExecutionCount="1">
-                    <Actors selectTriggeringEntities="false"/>
-                    <Maneuver name="WeatherChange">
-                        <Event name="WeatherChangeEvent" priority="overwrite">
-			                <Action name="WeatherChangeAction">
-			                <GlobalAction>
-			                    <EnvironmentAction>
-			                        <Environment name="Environment1">
-			                            <TimeOfDay animation="true" dateTime="2020-01-01T22:00:00"/>
-			                            <Weather cloudState="free">
-			                                <Sun intensity="0.05" azimuth="0" elevation="1.31" />
-			                                <Fog visualRange="100000.0" />
-			                                <Precipitation precipitationType="rain" intensity="0.9" />
-			                            </Weather>
-			                            <RoadCondition frictionScaleFactor="1.0" />
-			                        </Environment>
-			                    </EnvironmentAction>
-			                </GlobalAction>
-			                </Action>
-                            <StartTrigger>
-                                <ConditionGroup>
-                                    <Condition name="WeatherChangeStartTime" delay="0" conditionEdge="rising">
-                                        <ByValueCondition>
-                                            <SimulationTimeCondition value="20" rule="greaterThan" />
-                                        </ByValueCondition>
-                                    </Condition>
-                                </ConditionGroup>
-                            </StartTrigger>
-                        </Event>
-                    </Maneuver>
-                    <Maneuver name="DummyManeuver">
-                        <Event name="DummyManeuver" priority="overwrite">
-			                <Action name="DummyManeuver"/>
-                            <StartTrigger>
-                                <ConditionGroup>
-                                    <Condition name="DummyManeuverStartTime" delay="0" conditionEdge="rising">
-                                        <ByValueCondition>
-                                            <SimulationTimeCondition value="10000000" rule="greaterThan" />
-                                        </ByValueCondition>
-                                    </Condition>
-                                </ConditionGroup>
-                            </StartTrigger>
-                        </Event>
-                    </Maneuver>
-                </ManeuverGroup>
-                    <StartTrigger>
-                        <ConditionGroup>
-                            <Condition name="StartTime" delay="0" conditionEdge="rising">
-                                <ByValueCondition>
-                                    <SimulationTimeCondition value="5" rule="greaterThan" />
-                                </ByValueCondition>
-                            </Condition>
-                        </ConditionGroup>
-                    </StartTrigger>
-                    <StopTrigger/>
-            </Act>
-        </Story>
+              </Action>
+              <StartTrigger>
+                <ConditionGroup>
+                  <Condition name="WeatherChangeStartTime" delay="0" conditionEdge="rising">
+                    <ByValueCondition>
+                      <SimulationTimeCondition value="20" rule="greaterThan"/>
+                    </ByValueCondition>
+                  </Condition>
+                </ConditionGroup>
+              </StartTrigger>
+            </Event>
+          </Maneuver>
+          <Maneuver name="DummyManeuver">
+            <Event name="DummyManeuver" priority="overwrite">
+              <Action name="DummyManeuver"/>
+              <StartTrigger>
+                <ConditionGroup>
+                  <Condition name="DummyManeuverStartTime" delay="0" conditionEdge="rising">
+                    <ByValueCondition>
+                      <SimulationTimeCondition value="10000000" rule="greaterThan"/>
+                    </ByValueCondition>
+                  </Condition>
+                </ConditionGroup>
+              </StartTrigger>
+            </Event>
+          </Maneuver>
+        </ManeuverGroup>
+        <StartTrigger>
+          <ConditionGroup>
+            <Condition name="StartTime" delay="0" conditionEdge="rising">
+              <ByValueCondition>
+                <SimulationTimeCondition value="5" rule="greaterThan"/>
+              </ByValueCondition>
+            </Condition>
+          </ConditionGroup>
+        </StartTrigger>
         <StopTrigger/>
-    </Storyboard>
+      </Act>
+    </Story>
+    <StopTrigger/>
+  </Storyboard>
 </OpenSCENARIO>

--- a/srunner/examples/CyclistCrossing.xosc
+++ b/srunner/examples/CyclistCrossing.xosc
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <OpenSCENARIO>
-  <FileHeader revMajor="1" revMinor="0" date="2020-03-24" description="CARLA:CyclistCrossing" author=""/>
-  <ParameterDeclarations />
-  <CatalogLocations />
+  <FileHeader revMajor="1" revMinor="0" date="2020-03-24T12:00:00" description="CARLA:CyclistCrossing" author=""/>
+  <ParameterDeclarations/>
+  <CatalogLocations/>
   <RoadNetwork>
     <LogicFile filepath="Town01"/>
     <SceneGraphFile filepath=""/>
@@ -67,6 +67,25 @@
               </Position>
             </TeleportAction>
           </PrivateAction>
+          <PrivateAction>
+            <ControllerAction>
+              <AssignControllerAction>
+                <Controller name="HeroAgent">
+                  <Properties>
+                    <Property name="module" value="external_control"/>
+                  </Properties>
+                </Controller>
+              </AssignControllerAction>
+              <OverrideControllerValueAction>
+                <Throttle value="0" active="false"/>
+                <Brake value="0" active="false"/>
+                <Clutch value="0" active="false"/>
+                <ParkingBrake value="0" active="false"/>
+                <SteeringWheel value="0" active="false"/>
+                <Gear number="0" active="false"/>
+              </OverrideControllerValueAction>
+            </ControllerAction>
+          </PrivateAction>
         </Private>
         <Private entityRef="adversary">
           <PrivateAction>
@@ -75,6 +94,25 @@
                 <WorldPosition x="95.5" y="41" z="0.2" h="3.14159265359"/>
               </Position>
             </TeleportAction>
+          </PrivateAction>
+          <PrivateAction>
+            <ControllerAction>
+              <AssignControllerAction>
+                <Controller name="AdversaryAgent">
+                  <Properties>
+                    <Property name="module" value="vehicle_longitudinal_control"/>
+                  </Properties>
+                </Controller>
+              </AssignControllerAction>
+              <OverrideControllerValueAction>
+                <Throttle value="0" active="false"/>
+                <Brake value="0" active="false"/>
+                <Clutch value="0" active="false"/>
+                <ParkingBrake value="0" active="false"/>
+                <SteeringWheel value="0" active="false"/>
+                <Gear number="0" active="false"/>
+              </OverrideControllerValueAction>
+            </ControllerAction>
           </PrivateAction>
         </Private>
       </Actions>

--- a/srunner/examples/LaneChangeSimple.xosc
+++ b/srunner/examples/LaneChangeSimple.xosc
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <OpenSCENARIO>
-  <FileHeader revMajor="1" revMinor="0" date="2020-03-24" description="CARLA:LaneChangeSimple" author=""/>
-  <ParameterDeclarations />
-  <CatalogLocations />
+  <FileHeader revMajor="1" revMinor="0" date="2020-03-24T12:00:00" description="CARLA:LaneChangeSimple" author=""/>
+  <ParameterDeclarations/>
+  <CatalogLocations/>
   <RoadNetwork>
     <LogicFile filepath="Town04"/>
     <SceneGraphFile filepath=""/>
@@ -83,6 +83,25 @@
                 <WorldPosition x="-9.4" y="-152.8" z="0.5" h="1.57079632679"/>
               </Position>
             </TeleportAction>
+          </PrivateAction>
+          <PrivateAction>
+            <ControllerAction>
+              <AssignControllerAction>
+                <Controller name="HeroAgent">
+                  <Properties>
+                    <Property name="module" value="external_control"/>
+                  </Properties>
+                </Controller>
+              </AssignControllerAction>
+              <OverrideControllerValueAction>
+                <Throttle value="0" active="false"/>
+                <Brake value="0" active="false"/>
+                <Clutch value="0" active="false"/>
+                <ParkingBrake value="0" active="false"/>
+                <SteeringWheel value="0" active="false"/>
+                <Gear number="0" active="false"/>
+              </OverrideControllerValueAction>
+            </ControllerAction>
           </PrivateAction>
         </Private>
         <Private entityRef="adversary">

--- a/srunner/examples/OscControllerExample.xosc
+++ b/srunner/examples/OscControllerExample.xosc
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSCENARIO>
-  <FileHeader revMajor="1" revMinor="0" date="2020-03-20T12:00:00" description="CARLA:FollowLeadingVehicle" author=""/>
-  <ParameterDeclarations>
-    <ParameterDeclaration name="$leadingSpeed" parameterType="double" value="2.0"/>
-  </ParameterDeclarations>
+  <FileHeader revMajor="1" revMinor="0" date="2020-03-20T12:00:00" description="CARLA:ControllerExample" author=""/>
+  <ParameterDeclarations/>
   <CatalogLocations/>
   <RoadNetwork>
     <LogicFile filepath="Town01"/>
@@ -99,6 +97,36 @@
               </Position>
             </TeleportAction>
           </PrivateAction>
+          <PrivateAction>
+            <ControllerAction>
+              <AssignControllerAction>
+                <Controller name="AdversaryAgent">
+                  <Properties>
+                    <Property name="module" value="npc_vehicle_control"/>
+                    <Property name="an_unused_property" value="an_unused_value"/>
+                  </Properties>
+                </Controller>
+              </AssignControllerAction>
+              <OverrideControllerValueAction>
+                <Throttle value="0" active="false"/>
+                <Brake value="0" active="false"/>
+                <Clutch value="0" active="false"/>
+                <ParkingBrake value="0" active="false"/>
+                <SteeringWheel value="0" active="false"/>
+                <Gear number="0" active="false"/>
+              </OverrideControllerValueAction>
+            </ControllerAction>
+          </PrivateAction>
+          <PrivateAction>
+            <LongitudinalAction>
+              <SpeedAction>
+                <SpeedActionDynamics dynamicsShape="step" value="20" dynamicsDimension="distance"/>
+                <SpeedActionTarget>
+                  <AbsoluteTargetSpeed value="1"/>
+                </SpeedActionTarget>
+              </SpeedAction>
+            </LongitudinalAction>
+          </PrivateAction>
         </Private>
       </Actions>
     </Init>
@@ -114,9 +142,9 @@
                 <PrivateAction>
                   <LongitudinalAction>
                     <SpeedAction>
-                      <SpeedActionDynamics dynamicsShape="step" value="20" dynamicsDimension="distance"/>
+                      <SpeedActionDynamics dynamicsShape="step" value="10000" dynamicsDimension="distance"/>
                       <SpeedActionTarget>
-                        <AbsoluteTargetSpeed value="$leadingSpeed"/>
+                        <AbsoluteTargetSpeed value="10"/>
                       </SpeedActionTarget>
                     </SpeedAction>
                   </LongitudinalAction>
@@ -130,32 +158,9 @@
                         <EntityRef entityRef="hero"/>
                       </TriggeringEntities>
                       <EntityCondition>
-                        <RelativeDistanceCondition entityRef="adversary" relativeDistanceType="cartesianDistance" value="40.0" freespace="false" rule="lessThan"/>
+                        <RelativeDistanceCondition entityRef="adversary" relativeDistanceType="cartesianDistance" value="20.0" freespace="false" rule="lessThan"/>
                       </EntityCondition>
                     </ByEntityCondition>
-                  </Condition>
-                </ConditionGroup>
-              </StartTrigger>
-            </Event>
-            <Event name="LeadingVehicleWaits" priority="overwrite">
-              <Action name="LeadingVehicleWaits">
-                <PrivateAction>
-                  <LongitudinalAction>
-                    <SpeedAction>
-                      <SpeedActionDynamics dynamicsShape="step" value="10" dynamicsDimension="time"/>
-                      <SpeedActionTarget>
-                        <AbsoluteTargetSpeed value="0.0"/>
-                      </SpeedActionTarget>
-                    </SpeedAction>
-                  </LongitudinalAction>
-                </PrivateAction>
-              </Action>
-              <StartTrigger>
-                <ConditionGroup>
-                  <Condition name="AfterLeadingVehicleKeepsVelocity" delay="0" conditionEdge="rising">
-                    <ByValueCondition>
-                      <StoryboardElementStateCondition storyboardElementType="action" storyboardElementRef="LeadingVehicleKeepsVelocity" state="endTransition"/>
-                    </ByValueCondition>
                   </Condition>
                 </ConditionGroup>
               </StartTrigger>
@@ -189,7 +194,7 @@
                   <EntityRef entityRef="hero"/>
                 </TriggeringEntities>
                 <EntityCondition>
-                  <TraveledDistanceCondition value="200.0"/>
+                  <TraveledDistanceCondition value="20000.0"/>
                 </EntityCondition>
               </ByEntityCondition>
             </Condition>
@@ -197,44 +202,6 @@
         </StopTrigger>
       </Act>
     </Story>
-    <StopTrigger>
-      <ConditionGroup>
-        <Condition name="criteria_RunningStopTest" delay="0" conditionEdge="rising">
-          <ByValueCondition>
-            <ParameterCondition parameterRef="" value="" rule="lessThan"/>
-          </ByValueCondition>
-        </Condition>
-        <Condition name="criteria_RunningRedLightTest" delay="0" conditionEdge="rising">
-          <ByValueCondition>
-            <ParameterCondition parameterRef="" value="" rule="lessThan"/>
-          </ByValueCondition>
-        </Condition>
-        <Condition name="criteria_WrongLaneTest" delay="0" conditionEdge="rising">
-          <ByValueCondition>
-            <ParameterCondition parameterRef="" value="" rule="lessThan"/>
-          </ByValueCondition>
-        </Condition>
-        <Condition name="criteria_OnSidewalkTest" delay="0" conditionEdge="rising">
-          <ByValueCondition>
-            <ParameterCondition parameterRef="" value="" rule="lessThan"/>
-          </ByValueCondition>
-        </Condition>
-        <Condition name="criteria_KeepLaneTest" delay="0" conditionEdge="rising">
-          <ByValueCondition>
-            <ParameterCondition parameterRef="" value="" rule="lessThan"/>
-          </ByValueCondition>
-        </Condition>
-        <Condition name="criteria_CollisionTest" delay="0" conditionEdge="rising">
-          <ByValueCondition>
-            <ParameterCondition parameterRef="" value="" rule="lessThan"/>
-          </ByValueCondition>
-        </Condition>
-        <Condition name="criteria_DrivenDistanceTest" delay="0" conditionEdge="rising">
-          <ByValueCondition>
-            <ParameterCondition parameterRef="distance_success" value="100" rule="lessThan"/>
-          </ByValueCondition>
-        </Condition>
-      </ConditionGroup>
-    </StopTrigger>
+    <StopTrigger/>
   </Storyboard>
 </OpenSCENARIO>

--- a/srunner/examples/PedestrianCrossingFront.xosc
+++ b/srunner/examples/PedestrianCrossingFront.xosc
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <OpenSCENARIO>
-  <FileHeader revMajor="1" revMinor="0" date="2020-03-24" description="CARLA:PedestrianCrossing" author=""/>
-  <ParameterDeclarations />
-  <CatalogLocations />
+  <FileHeader revMajor="1" revMinor="0" date="2020-03-24T12:00:00" description="CARLA:PedestrianCrossing" author=""/>
+  <ParameterDeclarations/>
+  <CatalogLocations/>
   <RoadNetwork>
     <LogicFile filepath="Town01"/>
     <SceneGraphFile filepath=""/>
@@ -61,6 +61,25 @@
                 <WorldPosition x="150" y="55" z="0" h="3.14159265359"/>
               </Position>
             </TeleportAction>
+          </PrivateAction>
+          <PrivateAction>
+            <ControllerAction>
+              <AssignControllerAction>
+                <Controller name="HeroAgent">
+                  <Properties>
+                    <Property name="module" value="external_control"/>
+                  </Properties>
+                </Controller>
+              </AssignControllerAction>
+              <OverrideControllerValueAction>
+                <Throttle value="0" active="false"/>
+                <Brake value="0" active="false"/>
+                <Clutch value="0" active="false"/>
+                <ParkingBrake value="0" active="false"/>
+                <SteeringWheel value="0" active="false"/>
+                <Gear number="0" active="false"/>
+              </OverrideControllerValueAction>
+            </ControllerAction>
           </PrivateAction>
         </Private>
         <Private entityRef="adversary">
@@ -128,16 +147,6 @@
               </Action>
               <StartTrigger>
                 <ConditionGroup>
-                  <Condition name="StartCondition" delay="0" conditionEdge="rising">
-                    <ByEntityCondition>
-                      <TriggeringEntities triggeringEntitiesRule="any">
-                        <EntityRef entityRef="adversary"/>
-                      </TriggeringEntities>
-                      <EntityCondition>
-                        <StandStillCondition duration="1"/>
-                      </EntityCondition>
-                    </ByEntityCondition>
-                  </Condition>
                   <Condition name="AfterPedestrianWalks" delay="0" conditionEdge="rising">
                     <ByValueCondition>
                       <StoryboardElementStateCondition storyboardElementType="action" storyboardElementRef="PedestrianStartsWalking" state="completeState"/>

--- a/srunner/scenariomanager/actorcontrols/actor_control.py
+++ b/srunner/scenariomanager/actorcontrols/actor_control.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020 Intel Corporation
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+"""
+This module provides a wrapper to access/use user-defined actor
+controls for example to realize OpenSCENARIO controllers.
+
+At the moment only controls implemented in Python are supported.
+
+A user must not modify this module.
+"""
+
+import importlib
+import os
+import sys
+
+import carla
+
+from srunner.scenariomanager.actorcontrols.external_control import ExternalControl
+from srunner.scenariomanager.actorcontrols.npc_vehicle_control import NpcVehicleControl
+from srunner.scenariomanager.actorcontrols.pedestrian_control import PedestrianControl
+
+
+class ActorControl(object):
+
+    """
+    This class provides a wrapper (access mechanism) for user-defined actor controls.
+    The controllers are loaded via importlib. Therefore, the module name of the controller
+    has to match the control class name (e.g. my_own_control.py and MyOwnControl()).
+
+    At the moment only controllers implemented in Python are supported, or controllers that
+    are completely implemented outside of ScenarioRunner (see ExternalControl).
+
+    This wrapper is for example used to realize the OpenSCENARIO controllers.
+
+    Note:
+       If no controllers are provided in OpenSCENARIO a default controller for vehicles and
+       pedestrians is instantiated. For vehicles the NpcVehicleControl is used, for pedestrians
+       it is the PedestrianControl.
+
+    Args:
+        actor (carla.Actor): Actor that should be controlled by the controller.
+        control_py_module (string): Fully qualified path to the controller python module.
+        args (dict): A dictionary containing all parameters of the controller as (key, value) pairs.
+
+    Attributes:
+        control_instance: Instance of the user-defined controller.
+        _last_longitudinal_command: Timestamp of the last issued longitudinal control command (e.g. target speed).
+            Defaults to None. Used to avoid that 2 longitudinal control commands are issued at the same time.
+        _last_waypoint_command: Timestamp of the last issued waypoint control command.
+            Defaults to None. Used to avoid that 2 waypoint control commands are issued at the same time.
+    """
+
+    control_instance = None
+
+    _last_longitudinal_command = None
+    _last_waypoint_command = None
+
+    def __init__(self, actor, control_py_module, args):
+
+        # use importlib to import the control module
+        if not control_py_module:
+            if isinstance(actor, carla.Walker):
+                self.control_instance = PedestrianControl(actor)
+            elif isinstance(actor, carla.Vehicle):
+                self.control_instance = NpcVehicleControl(actor)
+            else:
+                # use ExternalControl for all misc objects to handle all actors the same way
+                self.control_instance = ExternalControl(actor)
+        else:
+            if ".py" in control_py_module:
+                module_name = os.path.basename(control_py_module).split('.')[0]
+                sys.path.append(os.path.dirname(control_py_module))
+                module_control = importlib.import_module(module_name)
+            else:
+                sys.path.append(os.path.dirname(__file__))
+                module_control = importlib.import_module(control_py_module)
+
+            control_class_name = module_control.__name__.title().replace('_', '')
+            self.control_instance = getattr(module_control, control_class_name)(actor, args)
+
+    def reset(self):
+        """
+        Reset the controller
+        """
+        self.control_instance.reset()
+
+    def update_target_speed(self, target_speed, start_time=None):
+        """
+        Update the actor's target speed.
+
+        Args:
+            target_speed (float): New target speed [m/s].
+            start_time (float): Start time of the new "maneuver" [s].
+        """
+        self.control_instance.update_target_speed(target_speed)
+        if start_time:
+            self._last_longitudinal_command = start_time
+
+    def update_waypoints(self, waypoints, start_time=None):
+        """
+        Update the actor's waypoints
+
+        Args:
+            waypoints (List of carla.Transform): List of new waypoints.
+            start_time (float): Start time of the new "maneuver" [s].
+        """
+        self.control_instance.update_waypoints(waypoints)
+        if start_time:
+            self._last_waypoint_command = start_time
+
+    def check_reached_waypoint_goal(self):
+        """
+        Check if the actor reached the end of the waypoint list
+
+        returns:
+            True if the end was reached, False otherwise.
+        """
+        return self.control_instance.check_reached_waypoint_goal()
+
+    def get_last_longitudinal_command(self):
+        """
+        Get timestamp of the last issued longitudinal control command (target_speed)
+
+        returns:
+            Timestamp of last longitudinal control command
+        """
+        return self._last_longitudinal_command
+
+    def get_last_waypoint_command(self):
+        """
+        Get timestamp of the last issued waypoint control command
+
+        returns:
+            Timestamp of last waypoint control command
+        """
+        return self._last_waypoint_command
+
+    def set_init_speed(self):
+        """
+        Update the actor's initial speed setting
+        """
+        self.control_instance.set_init_speed()
+
+    def run_step(self):
+        """
+        Execute on tick of the controller's control loop
+        """
+        self.control_instance.run_step()

--- a/srunner/scenariomanager/actorcontrols/basic_control.py
+++ b/srunner/scenariomanager/actorcontrols/basic_control.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020 Intel Corporation
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+"""
+This module provides the base class for user-defined actor
+controllers. All user-defined controls must be derived from
+this class.
+
+A user must not modify the module.
+"""
+
+
+class BasicControl(object):
+
+    """
+    This class is the base class for user-defined actor controllers
+    All user-defined agents must be derived from this class.
+
+    Args:
+        actor (carla.Actor): Actor that should be controlled by the controller.
+
+    Attributes:
+        _actor (carla.Actor): Controlled actor.
+            Defaults to None.
+        _target_speed (float): Logitudinal target speed of the controller.
+            Defaults to 0.
+        _init_speed (float): Initial longitudinal speed of the controller.
+            Defaults to 0.
+        _waypoints (list of carla.Transform): List of target waypoints the actor
+            should travel along. A waypoint here is of type carla.Transform!
+            Defaults to [].
+        _waypoints_updated (boolean):
+            Defaults to False.
+        _reached_goal (boolean):
+            Defaults to False.
+    """
+
+    _actor = None
+    _waypoints = []
+    _waypoints_updated = False
+    _target_speed = 0
+    _reached_goal = False
+    _init_speed = False
+
+    def __init__(self, actor):
+        """
+        Initialize the actor
+        """
+        self._actor = actor
+
+    def update_target_speed(self, speed):
+        """
+        Update the actor's target speed and set _init_speed to False.
+
+        Args:
+            speed (float): New target speed [m/s].
+        """
+        self._target_speed = speed
+        self._init_speed = False
+
+    def update_waypoints(self, waypoints, start_time=None):
+        """
+        Update the actor's waypoints
+
+        Args:
+            waypoints (List of carla.Transform): List of new waypoints.
+        """
+        self._waypoints = waypoints
+        self._waypoints_updated = True
+
+    def set_init_speed(self):
+        """
+        Set _init_speed to True
+        """
+        self._init_speed = True
+
+    def check_reached_waypoint_goal(self):
+        """
+        Check if the actor reached the end of the waypoint list
+
+        returns:
+            True if the end was reached, False otherwise.
+        """
+        return self._reached_goal
+
+    def reset(self):
+        """
+        Pure virtual function to reset the controller. This should be implemented
+        in the user-defined agent implementation.
+        """
+        raise NotImplementedError(
+            "This function must be re-implemented by the user-defined actor control."
+            "If this error becomes visible the class hierarchy is somehow broken")
+
+    def run_step(self):
+        """
+        Pure virtual function to run one step of the controllers's control loop.
+        This should be implemented in the user-defined agent implementation.
+        """
+        raise NotImplementedError(
+            "This function must be re-implemented by the user-defined actor control."
+            "If this error becomes visible the class hierarchy is somehow broken")

--- a/srunner/scenariomanager/actorcontrols/external_control.py
+++ b/srunner/scenariomanager/actorcontrols/external_control.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020 Intel Corporation
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+"""
+This module provides an example controller for actors, that use an external
+software for longitudinal and lateral control command calculation.
+Examples for external controls are: Autoware, CARLA manual_control, etc.
+
+This module is not intended for modification.
+"""
+
+from srunner.scenariomanager.actorcontrols.basic_control import BasicControl
+
+
+class ExternalControl(BasicControl):
+
+    """
+    Actor control class for actors, with externally implemented longitudinal and
+    lateral controlers (e.g. Autoware).
+
+    Args:
+        actor (carla.Actor): Actor that should be controlled by the agent.
+    """
+
+    def __init__(self, actor, args=None):
+        super(ExternalControl, self).__init__(actor)
+
+    def reset(self):
+        """
+        Reset the controller
+        """
+        if self._actor and self._actor.is_alive:
+            self._actor = None
+
+    def run_step(self):
+        """
+        The control loop and setting the actor controls is implemented externally.
+        """
+        pass

--- a/srunner/scenariomanager/actorcontrols/npc_vehicle_control.py
+++ b/srunner/scenariomanager/actorcontrols/npc_vehicle_control.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020 Intel Corporation
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+"""
+This module provides an example control for vehicles
+"""
+
+import math
+
+import carla
+from agents.navigation.basic_agent import LocalPlanner
+from agents.navigation.local_planner import RoadOption
+
+from srunner.scenariomanager.carla_data_provider import CarlaDataProvider
+from srunner.scenariomanager.actorcontrols.basic_control import BasicControl
+
+
+class NpcVehicleControl(BasicControl):
+
+    """
+    Controller class for vehicles derived from BasicControl.
+
+    The controller makes use of the LocalPlanner implemented in CARLA.
+
+    Args:
+        actor (carla.Actor): Vehicle actor that should be controlled.
+    """
+
+    _args = {'K_P': 1.0, 'K_D': 0.01, 'K_I': 0.0, 'dt': 0.05}
+
+    def __init__(self, actor, args=None):
+        super(NpcVehicleControl, self).__init__(actor)
+
+        self._local_planner = LocalPlanner(  # pylint: disable=undefined-variable
+            self._actor, opt_dict={
+                'target_speed': self._target_speed * 3.6,
+                    'lateral_control_dict': self._args})
+
+        if self._waypoints:
+            self._update_plan()
+
+    def _update_plan(self):
+        """
+        Update the plan (waypoint list) of the LocalPlanner
+        """
+        plan = []
+        for transform in self._waypoints:
+            waypoint = CarlaDataProvider.get_map().get_waypoint(
+                transform.location, project_to_road=True, lane_type=carla.LaneType.Any)
+            plan.append((waypoint, RoadOption.LANEFOLLOW))
+        self._local_planner.set_global_plan(plan)
+
+    def reset(self):
+        """
+        Reset the controller
+        """
+        if self._actor and self._actor.is_alive:
+            if self._local_planner:
+                self._local_planner.reset_vehicle()
+                self._local_planner = None
+            self._actor = None
+
+    def run_step(self):
+        """
+        Execute on tick of the controller's control loop
+
+        If _waypoints are provided, the vehicle moves towards the next waypoint
+        with the given _target_speed, until reaching the final waypoint. Upon reaching
+        the final waypoint, _reached_goal is set to True.
+
+        If _waypoints is empty, the vehicle moves in its current direction with
+        the given _target_speed.
+
+        If _init_speed is True, the control command is post-processed to ensure that
+        the initial actor velocity is maintained independent of physics.
+        """
+        self._reached_goal = False
+        self._local_planner.set_speed(self._target_speed * 3.6)
+
+        if self._waypoints_updated:
+            self._waypoints_updated = False
+            self._update_plan()
+
+        control = self._local_planner.run_step(debug=False)
+
+        # Check if the actor reached the end of the plan
+        # @TODO replace access to private _waypoints_queue with public getter
+        if not self._local_planner._waypoints_queue:  # pylint: disable=protected-access
+            self._reached_goal = True
+
+        self._actor.apply_control(control)
+
+        if self._init_speed:
+            current_speed = math.sqrt(self._actor.get_velocity().x**2 + self._actor.get_velocity().y**2)
+
+            if abs(self._target_speed - current_speed) > 3:
+                yaw = self._actor.get_transform().rotation.yaw * (math.pi / 180)
+                vx = math.cos(yaw) * self._target_speed
+                vy = math.sin(yaw) * self._target_speed
+                self._actor.set_velocity(carla.Vector3D(vx, vy, 0))

--- a/srunner/scenariomanager/actorcontrols/pedestrian_control.py
+++ b/srunner/scenariomanager/actorcontrols/pedestrian_control.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020 Intel Corporation
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+"""
+This module provides an example control for pedestrians
+"""
+
+import math
+
+import carla
+
+from srunner.scenariomanager.actorcontrols.basic_control import BasicControl
+
+
+class PedestrianControl(BasicControl):
+
+    """
+    Controller class for pedestrians derived from BasicControl.
+
+    Args:
+        actor (carla.Actor): Pedestrian actor that should be controlled.
+    """
+
+    def __init__(self, actor, args=None):
+        if not isinstance(actor, carla.Walker):
+            raise RuntimeError("PedestrianControl: The to be controlled actor is not a pedestrian")
+
+        super(PedestrianControl, self).__init__(actor)
+
+    def reset(self):
+        """
+        Reset the controller
+        """
+        if self._actor and self._actor.is_alive:
+            self._actor = None
+
+    def run_step(self):
+        """
+        Execute on tick of the controller's control loop
+
+        If _waypoints are provided, the pedestrian moves towards the next waypoint
+        with the given _target_speed, until reaching the final waypoint. Upon reaching
+        the final waypoint, _reached_goal is set to True.
+
+        If _waypoints is empty, the pedestrians moves in its current direction with
+        the given _target_speed.
+        """
+        if not self._actor or not self._actor.is_alive:
+            return
+
+        control = self._actor.get_control()
+        control.speed = self._target_speed
+
+        if self._waypoints:
+            self._reached_goal = False
+            location = self._waypoints[0].location
+            direction = location - self._actor.get_location()
+            direction_norm = math.sqrt(direction.x**2 + direction.y**2)
+            control.direction = direction / direction_norm
+            self._actor.apply_control(control)
+            if direction_norm < 1.0:
+                self._waypoints = self._waypoints[1:]
+                if not self._waypoints:
+                    self._reached_goal = True
+        else:
+            control.direction = self._actor.get_transform().rotation.get_forward_vector()
+            self._actor.apply_control(control)

--- a/srunner/scenariomanager/actorcontrols/vehicle_longitudinal_control.py
+++ b/srunner/scenariomanager/actorcontrols/vehicle_longitudinal_control.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020 Intel Corporation
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+"""
+This module provides an example longitudinal control for vehicles
+"""
+
+import math
+
+import carla
+
+from srunner.scenariomanager.actorcontrols.basic_control import BasicControl
+
+
+class VehicleLongitudinalControl(BasicControl):
+
+    """
+    Controller class for vehicles derived from BasicControl.
+
+    The controller only controls the throttle of a vehicle, but not the steering.
+
+    Args:
+        actor (carla.Actor): Vehicle actor that should be controlled.
+    """
+
+    def __init__(self, actor, args=None):
+        super(VehicleLongitudinalControl, self).__init__(actor)
+
+    def reset(self):
+        """
+        Reset the controller
+        """
+        if self._actor and self._actor.is_alive:
+            self._actor = None
+
+    def run_step(self):
+        """
+        Execute on tick of the controller's control loop
+
+        The control loop is very simplistic:
+            If the actor speed is below the _target_speed, set throttle to 1.0,
+            otherwise, set throttle to 0.0
+        Note, that this is a longitudinal controller only.
+
+        If _init_speed is True, the control command is post-processed to ensure that
+        the initial actor velocity is maintained independent of physics.
+        """
+
+        control = self._actor.get_control()
+
+        velocity = self._actor.get_velocity()
+        current_speed = math.sqrt(velocity.x**2 + velocity.y**2)
+        if current_speed < self._target_speed:
+            control.throttle = 1.0
+        else:
+            control.throttle = 0.0
+
+        self._actor.apply_control(control)
+
+        if self._init_speed:
+            if abs(self._target_speed - current_speed) > 3:
+                yaw = self._actor.get_transform().rotation.yaw * (math.pi / 180)
+                vx = math.cos(yaw) * self._target_speed
+                vy = math.sin(yaw) * self._target_speed
+                self._actor.set_velocity(carla.Vector3D(vx, vy, 0))

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -112,8 +112,6 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
         world = CarlaDataProvider._world
         if world is None:
             print("WARNING: CarlaDataProvider couldn't find the world")
-        else:
-            CarlaDataProvider._sync_flag = world.get_settings().synchronous_mode
 
     @staticmethod
     def get_velocity(actor):

--- a/srunner/scenariomanager/scenario_manager.py
+++ b/srunner/scenariomanager/scenario_manager.py
@@ -22,6 +22,7 @@ from srunner.scenariomanager.result_writer import ResultOutputProvider
 from srunner.scenariomanager.weather_sim import WeatherBehavior
 from srunner.scenariomanager.timer import GameTime, TimeOut
 from srunner.scenariomanager.watchdog import Watchdog
+from srunner.scenariomanager.scenarioatomics.atomic_behaviors import UpdateAllActorControls
 
 
 class Scenario(object):
@@ -66,6 +67,8 @@ class Scenario(object):
             self.scenario_tree.add_child(self.behavior)
         self.scenario_tree.add_child(self.timeout_node)
         self.scenario_tree.add_child(WeatherBehavior())
+        self.scenario_tree.add_child(UpdateAllActorControls())
+
         if criteria is not None:
             self.scenario_tree.add_child(self.criteria_tree)
         self.scenario_tree.setup(timeout=1)

--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -32,6 +32,7 @@ from agents.navigation.basic_agent import BasicAgent, LocalPlanner
 from agents.navigation.local_planner import RoadOption
 
 from srunner.scenariomanager.carla_data_provider import CarlaDataProvider
+from srunner.scenariomanager.actorcontrols.actor_control import ActorControl
 from srunner.scenariomanager.timer import GameTime
 from srunner.tools.scenario_helper import detect_lane_obstacle
 from srunner.tools.scenario_helper import generate_target_waypoint_list_multilane
@@ -163,7 +164,7 @@ class RunScript(AtomicBehavior):
         return new_status
 
 
-class UpdateWeather(AtomicBehavior):
+class ChangeWeather(AtomicBehavior):
 
     """
     Atomic to write a new weather configuration into the blackboard.
@@ -180,11 +181,11 @@ class UpdateWeather(AtomicBehavior):
         _weather (srunner.scenariomanager.weather_sim.Weather): Weather settings.
     """
 
-    def __init__(self, weather, name="UpdateWeather"):
+    def __init__(self, weather, name="ChangeWeather"):
         """
         Setup parameters
         """
-        super(UpdateWeather, self).__init__(name)
+        super(ChangeWeather, self).__init__(name)
         self._weather = weather
 
     def update(self):
@@ -192,13 +193,13 @@ class UpdateWeather(AtomicBehavior):
         Write weather into blackboard and exit with success
 
         returns:
-            SUCCESS
+            py_trees.common.Status.SUCCESS
         """
         py_trees.blackboard.Blackboard().set("CarlaWeather", self._weather, overwrite=True)
         return py_trees.common.Status.SUCCESS
 
 
-class UpdateRoadFriction(AtomicBehavior):
+class ChangeRoadFriction(AtomicBehavior):
 
     """
     Atomic to update the road friction in CARLA.
@@ -214,11 +215,11 @@ class UpdateRoadFriction(AtomicBehavior):
         _friction (float): Friction coefficient.
     """
 
-    def __init__(self, friction, name="UpdateRoadFriction"):
+    def __init__(self, friction, name="ChangeRoadFriction"):
         """
         Setup parameters
         """
-        super(UpdateRoadFriction, self).__init__(name)
+        super(ChangeRoadFriction, self).__init__(name)
         self._friction = friction
 
     def update(self):
@@ -226,7 +227,7 @@ class UpdateRoadFriction(AtomicBehavior):
         Update road friction. Spawns new friction blueprint and removes the old one, if existing.
 
         returns:
-            SUCCESS
+            py_trees.common.Status.SUCCESS
         """
 
         for actor in CarlaDataProvider.get_world().get_actors().filter('static.trigger.friction'):
@@ -245,6 +246,466 @@ class UpdateRoadFriction(AtomicBehavior):
         CarlaDataProvider.get_world().spawn_actor(friction_bp, transform)
 
         return py_trees.common.Status.SUCCESS
+
+
+class ChangeActorControl(AtomicBehavior):
+
+    """
+    Atomic to change the longitudinal/lateral control logic for an actor.
+    The (actor, controller) pair is stored inside the Blackboard.
+
+    The behavior immediately terminates with SUCCESS after the controller.
+
+    Args:
+        actor (carla.Actor): Actor that should be controlled by the controller.
+        control_py_module (string): Name of the python module containing the implementation
+            of the controller.
+        args (dictionary): Additional arguments for the controller.
+        name (string): Name of the behavior.
+            Defaults to 'ChangeActorControl'.
+
+    Attributes:
+        _actor_control (ActorControl): Instance of the actor control.
+    """
+
+    def __init__(self, actor, control_py_module, args, name="ChangeActorControl"):
+        """
+        Setup actor controller.
+        """
+        super(ChangeActorControl, self).__init__(name, actor)
+
+        self._actor_control = ActorControl(actor, control_py_module=control_py_module, args=args)
+
+    def update(self):
+        """
+        Write (actor, controler) pair to Blackboard, or update the controller
+        if actor already exists as a key.
+
+        returns:
+            py_trees.common.Status.SUCCESS
+        """
+
+        actor_dict = {}
+
+        try:
+            check_actors = operator.attrgetter("ActorsWithController")
+            actor_dict = check_actors(py_trees.blackboard.Blackboard())
+        except AttributeError:
+            pass
+
+        if actor_dict:
+            if self._actor.id in actor_dict:
+                actor_dict[self._actor.id].reset()
+
+        actor_dict[self._actor.id] = self._actor_control
+        py_trees.blackboard.Blackboard().set("ActorsWithController", actor_dict, overwrite=True)
+
+        return py_trees.common.Status.SUCCESS
+
+
+class UpdateAllActorControls(AtomicBehavior):
+
+    """
+    Atomic to update (run one control loop step) all actor controls.
+
+    The behavior is always in RUNNING state.
+
+    Args:
+        name (string): Name of the behavior.
+            Defaults to 'UpdateAllActorControls'.
+    """
+
+    def __init__(self, name="UpdateAllActorControls"):
+        """
+        Constructor
+        """
+        super(UpdateAllActorControls, self).__init__(name)
+
+    def update(self):
+        """
+        Execute one control loop step for all actor controls.
+
+        returns:
+            py_trees.common.Status.RUNNING
+        """
+
+        actor_dict = {}
+
+        try:
+            check_actors = operator.attrgetter("ActorsWithController")
+            actor_dict = check_actors(py_trees.blackboard.Blackboard())
+        except AttributeError:
+            pass
+
+        for actor_id in actor_dict:
+            actor_dict[actor_id].run_step()
+
+        return py_trees.common.Status.RUNNING
+
+
+class ChangeActorTargetSpeed(AtomicBehavior):
+
+    """
+    Atomic to change the target speed for an actor controller.
+
+    The behavior is in RUNNING state until the distance/duration
+    conditions are satisfied, or if a second ChangeActorTargetSpeed atomic
+    for the same actor is triggered.
+
+    Args:
+        actor (carla.Actor): Controlled actor.
+        target_speed (float): New target speed [m/s].
+        init_speed (boolean): Flag to indicate if the speed is the initial actor speed.
+            Defaults to False.
+        duration (float): Duration of the maneuver [s].
+            Defaults to None.
+        distance (float): Distance of the maneuver [m].
+            Defaults to None.
+        relative_actor (carla.Actor): If the target speed setting should be relative to another actor.
+            Defaults to None.
+        value (float): Offset, if the target speed setting should be relative to another actor.
+            Defaults to None.
+        value_type (string): Either 'Delta' or 'Factor' influencing how the offset to the reference actors
+            velocity is applied. Defaults to None.
+        continuous (boolean): If True, the atomic remains in RUNNING, independent of duration or distance.
+            Defaults to False.
+        name (string): Name of the behavior.
+            Defaults to 'ChangeActorTargetSpeed'.
+
+    Attributes:
+        _target_speed (float): New target speed [m/s].
+        _init_speed (boolean): Flag to indicate if the speed is the initial actor speed.
+            Defaults to False.
+        _start_time (float): Start time of the atomic [s].
+            Defaults to None.
+        _start_location (carla.Location): Start location of the atomic.
+            Defaults to None.
+        _duration (float): Duration of the maneuver [s].
+            Defaults to None.
+        _distance (float): Distance of the maneuver [m].
+            Defaults to None.
+        _relative_actor (carla.Actor): If the target speed setting should be relative to another actor.
+            Defaults to None.
+        _value (float): Offset, if the target speed setting should be relative to another actor.
+            Defaults to None.
+        _value_type (string): Either 'Delta' or 'Factor' influencing how the offset to the reference actors
+            velocity is applied. Defaults to None.
+        _continuous (boolean): If True, the atomic remains in RUNNING, independent of duration or distance.
+            Defaults to False.
+    """
+
+    def __init__(self, actor, target_speed, init_speed=False,
+                 duration=None, distance=None, relative_actor=None,
+                 value=None, value_type=None, continuous=False, name="ChangeActorTargetSpeed"):
+        """
+        Setup parameters
+        """
+        super(ChangeActorTargetSpeed, self).__init__(name, actor)
+
+        self._target_speed = target_speed
+        self._init_speed = init_speed
+
+        self._start_time = None
+        self._start_location = None
+
+        self._relative_actor = relative_actor
+        self._value = value
+        self._value_type = value_type
+        self._continuous = continuous
+        self._duration = duration
+        self._distance = distance
+
+    def initialise(self):
+        """
+        Set initial parameters such as _start_time and _start_location,
+        and get (actor, controller) pair from Blackboard.
+
+        May throw if actor is not available as key for the ActorsWithController
+        dictionary from Blackboard.
+        """
+        actor_dict = {}
+
+        try:
+            check_actors = operator.attrgetter("ActorsWithController")
+            actor_dict = check_actors(py_trees.blackboard.Blackboard())
+        except AttributeError:
+            pass
+
+        if not actor_dict or not self._actor.id in actor_dict:
+            raise RuntimeError("Actor not found in ActorsWithController BlackBoard")
+
+        self._start_time = GameTime.get_time()
+        self._start_location = CarlaDataProvider.get_location(self._actor)
+
+        actor_dict[self._actor.id].update_target_speed(self._target_speed, start_time=self._start_time)
+
+        if self._init_speed:
+            actor_dict[self._actor.id].set_init_speed()
+
+        super(ChangeActorTargetSpeed, self).initialise()
+
+    def update(self):
+        """
+        Check the actor's current state and update target speed, if it is relative to another actor.
+
+        returns:
+            py_trees.common.Status.SUCCESS, if the duration or distance driven exceeded limits
+                                            if another ChangeActorTargetSpeed atomic for the same actor was triggered.
+            py_trees.common.Status.FAILURE, if the actor is not found in ActorsWithController Blackboard dictionary.
+            py_trees.common.Status.FAILURE, else.
+        """
+        try:
+            check_actors = operator.attrgetter("ActorsWithController")
+            actor_dict = check_actors(py_trees.blackboard.Blackboard())
+        except AttributeError:
+            pass
+
+        if not actor_dict or not self._actor.id in actor_dict:
+            return py_trees.common.Status.FAILURE
+
+        if actor_dict[self._actor.id].get_last_longitudinal_command() != self._start_time:
+            return py_trees.common.Status.SUCCESS
+
+        new_status = py_trees.common.Status.RUNNING
+
+        if self._relative_actor:
+            relative_velocity = CarlaDataProvider.get_velocity(self._relative_actor)
+
+            # get target velocity
+            if self._value_type == 'delta':
+                actor_dict[self._actor.id].update_target_speed(relative_velocity + self._value)
+            elif self._value_type == 'factor':
+                actor_dict[self._actor.id].update_target_speed(relative_velocity * self._value)
+            else:
+                print('self._value_type must be delta or factor')
+
+        # check duration and driven_distance
+        if not self._continuous:
+            if (self._duration is not None) and (GameTime.get_time() - self._start_time > self._duration):
+                new_status = py_trees.common.Status.SUCCESS
+
+            driven_distance = CarlaDataProvider.get_location(self._actor).distance(self._start_location)
+            if (self._distance is not None) and (driven_distance > self._distance):
+                new_status = py_trees.common.Status.SUCCESS
+
+        if self._distance is None and self._duration is None:
+            new_status = py_trees.common.Status.SUCCESS
+
+        return new_status
+
+
+class ChangeActorWaypoints(AtomicBehavior):
+
+    """
+    Atomic to change the waypoints for an actor controller.
+
+    The behavior is in RUNNING state until the last waypoint is reached,
+    or if a second ChangeActorWaypoints atomic for the same actor is triggered.
+
+    Args:
+        actor (carla.Actor): Controlled actor.
+        waypoints (List of carla.Transform): List of waypoints (CARLA transforms).
+        name (string): Name of the behavior.
+            Defaults to 'ChangeActorWaypoints'.
+
+    Attributes:
+        _waypoints (List of carla.Transform): List of waypoints (CARLA transforms).
+        _start_time (float): Start time of the atomic [s].
+            Defaults to None.
+    """
+
+    def __init__(self, actor, waypoints, name="ChangeActorWaypoints"):
+        """
+        Setup parameters
+        """
+        super(ChangeActorWaypoints, self).__init__(name, actor)
+
+        self._waypoints = waypoints
+        self._start_time = None
+
+    def initialise(self):
+        """
+        Set _start_time and get (actor, controller) pair from Blackboard.
+
+        Set waypoint list for actor controller.
+
+        May throw if actor is not available as key for the ActorsWithController
+        dictionary from Blackboard.
+        """
+        actor_dict = {}
+
+        try:
+            check_actors = operator.attrgetter("ActorsWithController")
+            actor_dict = check_actors(py_trees.blackboard.Blackboard())
+        except AttributeError:
+            pass
+
+        if not actor_dict or not self._actor.id in actor_dict:
+            raise RuntimeError("Actor not found in ActorsWithController BlackBoard")
+
+        self._start_time = GameTime.get_time()
+
+        actor_dict[self._actor.id].update_waypoints(self._waypoints, start_time=self._start_time)
+
+        super(ChangeActorWaypoints, self).initialise()
+
+    def update(self):
+        """
+        Check the actor's state along the waypoint route.
+
+        returns:
+            py_trees.common.Status.SUCCESS, if the final waypoint was reached, or
+                                            if another ChangeActorWaypoints atomic for the same actor was triggered.
+            py_trees.common.Status.FAILURE, if the actor is not found in ActorsWithController Blackboard dictionary.
+            py_trees.common.Status.FAILURE, else.
+        """
+        try:
+            check_actors = operator.attrgetter("ActorsWithController")
+            actor_dict = check_actors(py_trees.blackboard.Blackboard())
+        except AttributeError:
+            pass
+
+        if not actor_dict or not self._actor.id in actor_dict:
+            return py_trees.common.Status.FAILURE
+
+        if actor_dict[self._actor.id].get_last_waypoint_command() != self._start_time:
+            return py_trees.common.Status.SUCCESS
+
+        new_status = py_trees.common.Status.RUNNING
+
+        if actor_dict[self._actor.id].check_reached_waypoint_goal():
+            new_status = py_trees.common.Status.SUCCESS
+
+        return new_status
+
+
+class ChangeActorLateralMotion(AtomicBehavior):
+
+    """
+    Atomic to change the waypoints for an actor controller.
+
+    The behavior is in RUNNING state until the driven distance exceeds
+    distance_lane_change, or if a second ChangeActorLateralMotion atomic
+    for the same actor is triggered.
+
+    Args:
+        actor (carla.Actor): Controlled actor.
+        direction (string): Lane change direction ('left' or 'right').
+            Defaults to 'left'.
+        distance_lane_change (float): Distance of the lance change [meters].
+            Defaults to 25.
+        name (string): Name of the behavior.
+            Defaults to 'ChangeActorLateralMotion'.
+
+    Attributes:
+        _waypoints (List of carla.Transform): List of waypoints representing the lane change (CARLA transforms).
+        _direction (string): Lane change direction ('left' or 'right').
+        _distance_same_lane (float): Distance on the same lane before the lane change starts [meters]
+            Constant to 5.
+        _distance_other_lane (float): Max. distance on the target lane after the lance change [meters]
+            Constant to 100.
+        _distance_lane_change (float): Max. total distance of the lane change [meters].
+        _pos_before_lane_change: carla.Location of the actor before the lane change.
+            Defaults to None.
+        _target_lane_id (int): Id of the target lane
+            Defaults to None.
+        _start_time (float): Start time of the atomic [s].
+            Defaults to None.
+    """
+
+    def __init__(self, actor, direction='left', distance_lane_change=25, name="ChangeActorLateralMotion"):
+        """
+        Setup parameters
+        """
+        super(ChangeActorLateralMotion, self).__init__(name, actor)
+
+        self._waypoints = []
+        self._direction = direction
+        self._distance_same_lane = 5
+        self._distance_other_lane = 100
+        self._distance_lane_change = distance_lane_change
+        self._pos_before_lane_change = None
+        self._target_lane_id = None
+
+        self._start_time = None
+
+    def initialise(self):
+        """
+        Set _start_time and get (actor, controller) pair from Blackboard.
+
+        Generate a waypoint list (route) which representes the lane change. Set
+        this waypoint list for the actor controller.
+
+        May throw if actor is not available as key for the ActorsWithController
+        dictionary from Blackboard.
+        """
+        actor_dict = {}
+
+        try:
+            check_actors = operator.attrgetter("ActorsWithController")
+            actor_dict = check_actors(py_trees.blackboard.Blackboard())
+        except AttributeError:
+            pass
+
+        if not actor_dict or not self._actor.id in actor_dict:
+            raise RuntimeError("Actor not found in ActorsWithController BlackBoard")
+
+        self._start_time = GameTime.get_time()
+
+        # get start position
+        position_actor = CarlaDataProvider.get_map().get_waypoint(CarlaDataProvider.get_location(self._actor))
+
+        # calculate plan with scenario_helper function
+        plan, self._target_lane_id = generate_target_waypoint_list_multilane(
+            position_actor, self._direction, self._distance_same_lane,
+            self._distance_other_lane, self._distance_lane_change, check='false')
+
+        for elem in plan:
+            self._waypoints.append(elem[0].transform)
+
+        actor_dict[self._actor.id].update_waypoints(self._waypoints, start_time=self._start_time)
+
+        super(ChangeActorLateralMotion, self).initialise()
+
+    def update(self):
+        """
+        Check the actor's current state and if the lane change was completed
+
+        returns:
+            py_trees.common.Status.SUCCESS, if lane change was successful, or
+                                            if another ChangeActorLateralMotion atomic for the same actor was triggered.
+            py_trees.common.Status.FAILURE, if the actor is not found in ActorsWithController Blackboard dictionary.
+            py_trees.common.Status.FAILURE, else.
+        """
+        try:
+            check_actors = operator.attrgetter("ActorsWithController")
+            actor_dict = check_actors(py_trees.blackboard.Blackboard())
+        except AttributeError:
+            pass
+
+        if not actor_dict or not self._actor.id in actor_dict:
+            return py_trees.common.Status.FAILURE
+
+        if actor_dict[self._actor.id].get_last_waypoint_command() != self._start_time:
+            return py_trees.common.Status.SUCCESS
+
+        new_status = py_trees.common.Status.RUNNING
+
+        current_position_actor = CarlaDataProvider.get_map().get_waypoint(self._actor.get_location())
+        current_lane_id = current_position_actor.lane_id
+
+        if current_lane_id == self._target_lane_id:
+            # driving on new lane
+            distance = current_position_actor.transform.location.distance(self._pos_before_lane_change)
+
+            if distance > self._distance_other_lane:
+                # long enough distance on new lane --> SUCCESS
+                new_status = py_trees.common.Status.SUCCESS
+        else:
+            # no lane change yet
+            self._pos_before_lane_change = current_position_actor.transform.location
+
+        return new_status
 
 
 class ActorTransformSetterToOSCPosition(AtomicBehavior):
@@ -301,89 +762,6 @@ class ActorTransformSetterToOSCPosition(AtomicBehavior):
         if calculate_distance(self._actor.get_location(), self._osc_transform.location) < 1.0:
             if self._physics:
                 self._actor.set_simulate_physics(enabled=True)
-            new_status = py_trees.common.Status.SUCCESS
-
-        return new_status
-
-
-class SetRelativeOSCVelocity(AtomicBehavior):
-
-    """
-    OpenSCENARIO atomic
-    This class contains an atomic behavior to set a relative velocity of an OpenSCENARIO actor.
-
-    Important parameters:
-    - actor: CARLA actor to execute the behavior
-    - relative_actor: Relative CARLA actor for relative_velocity
-    - value: offset or factor for relative_velocity
-    - value_type: Must be delta or factor
-    - continuous: Boolean value, not considered
-    - duration[optional]: Maximum duration in seconds
-    - distance[optional]: Maximum distance in meters
-
-    The behavior terminates successfully after driven distance is reached or maximum duration
-    passed by. There is no check whether the target velocity is reached.
-    If duration and distance are both set to None, then the behavior will not terminate.
-    """
-
-    def __init__(self, actor, relative_actor, value, value_type, continuous,
-                 duration=None, distance=None, name="SetRelativeOSCVelocity"):
-        """
-        Setup parameters
-        """
-        super(SetRelativeOSCVelocity, self).__init__(name, actor)
-        self._relative_actor = relative_actor
-        self._value = value
-        self._value_type = value_type
-        self._continuous = continuous
-        self._duration = duration
-        self._distance = distance
-
-        self._start_time = None
-        self._start_location = None
-
-        self._control, self._type = get_actor_control(actor)
-
-    def initialise(self):
-        """
-        Set initial start values for time and location
-        """
-        self._start_time = GameTime.get_time()
-        self._start_location = CarlaDataProvider.get_location(self._actor)
-        super(SetRelativeOSCVelocity, self).initialise()
-
-    def update(self):
-        """
-        Set speed value and check termination conditions
-        """
-        new_status = py_trees.common.Status.RUNNING
-
-        actor_velocity = CarlaDataProvider.get_velocity(self._actor)
-        relative_velocity = CarlaDataProvider.get_velocity(self._relative_actor)
-
-        # get target velocity
-        if self._value_type == 'delta':
-            target_velocity = relative_velocity + self._value
-        elif self._value_type == 'factor':
-            target_velocity = relative_velocity * self._value
-        else:
-            print('self._value_type must be delta or factor')
-
-        # set target velocity
-        if actor_velocity < target_velocity:
-            self._control.throttle = 1.0
-            self._control.brake = 0.0
-        else:
-            self._control.throttle = 0.0
-            self._control.brake = 1.0
-        self._actor.apply_control(self._control)
-
-        # check duration and driven_distance
-        if (self._duration is not None) and (GameTime.get_time() - self._start_time > self._duration):
-            new_status = py_trees.common.Status.SUCCESS
-
-        driven_distance = CarlaDataProvider.get_location(self._actor).distance(self._start_location)
-        if (self._distance is not None) and (driven_distance > self._distance):
             new_status = py_trees.common.Status.SUCCESS
 
         return new_status
@@ -1256,60 +1634,6 @@ class LaneChange(WaypointFollower):
             self._pos_before_lane_change = current_position_actor.transform.location
 
         return status
-
-
-class SetOSCInitSpeed(WaypointFollower):
-
-    """
-    OpenSCENARIO atomic
-    This class inherits from the class WaypointFollower.
-    This class contains an atomic behavior to set the init_speed of an OpenSCENARIO actor.
-
-    Important parameters:
-    - actor: CARLA actor to execute the behavior
-    - init_speed: initial actor speed when scenario starts, in m/s
-
-    Termination of behavior with blackboard variable which is set in
-    super(classname, self).initialise() of all other behavioral atomics.
-    """
-
-    def __init__(self, actor, init_speed=10, name='SetOSCInitSpeed'):
-
-        self._init_speed = init_speed
-        self._terminate = None
-
-        super(SetOSCInitSpeed, self).__init__(actor, target_speed=init_speed, name=name)
-
-    def initialise(self):
-        """
-        Calculate the init_velocity and set blackboard variable
-        terminate_init_speed_actor_ID to False to stop termination of behavior
-        """
-        super(SetOSCInitSpeed, self).initialise()
-
-        transform = self._actor.get_transform()
-        yaw = transform.rotation.yaw * (math.pi / 180)
-
-        vx = math.cos(yaw) * self._init_speed
-        vy = math.sin(yaw) * self._init_speed
-        self._actor.set_velocity(carla.Vector3D(vx, vy, 0))
-
-    def update(self):
-        """
-        Run local planner and calculate a new velocity if the deviation from target_speed
-        is greater than 3m/s. Check whether the SetOSCInitSpeed behavior should terminate by
-        checking the corresponding blackboard variable.
-        """
-        new_status = super(SetOSCInitSpeed, self).update()
-
-        # set velocity, workaround because local planner doesn't hold velocity
-        if abs(self._init_speed - CarlaDataProvider.get_velocity(self._actor)) > 3:
-            yaw = CarlaDataProvider.get_transform(self._actor).rotation.yaw * (math.pi / 180)
-            vx = math.cos(yaw) * self._init_speed
-            vy = math.sin(yaw) * self._init_speed
-            self._actor.set_velocity(carla.Vector3D(vx, vy, 0))
-
-        return new_status
 
 
 class SetInitSpeed(AtomicBehavior):

--- a/srunner/scenarios/open_scenario.py
+++ b/srunner/scenarios/open_scenario.py
@@ -221,10 +221,6 @@ class OpenScenario(BasicScenario):
 
                     controller_atomic = None
 
-                    # print("we are here",actions)
-                    # for child in actions:
-                    #    print({x.tag for x in actions.findall(child.tag+"/*")})
-
                     for private in self.config.init.iter("Private"):
                         if private.attrib.get('entityRef', None) == actor.rolename:
                             for private_action in private.iter("PrivateAction"):

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -22,15 +22,14 @@ from srunner.scenariomanager.weather_sim import Weather
 from srunner.scenariomanager.scenarioatomics.atomic_behaviors import (TrafficLightStateSetter,
                                                                       ActorTransformSetterToOSCPosition,
                                                                       AccelerateToVelocity,
-                                                                      ChangeAutoPilot,
-                                                                      KeepVelocity,
-                                                                      LaneChange,
                                                                       RunScript,
-                                                                      SetRelativeOSCVelocity,
-                                                                      UpdateWeather,
-                                                                      UpdateRoadFriction,
-                                                                      Idle,
-                                                                      WaypointFollower)
+                                                                      ChangeWeather,
+                                                                      ChangeRoadFriction,
+                                                                      ChangeActorTargetSpeed,
+                                                                      ChangeActorControl,
+                                                                      ChangeActorWaypoints,
+                                                                      ChangeActorLateralMotion,
+                                                                      Idle)
 # pylint: disable=unused-import
 # For the following includes the pylint check is disabled, as these are accessed via globals()
 from srunner.scenariomanager.scenarioatomics.atomic_criteria import (CollisionTest,
@@ -154,6 +153,37 @@ class OpenScenarioParser(object):
         dtime = datetime.datetime.strptime(time, "%Y-%m-%dT%H:%M:%S")
 
         return Weather(carla_weather, dtime, weather_animation)
+
+    @staticmethod
+    def get_controller(xml_tree, catalogs):
+        """
+        Extract the object controller from the OSC XML or a catalog
+
+        Args:
+            xml_tree: Containing the controller information,
+                or the reference to the catalog it is defined in.
+            catalogs: XML Catalogs that could contain the controller definition
+
+        returns:
+           module: Python module containing the controller implementation
+           args: Dictonary with (key, value) parameters for the controller
+        """
+
+        assign_action = xml_tree.find('AssignControllerAction')
+        module = None
+        args = {}
+        for prop in assign_action.find('Controller').find('Properties'):
+            if prop.attrib.get('name') == "module":
+                module = prop.attrib.get('value')
+            else:
+                args[prop.attrib.get('name')] = prop.attrib.get('value')
+
+        override_action = xml_tree.find('OverrideControllerValueAction')
+        for child in override_action:
+            if strtobool(child.attrib.get('active')):
+                raise NotImplementedError("Controller override actions are not yet supported")
+
+        return module, args
 
     @staticmethod
     def convert_position_to_transform(position, actor_list=None):
@@ -544,9 +574,9 @@ class OpenScenarioParser(object):
                 else:
                     raise NotImplementedError("TrafficLights can only be influenced via TrafficSignalStateAction")
             elif global_action.find('EnvironmentAction') is not None:
-                weather_behavior = UpdateWeather(
+                weather_behavior = ChangeWeather(
                     OpenScenarioParser.get_weather_from_env_action(global_action, catalogs))
-                friction_behavior = UpdateRoadFriction(
+                friction_behavior = ChangeRoadFriction(
                     OpenScenarioParser.get_friction_from_env_action(global_action, catalogs))
 
                 env_behavior = py_trees.composites.Parallel(
@@ -588,11 +618,14 @@ class OpenScenarioParser(object):
                     if long_maneuver.find("SpeedActionTarget").find("AbsoluteTargetSpeed") is not None:
                         target_speed = float(long_maneuver.find("SpeedActionTarget").find(
                             "AbsoluteTargetSpeed").attrib.get('value', 0))
-                        atomic = KeepVelocity(actor,
-                                              target_speed,
-                                              distance=distance,
-                                              duration=duration,
-                                              name=maneuver_name)
+                        # atomic = KeepVelocity(actor,
+                        #                      target_speed,
+                        #                      distance=distance,
+                        #                      duration=duration,
+                        #                      name=maneuver_name)
+
+                        atomic = ChangeActorTargetSpeed(
+                            actor, target_speed, distance=distance, duration=duration, name=maneuver_name)
 
                     # relative velocity to given actor
                     if long_maneuver.find("SpeedActionTarget").find("RelativeTargetSpeed") is not None:
@@ -605,13 +638,16 @@ class OpenScenarioParser(object):
                         for traffic_actor in CarlaDataProvider.get_world().get_actors():
                             if 'role_name' in traffic_actor.attributes and traffic_actor.attributes['role_name'] == obj:
                                 obj_actor = traffic_actor
-                        atomic = SetRelativeOSCVelocity(actor,
-                                                        obj_actor,
-                                                        value,
-                                                        value_type,
-                                                        continuous,
-                                                        duration,
-                                                        distance)
+
+                        atomic = ChangeActorTargetSpeed(actor,
+                                                        target_speed,
+                                                        relative_actor=obj_actor,
+                                                        value=value,
+                                                        value_type=value_type,
+                                                        continuous=continuous,
+                                                        distance=distance,
+                                                        duration=duration,
+                                                        name=maneuver_name)
 
                 elif private_action.find('LongitudinalDistanceAction') is not None:
                     raise NotImplementedError("Longitudinal distance actions are not yet supported")
@@ -635,11 +671,10 @@ class OpenScenarioParser(object):
                     else:
                         duration = float(
                             lat_maneuver.find("LaneChangeActionDynamics").attrib.get('value', float("inf")))
-                    atomic = LaneChange(actor,
-                                        None,
-                                        direction="left" if target_lane_rel < 0 else "right",
-                                        distance_lane_change=distance,
-                                        name=maneuver_name)
+                    atomic = ChangeActorLateralMotion(actor,
+                                                      direction="left" if target_lane_rel < 0 else "right",
+                                                      distance_lane_change=distance,
+                                                      name=maneuver_name)
                 else:
                     raise AttributeError("Unknown lateral action")
             elif private_action.find('VisibilityAction') is not None:
@@ -647,32 +682,26 @@ class OpenScenarioParser(object):
             elif private_action.find('SynchronizeAction') is not None:
                 raise NotImplementedError("Synchronization actions are not yet supported")
             elif private_action.find('ActivateControllerAction') is not None:
-                private_action = private_action.find('ActivateControllerAction')
-                activate = strtobool(private_action.attrib.get('longitudinal'))
-                atomic = ChangeAutoPilot(actor, activate, name=maneuver_name)
+                raise NotImplementedError("ActivateControllerAction actions are not yet supported")
             elif private_action.find('ControllerAction') is not None:
-                raise NotImplementedError("Controller actions are not yet supported")
+                controller_action = private_action.find('ControllerAction')
+                module, args = OpenScenarioParser.get_controller(controller_action, catalogs)
+                atomic = ChangeActorControl(actor, control_py_module=module, args=args)
             elif private_action.find('TeleportAction') is not None:
                 position = private_action.find('TeleportAction')
                 atomic = ActorTransformSetterToOSCPosition(actor, position, name=maneuver_name)
             elif private_action.find('RoutingAction') is not None:
-                target_speed = 5.0
                 private_action = private_action.find('RoutingAction')
                 if private_action.find('AssignRouteAction') is not None:
                     private_action = private_action.find('AssignRouteAction')
                     if private_action.find('Route') is not None:
                         route = private_action.find('Route')
-                        plan = []
-                        if route.find('ParameterDeclarations') is not None:
-                            if route.find('ParameterDeclarations').find('Parameter') is not None:
-                                parameter = route.find('ParameterDeclarations').find('Parameter')
-                                if parameter.attrib.get('name') == "Speed":
-                                    target_speed = float(parameter.attrib.get('value', 5.0))
+                        waypoints = []
                         for waypoint in route.iter('Waypoint'):
                             position = waypoint.find('Position')
                             transform = OpenScenarioParser.convert_position_to_transform(position)
-                            plan.append(transform.location)
-                        atomic = WaypointFollower(actor, target_speed=target_speed, plan=plan, name=maneuver_name)
+                            waypoints.append(transform)
+                        atomic = ChangeActorWaypoints(actor, waypoints=waypoints, name=maneuver_name)
                     elif private_action.find('CatalogReference') is not None:
                         raise NotImplementedError("CatalogReference private actions are not yet supported")
                     else:
@@ -687,7 +716,7 @@ class OpenScenarioParser(object):
                 raise AttributeError("Unknown private action")
 
         else:
-            if action:
+            if list(action):
                 raise AttributeError("Unknown action: {}".format(maneuver_name))
             else:
                 return Idle(duration=0, name=maneuver_name)

--- a/srunner/utilities/code_check_and_formatting.sh
+++ b/srunner/utilities/code_check_and_formatting.sh
@@ -2,6 +2,7 @@
 
 autopep8 scenario_runner.py --in-place --max-line-length=120
 autopep8 srunner/scenariomanager/*.py --in-place --max-line-length=120
+autopep8 srunner/scenariomanager/actorcontrols/*.py --in-place --max-line-length=120
 autopep8 srunner/scenariomanager/scenarioatomics/*.py --in-place --max-line-length=120
 autopep8 srunner/scenarios/*.py --in-place --max-line-length=120
 autopep8 srunner/autoagents/*.py --in-place --max-line-length=120


### PR DESCRIPTION
#### Description
Added controller support for OSC
- Controllers are implemented in srunner.scenariomanager.actorcontrols
- Provided several example controllers for vehicles and pedestrians
  * NpcVehicleControl using CARLA LocalPlanner
  * PedestrianControl
  * VehicleLongitudinalControl only modifying throttle
  * ExternalControl to allow using manual_control.py
- Extended scenario atomics to handle new controls
  * ChangeActorControl: Change actor controller
  * ChangeActorTargetSpeed: Change target speed (longitudinal control)
  * ChangeActorWaypoints: Change waypoints
  * ChangeActorLateralMotion: Change lateral control
  * UpdateAllActorControls: Execute one control loop step for all actors
- Not yet supported:
  * Activation/Deactivation of a controller

Updated synchronous mode handling to resolve conflicts with multiple
CARLA clients trying to call tick()
- CarlaDataProvider._sync_flag is no longer updated at runtime, to avoid
  that the scenariorunner starts to call tick(), when another client
  activates synchronous mode

Other changes:
- Cleaned formatting of OSC examples
- Fixed timestamp of OSC examples
- Renamed UpdateWeather, UpdateRoadFriction atomics to ChangeWeather and
  ChangeRoadFriction

Fixes #523 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 16.04 and Ubuntu 18.04
  * **Python version(s):** 2.7
  * **CARLA version:** 0.9.9

#### Possible Drawbacks
Some OSC scenarios may no longer work as expected, as the ego vehicle may require now a proper controller definition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/543)
<!-- Reviewable:end -->
