### PR TITLE
Added support of OSC's EndOfRoadCondition

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -26,11 +26,12 @@
     - Added support for controllers and provided default implementations for vehicles and pedestrians. This required changing the handling of actors, which results in that now all actors are controlled by an OSC controller.
     - Added initial speed support for pedestrians for OpenSCENARIO
     - Support for EnvironmentActions within Story (before only within Init). This allows changing weather conditions during scenario execution
-    - Extended FollowLeadingVehicle example to illustrate weather changes
     - Added support for RelativeSpeedCondition
     - Added support for AccelerationCondition
     - Added support for TimeOfDayCondition
     - Added support for OffroadCondition
+    - Added support for EndOfRoadCondition
+    - Extended FollowLeadingVehicle example to illustrate weather changes
     - Created example scenarios to illustrate usage of controllers and weather changes
     - Reworked the handling of Catalogs to make it compliant to the 1.0 version (relative paths have to be relative to the scenario file)
     - The RoadNetwork can be defined as global Parameter
@@ -44,8 +45,9 @@
     - new RelativeVelocityToOtherActor trigger condition, used to compare velocities of two actors
     - new TriggerAcceleration trigger condition which compares a reference acceleration with the actor's one.
     - new TimeOfDayComparison trigger condition, comparing the simulation time (set up by the new weather system) with a given *datetime*.
-    - Added a *duration* argument to *OnSidewalkTest* criteria, which makes the criteria fail after a certain time has passed, instead of doing so immediately. This *duration* is 0 by default, so the behavior is unchanged.
-    - Added new *OffRoadTest* criteria.
+    - new *OffRoadTest* criteria.
+    - new *EndofRoadTest* criteria, to detect when a vehicle changes between OpenDRIVE roads.
+    - Added a *duration* argument to *OnSidewalkTest* criteria, which makes the criteria fail after a certain time has passed, instead of doing so immediately. The default behavior has been unchanged.
 * Removed unsupported scenarios (ChallengeBasic and BackgroundActivity) 
 ### :bug: Bug Fixes
 * Do not register SIGHUP signal in windows

--- a/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
@@ -629,7 +629,6 @@ class OffRoadTest(Criterion):
         super(OffRoadTest, self).__init__(name, actor, 0, None, optional, terminate_on_failure)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
-        self._actor = actor
         self._map = CarlaDataProvider.get_map()
         self._offroad = False
 
@@ -649,7 +648,7 @@ class OffRoadTest(Criterion):
         """
         new_status = py_trees.common.Status.RUNNING
 
-        current_location = CarlaDataProvider.get_location(self._actor)
+        current_location = CarlaDataProvider.get_location(self.actor)
 
         # Get the waypoint at the current location to see if the actor is offroad
         drive_waypoint = self._map.get_waypoint(
@@ -682,6 +681,75 @@ class OffRoadTest(Criterion):
 
         if self._terminate_on_failure and self.test_status == "FAILURE":
             new_status = py_trees.common.Status.FAILURE
+
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+
+        return new_status
+
+
+class EndofRoadTest(Criterion):
+
+    """
+    Atomic containing a test to detect when an actor has changed to a different road
+
+    Args:
+        actor (carla.Actor): CARLA actor to be used for this test
+        duration (float): Time spent after ending the road before the atomic fails.
+            If terminate_on_failure isn't active, this is ignored.
+        optional (bool): If True, the result is not considered for an overall pass/fail result
+            when using the output argument
+        terminate_on_failure (bool): If True, the atomic will fail when the duration condition has been met.
+    """
+
+    def __init__(self, actor, duration=0, optional=False, terminate_on_failure=False, name="EndofRoadTest"):
+        """
+        Setup of the variables
+        """
+        super(EndofRoadTest, self).__init__(name, actor, 0, None, optional, terminate_on_failure)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+
+        self._map = CarlaDataProvider.get_map()
+        self._end_of_road = False
+
+        self._duration = duration
+        self._start_time = None
+        self._time_end_road = 0
+        self._road_id = None
+
+    def update(self):
+        """
+        First, transforms the actor's current position to its corresponding waypoint. Then the road id
+        is compared with the initial one and if that's the case, a time is started
+
+        returns:
+            py_trees.common.Status.FAILURE: when the actor has spent a given duration outside driving lanes
+            py_trees.common.Status.RUNNING: the rest of the time
+        """
+        new_status = py_trees.common.Status.RUNNING
+
+        current_location = CarlaDataProvider.get_location(self.actor)
+        current_waypoint = self._map.get_waypoint(current_location)
+
+        # Get the current road id
+        if self._road_id is None:
+            self._road_id = current_waypoint.road_id
+
+        else:
+            # Wait until the actor has left the road
+            if self._road_id != current_waypoint.road_id or self._start_time:
+
+                # Start counting
+                if self._start_time is None:
+                    self._start_time = GameTime.get_time()
+                    return new_status
+
+                curr_time = GameTime.get_time()
+                self._time_end_road = curr_time - self._start_time
+
+                if self._time_end_road > self._duration:
+                    self.test_status = "FAILURE"
+                    self.actual_value += 1
+                    return py_trees.common.Status.SUCCESS
 
         self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -45,7 +45,8 @@ from srunner.scenariomanager.scenarioatomics.atomic_criteria import (CollisionTe
                                                                      RouteCompletionTest,
                                                                      RunningRedLightTest,
                                                                      RunningStopTest,
-                                                                     OffRoadTest)
+                                                                     OffRoadTest,
+                                                                     EndofRoadTest)
 # pylint: enable=unused-import
 from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import (InTriggerDistanceToVehicle,
                                                                                InTriggerDistanceToOSCPosition,
@@ -435,7 +436,11 @@ class OpenScenarioParser(object):
 
             for entity_condition in condition.find('ByEntityCondition').iter('EntityCondition'):
                 if entity_condition.find('EndOfRoadCondition') is not None:
-                    raise NotImplementedError("EndOfRoad conditions are not yet supported")
+                    end_road_condition = entity_condition.find('EndOfRoadCondition')
+                    condition_duration = float(end_road_condition.attrib.get('duration'))
+                    atomic_cls = py_trees.meta.inverter(EndofRoadTest)
+                    atomic = atomic_cls(
+                        trigger_actor, condition_duration, terminate_on_failure=True, name=condition_name)
                 elif entity_condition.find('CollisionCondition') is not None:
                     atomic_cls = py_trees.meta.inverter(CollisionTest)
                     atomic = atomic_cls(trigger_actor, terminate_on_failure=True, name=condition_name)


### PR DESCRIPTION
### Description

Added a new *EndofRoadTest* atomic criterion, which allows the support of _EndOfRoadCondition_

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.9.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/570)
<!-- Reviewable:end -->
