### PR TITLE
Added support for OSC's TimeOfDayCondition

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -28,6 +28,7 @@
     - Extended FollowLeadingVehicle example to illustrate weather changes
     - Added support for RelativeSpeedCondition
     - Added support for AccelerationCondition
+    - Added support for TimeOfDayCondition
     - Created example scenarios to illustrate usage of controllers and weather changes
     - Reworked the handling of Catalogs to make it compliant to the 1.0 version (relative paths have to be relative to the scenario file)
     - The RoadNetwork can be defined as global Parameter
@@ -39,6 +40,7 @@
     - UpdateRoadFriction to update the road friction while running
     - new RelativeVelocityToOtherActor trigger condition, used to compare velocities of two actors
     - new TriggerAcceleration trigger condition which compares a reference acceleration with the actor's one.
+    - new TimeOfDayComparison trigger condition, comparing the simulation time (set up by the new weather system) with a given *datetime*.
 * Removed unsupported scenarios (ChallengeBasic and BackgroundActivity) 
 ### :bug: Bug Fixes
 * Fixed initial speed of vehicles using OpenSCENARIO

--- a/Docs/openscenario_support.md
+++ b/Docs/openscenario_support.md
@@ -366,7 +366,7 @@ The following two tables list the support status for each.
 <td>startTransition, stopTransition, endTransition and completeState are currently supported.</td>
 <tr>
 <td><code>TimeOfDayCondition</code></td>
-<td>&#10060;</td>
+<td>&#9989;</td>
 <td></td>
 <tr>
 <td><code>TrafficSignalCondition</code></td>

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -406,7 +406,6 @@ class TimeOfDayComparison(AtomicCondition):
         self._datetime = datetime.datetime.strptime(dattime, "%Y-%m-%dT%H:%M:%S")
         self._comparison_operator = comparison_operator
 
-
     def update(self):
         """
         Gets the time of day of the simulation and compares it with the reference one

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -422,9 +422,6 @@ class TimeOfDayComparison(AtomicCondition):
         except AttributeError:
             pass
 
-        print("{} -- {}".format(dtime, self._datetime))
-        print(self._comparison_operator(dtime, self._datetime))
-
         if self._comparison_operator(dtime, self._datetime):
             new_status = py_trees.common.Status.SUCCESS
 

--- a/srunner/scenariomanager/weather_sim.py
+++ b/srunner/scenariomanager/weather_sim.py
@@ -97,6 +97,8 @@ class WeatherBehavior(py_trees.behaviour.Behaviour):
     This behavior is always in a running state and must never terminate.
     The user must not add this behavior. It is automatically added by the ScenarioManager.
 
+    This atomic also sets the datetime to blackboard variable, used by TimeOfDayComparison atomic
+
     Args:
         name (string): Name of the behavior.
             Defaults to 'WeatherBehavior'.
@@ -133,7 +135,7 @@ class WeatherBehavior(py_trees.behaviour.Behaviour):
             frequency is 1 Hz.
 
         returns:
-            RUNNING
+            py_trees.common.Status.RUNNING
         """
 
         weather = None

--- a/srunner/scenariomanager/weather_sim.py
+++ b/srunner/scenariomanager/weather_sim.py
@@ -45,7 +45,7 @@ class Weather(object):
         _sun (ephem.Sun): The sun as astronomic entity.
         _observer_location (ephem.Observer): Holds the geographical position (lat/lon/altitude)
             for which the sun position is obtained.
-        _datetime (datetime): Date and time in UTC (required for animation only).
+        datetime (datetime): Date and time in UTC (required for animation only).
     """
 
     def __init__(self, carla_weather, dtime=None, animation=False):
@@ -62,9 +62,9 @@ class Weather(object):
         self._observer_location.lat = str(geo_location.latitude)
 
         #@TODO This requires the time to be in UTC to be accurate
-        self._datetime = dtime
-        if self._datetime:
-            self._observer_location.date = self._datetime
+        self.datetime = dtime
+        if self.datetime:
+            self._observer_location.date = self.datetime
 
         self.update()
 
@@ -72,16 +72,16 @@ class Weather(object):
         """
         If the weather animation is true, the new sun position is calculated w.r.t delta_time
 
-        Nothing happens if animation or _datetime are None.
+        Nothing happens if animation or datetime are None.
 
         Args:
-            delta_time (float): Time passed since self._datetime [seconds].
+            delta_time (float): Time passed since self.datetime [seconds].
         """
-        if not self.animation or not self._datetime:
+        if not self.animation or not self.datetime:
             return
 
-        self._datetime = self._datetime + datetime.timedelta(seconds=delta_time)
-        self._observer_location.date = self._datetime
+        self.datetime = self.datetime + datetime.timedelta(seconds=delta_time)
+        self._observer_location.date = self.datetime
 
         self._sun.compute(self._observer_location)
         self.carla_weather.sun_altitude_angle = math.degrees(self._sun.alt)
@@ -148,7 +148,7 @@ class WeatherBehavior(py_trees.behaviour.Behaviour):
             self._weather = weather
             delattr(py_trees.blackboard.Blackboard(), "CarlaWeather")
             CarlaDataProvider.get_world().set_weather(self._weather.carla_weather)
-            py_trees.blackboard.Blackboard().set("Datetime", self._weather._datetime, overwrite=True)
+            py_trees.blackboard.Blackboard().set("Datetime", self._weather.datetime, overwrite=True)
 
         if self._weather and self._weather.animation:
             new_time = GameTime.get_time()
@@ -159,6 +159,6 @@ class WeatherBehavior(py_trees.behaviour.Behaviour):
                 self._current_time = new_time
                 CarlaDataProvider.get_world().set_weather(self._weather.carla_weather)
 
-                py_trees.blackboard.Blackboard().set("Datetime", self._weather._datetime, overwrite=True)
+                py_trees.blackboard.Blackboard().set("Datetime", self._weather.datetime, overwrite=True)
 
         return py_trees.common.Status.RUNNING

--- a/srunner/scenariomanager/weather_sim.py
+++ b/srunner/scenariomanager/weather_sim.py
@@ -148,6 +148,7 @@ class WeatherBehavior(py_trees.behaviour.Behaviour):
             self._weather = weather
             delattr(py_trees.blackboard.Blackboard(), "CarlaWeather")
             CarlaDataProvider.get_world().set_weather(self._weather.carla_weather)
+            py_trees.blackboard.Blackboard().set("Datetime", self._weather._datetime, overwrite=True)
 
         if self._weather and self._weather.animation:
             new_time = GameTime.get_time()
@@ -157,5 +158,7 @@ class WeatherBehavior(py_trees.behaviour.Behaviour):
                 self._weather.update(delta_time)
                 self._current_time = new_time
                 CarlaDataProvider.get_world().set_weather(self._weather.carla_weather)
+
+                py_trees.blackboard.Blackboard().set("Datetime", self._weather._datetime, overwrite=True)
 
         return py_trees.common.Status.RUNNING

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -55,7 +55,8 @@ from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import (I
                                                                                StandStill,
                                                                                OSCStartEndCondition,
                                                                                TriggerAcceleration,
-                                                                               RelativeVelocityToOtherActor)
+                                                                               RelativeVelocityToOtherActor,
+                                                                               TimeOfDayComparison)
 from srunner.scenariomanager.timer import TimeOut, SimulationTimeCondition
 from srunner.tools.py_trees_port import oneshot_behavior
 
@@ -532,7 +533,11 @@ class OpenScenarioParser(object):
                 rule = simtime_condition.attrib.get('rule')
                 atomic = SimulationTimeCondition(value, success_rule=rule)
             elif value_condition.find('TimeOfDayCondition') is not None:
-                raise NotImplementedError("ByValue TimeOfDay conditions are not yet supported")
+                tod_condition = value_condition.find('TimeOfDayCondition')
+                condition_date = tod_condition.attrib.get('dateTime')
+                condition_rule = tod_condition.attrib.get('rule')
+                condition_operator = OpenScenarioParser.operators[condition_rule]
+                atomic = TimeOfDayComparison(condition_date, condition_operator, condition_name)
             elif value_condition.find('StoryboardElementStateCondition') is not None:
                 state_condition = value_condition.find('StoryboardElementStateCondition')
                 element_name = state_condition.attrib.get('storyboardElementRef')


### PR DESCRIPTION
#### Description

Added TimeOfDayComparison atomic trigger condition, which also allows the support TimeOfDayCondition for OSC.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.9

#### Possible Drawbacks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/551)
<!-- Reviewable:end -->
