### PR TITLE
Enabled using relative positioning for all entities in OSC

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -42,6 +42,7 @@
     - The RoadNetwork can be defined as global Parameter
     - Fixed handling of relative positions with negative offset
     - Added support for local ParamaterDeclarations
+    - Fixed use of relative initial positions for any actor
 * Atomics:
     - Several new atomics to enable usage of OSC controllers
     - WeatherBehavior to simulate weather over time


### PR DESCRIPTION
Previously, all entities were passed in the order they are listed
in the XOSC file, which could cause problems if the position of the
first entity is relative to the second entity.

The parsing of the initial positions was reworked to allow relative
positions to any other entity.

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/578)
<!-- Reviewable:end -->
