### PR TITLE
Fix module loading for ExternalControl

### DIFF
--- a/srunner/scenariomanager/actorcontrols/actor_control.py
+++ b/srunner/scenariomanager/actorcontrols/actor_control.py
@@ -76,11 +76,12 @@ class ActorControl(object):
                 module_name = os.path.basename(control_py_module).split('.')[0]
                 sys.path.append(os.path.dirname(control_py_module))
                 module_control = importlib.import_module(module_name)
+                control_class_name = module_control.__name__.title().replace('_', '')
             else:
                 sys.path.append(os.path.dirname(__file__))
                 module_control = importlib.import_module(control_py_module)
+                control_class_name = control_py_module.split('.')[-1].title().replace('_', '')
 
-            control_class_name = module_control.__name__.title().replace('_', '')
             self.control_instance = getattr(module_control, control_class_name)(actor, args)
 
     def reset(self):


### PR DESCRIPTION
If a controller is specified as a python module, use last section after '.' as classname.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/560)
<!-- Reviewable:end -->
