### PR TITLE
Fixed FollowLeadingVehicle ending bug + CollisionTest bug

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -56,6 +56,7 @@
 * Fixed bug causing OpenSCENARIO's SpeedCondition to not work as intended
 * Fixed bug causing CollisionConditions not to work properly in OpenSCENARIO
 * Fixed bug causing the *group:* functionality to behave incorrectly when moving scenarios around.
+* Fixed bug causing FollowLeadingVehicle and FollowLeadingVehicleWithObstacle scenarios to not properly end
 
 
 ## CARLA ScenarioRunner 0.9.9

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -57,6 +57,7 @@
 * Fixed bug causing CollisionConditions not to work properly in OpenSCENARIO
 * Fixed bug causing the *group:* functionality to behave incorrectly when moving scenarios around.
 * Fixed bug causing FollowLeadingVehicle and FollowLeadingVehicleWithObstacle scenarios to not properly end
+* Fixed bug causing CollisionTest to ignore multiple collisions with scene objects
 
 
 ## CARLA ScenarioRunner 0.9.9

--- a/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
@@ -389,7 +389,7 @@ class CollisionTest(Criterion):
         # Register it if needed
         if not registered:
             self.actual_value += 1
-            if event.other_actor.id != 0: # Number 0: static objects -> ignore it
+            if event.other_actor.id != 0:  # Number 0: static objects -> ignore it
                 self.last_id = event.other_actor.id
 
             if ('static' in event.other_actor.type_id or 'traffic' in event.other_actor.type_id) \

--- a/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
@@ -301,7 +301,6 @@ class CollisionTest(Criterion):
         Construction with sensor setup
         """
         self._actor = actor
-        self.last_walker_id = None
         super(CollisionTest, self).__init__(name, actor, 0, None, optional, terminate_on_failure)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
@@ -390,7 +389,8 @@ class CollisionTest(Criterion):
         # Register it if needed
         if not registered:
             self.actual_value += 1
-            self.last_id = event.other_actor.id
+            if event.other_actor.id != 0: # Number 0: static objects -> ignore it
+                self.last_id = event.other_actor.id
 
             if ('static' in event.other_actor.type_id or 'traffic' in event.other_actor.type_id) \
                     and 'sidewalk' not in event.other_actor.type_id:

--- a/srunner/scenarios/follow_leading_vehicle.py
+++ b/srunner/scenarios/follow_leading_vehicle.py
@@ -138,7 +138,7 @@ class FollowLeadingVehicle(BasicScenario):
                                                         self.ego_vehicles[0],
                                                         distance=20,
                                                         name="FinalDistance")
-        endcondition_part2 = StandStill(self.ego_vehicles[0], name="StandStill")
+        endcondition_part2 = StandStill(self.ego_vehicles[0], name="StandStill", duration=1)
         endcondition.add_child(endcondition_part1)
         endcondition.add_child(endcondition_part2)
 
@@ -285,7 +285,7 @@ class FollowLeadingVehicleWithObstacle(BasicScenario):
                                                         self.ego_vehicles[0],
                                                         distance=20,
                                                         name="FinalDistance")
-        endcondition_part2 = StandStill(self.ego_vehicles[0], name="FinalSpeed")
+        endcondition_part2 = StandStill(self.ego_vehicles[0], name="FinalSpeed", duration=1)
         endcondition.add_child(endcondition_part1)
         endcondition.add_child(endcondition_part2)
 


### PR DESCRIPTION
#### Description

Fixed a bug causing FollowLeadingVehicle and FollowLeadingvehicleWithObstacle scenarios to not properly end. This was caused by the StandStill behavior, which by default, needs a duration to succeed (and it wasn't being passed)

Also fixes a bug at CollisionTest causing it to ignore multiple hits with scene objects (as their id was always 0.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.9.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/564)
<!-- Reviewable:end -->
