### PR TITLE
Added support for TimeHeadwayCondition + alongRoute argument support

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -32,6 +32,7 @@
     - Added support for OffroadCondition
     - Added support for CollisionCondition
     - Added support for EndOfRoadCondition
+    - Added support for TimeHeadwayCondition
     - Extended FollowLeadingVehicle example to illustrate weather changes
     - Created example scenarios to illustrate usage of controllers and weather changes
     - Reworked the handling of Catalogs to make it compliant to the 1.0 version (relative paths have to be relative to the scenario file)
@@ -50,6 +51,8 @@
     - Added new *EndofRoadTest* criteria, to detect when a vehicle changes between OpenDRIVE roads.
     - CollisionTest criterion can now filter the collisions for a specific actor, or actor type_id.
     - Added a *duration* argument to *OnSidewalkTest* criteria, which makes the criteria fail after a certain time has passed, instead of doing so immediately. The default behavior has been unchanged.
+    - InTimeToArrivalToVehicle has had its two actor arguments swapped, to match all the other behaviors.
+    - Added *along_route* flag to InTimeToArrivalToVehicle, to take into account the topology of the road
 * Removed unsupported scenarios (ChallengeBasic and BackgroundActivity) 
 ### :bug: Bug Fixes
 * Do not register SIGHUP signal in windows

--- a/Docs/openscenario_support.md
+++ b/Docs/openscenario_support.md
@@ -289,7 +289,7 @@ The following two tables list the support status for each.
 <tr>
 <td><code>DistanceCondition</code></td>
 <td>&#9989;</td>
-<td></td>
+<td>*freespace* attribute is still not supported</td>
 <tr>
 <td><code>EndOfRoadCondition</code></td>
 <td>&#9989;</td>
@@ -305,7 +305,7 @@ The following two tables list the support status for each.
 <tr>
 <td><code>RelativeDistanceCondition</code></td>
 <td>&#9989;</td>
-<td></td>
+<td>*freespace* attribute is still not supported</td>
 <tr>
 <td><code>RelativeSpeedCondition</code></td>
 <td>&#9989;</td>

--- a/Docs/openscenario_support.md
+++ b/Docs/openscenario_support.md
@@ -320,12 +320,12 @@ The following two tables list the support status for each.
 <td></td>
 <tr>
 <td><code>TimeHeadwayCondition</code></td>
-<td>&#10060;</td>
-<td></td>
+<td>&#9989;</td>
+<td>*freespace* attribute is still not supported</td>
 <tr>
 <td><code>TimeToCollisionCondition</code></td>
 <td>&#9989;</td>
-<td></td>
+<td>*freespace* attribute is still not supported</td>
 <tr>
 <td><code>TraveledDistanceCondition</code></td>
 <td>&#9989;</td>

--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -43,7 +43,7 @@ import srunner.tools
 EPSILON = 0.001
 
 
-def calculate_distance(location, other_location):
+def calculate_distance(location, other_location, global_planner=None):
     """
     Method to calculate the distance between to locations
 
@@ -52,6 +52,21 @@ def calculate_distance(location, other_location):
           To be accurate, it would have to use the distance along the
           (shortest) route between the two locations.
     """
+    if global_planner:
+        distance = 0
+
+        # Get the route
+        route = global_planner.trace_route(location, other_location)
+
+        # Get the distance of the route
+        for i in range(1, len(route)):
+            curr_loc = route[i][0].transform.location
+            prev_loc = route[i - 1][0].transform.location
+
+            distance += curr_loc.distance(prev_loc)
+
+        return distance
+
     return location.distance(other_location)
 
 

--- a/srunner/scenarios/object_crash_vehicle.py
+++ b/srunner/scenarios/object_crash_vehicle.py
@@ -321,8 +321,8 @@ class DynamicObjectCrossing(BasicScenario):
                                                                     self.transform.location,
                                                                     dist_to_trigger)
         else:
-            start_condition = InTimeToArrivalToVehicle(self.other_actors[0],
-                                                       self.ego_vehicles[0],
+            start_condition = InTimeToArrivalToVehicle(self.ego_vehicles[0],
+                                                       self.other_actors[0],
                                                        self._time_to_reach)
 
         actor_velocity = KeepVelocity(self.other_actors[0],

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -588,17 +588,32 @@ class OpenScenarioParser(object):
                         trigger_actor, position, distance_value, name=condition_name)
                 elif entity_condition.find('DistanceCondition') is not None:
                     distance_condition = entity_condition.find('DistanceCondition')
+
                     distance_value = float(distance_condition.attrib.get('value'))
+
                     distance_rule = distance_condition.attrib.get('rule')
                     distance_operator = OpenScenarioParser.operators[distance_rule]
+
+                    distance_freespace = strtobool(distance_condition.attrib.get('freespace', False))
+                    if distance_freespace:
+                        raise NotImplementedError(
+                            "DistanceCondition: freespace attribute is currently not implemented")
+                    distance_along_route = strtobool(distance_condition.attrib.get('alongRoute', False))
+
                     if distance_condition.find('Position') is not None:
                         position = distance_condition.find('Position')
                         atomic = InTriggerDistanceToOSCPosition(
-                            trigger_actor, position, distance_value, distance_operator, name=condition_name)
+                            trigger_actor, position, distance_value, distance_along_route,
+                            distance_operator, name=condition_name)
 
                 elif entity_condition.find('RelativeDistanceCondition') is not None:
                     distance_condition = entity_condition.find('RelativeDistanceCondition')
                     distance_value = float(distance_condition.attrib.get('value'))
+
+                    distance_freespace = strtobool(distance_condition.attrib.get('freespace', False))
+                    if distance_freespace:
+                        raise NotImplementedError(
+                            "RelativeDistanceCondition: freespace attribute is currently not implemented")
                     if distance_condition.attrib.get('relativeDistanceType') == "cartesianDistance":
                         for actor in actor_list:
                             if distance_condition.attrib.get('entityRef', None) == actor.attributes['role_name']:


### PR DESCRIPTION
### Description

Added support for OSC's TimeHeadwayCondition, which uses *InTimeToArrivalToVehicle*.

Added support of *alongRoute* attribute (calculate the distance taking into account the driving lanes) for *RelativeDistanceCondition* and *TimeToCollisionCondition*

For all these behaviors, the *freespace* argument (used to check the bounding box, not only the reference points) is still unsupported

Changes:
- **calculate_distance** at *atomic_behaviors* now has a global_planner argument, used to calculate the "route distance".
- **InTriggerDistanceToOSCPosition**: added *along_route* argument.
- **InTimeToArrivalToOSCPosition**: added *along_route* argument.
- **InTimeToArrivalToVehicle**: added *along_route* argument. Swapped the places of *actor* and *other_actor* arguments, to match the other behaviors (changed all references to this behavior)

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.9.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/575)
<!-- Reviewable:end -->
