### PR TITLE
Added Windows Docs and support for manual control

### DIFF
--- a/Docs/getting_scenariorunner.md
+++ b/Docs/getting_scenariorunner.md
@@ -142,10 +142,13 @@ __3. Pull the latest changes from the repository.__
 git pull
 ```
 
-__4. Add environemnt variables and Python paths__ These are necessary for the system to find CARLA, and add the PythonAPI to the Python path.  
+__4. Add environment variables and Python paths__ These are necessary for the system to find CARLA, and add the PythonAPI to the Python path.
+
+*   __For Linux__
 
 ```sh
 # ${CARLA_ROOT} is the CARLA installation directory
+# ${SCENARIO_RUNNER} is the ScenarioRunner installation directory
 # <VERSION> is the correct string for the Python version being used
 # In a build from source, the .egg files may be in: ${CARLA_ROOT}/PythonAPI/dist/ instead of ${CARLA_ROOT}/PythonAPI
 export CARLA_ROOT=/path/to/your/carla/installation
@@ -153,11 +156,30 @@ export SCENARIO_RUNNER_ROOT=/path/to/your/scenario/runner/installation
 export PYTHONPATH=$PYTHONPATH:${CARLA_ROOT}/PythonAPI/carla/dist/carla-<VERSION>.egg
 export PYTHONPATH=$PYTHONPATH:${CARLA_ROOT}/PythonAPI/carla/agents
 export PYTHONPATH=$PYTHONPATH:${CARLA_ROOT}/PythonAPI/carla
-export PYTHONPATH=$PYTHONPATH:${SCENARIO_RUNNER}/PythonAPI/carla
 ```
 
 !!! Note
     Change the command lines with the proper paths, according to the comments. 
+
+*   __For Windows__
+
+
+```sh
+# %CARLA_ROOT% is the CARLA installation directory
+# %SCENARIO_RUNNER% is the ScenarioRunner installation directory
+# <VERSION> is the correct string for the Python version being used
+# In a build from source, the .egg files may be in: ${CARLA_ROOT}/PythonAPI/dist/ instead of ${CARLA_ROOT}/PythonAPI
+set CARLA_ROOT=\path\to\your\carla\installation
+set SCENARIO_RUNNER_ROOT=\path\to\your\scenario\runner\installation
+set PYTHONPATH=%PYTHONPATH%;%CARLA_ROOT%\PythonAPI\carla\dist\carla-<VERSION>.egg
+set PYTHONPATH=%PYTHONPATH%;%CARLA_ROOT%\PythonAPI\carla\agents
+set PYTHONPATH=%PYTHONPATH%;%CARLA_ROOT%\PythonAPI\carla
+```
+
+!!! Note
+    Change the command lines with the proper paths, according to the comments. 
+
+To permanently set the environment variables, go to *edit the environment variables of this account*. This can be quickly accessed by writing *env* on the Windows' search panel.
 
 ---
 ## Run a test 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Currently no build is required, as all code is in Python.
 Using the ScenarioRunner
 ------------------------
 
-Please take a look at our [Getting started](Docs/getting_started.md)
+Please take a look at our [Getting started](Docs/getting_scenariorunner.md)
 documentation.
 
 Challenge Evaluation

--- a/manual_control.py
+++ b/manual_control.py
@@ -44,6 +44,7 @@ import carla
 
 from carla import ColorConverter as cc
 
+import os
 import argparse
 import collections
 import datetime
@@ -253,7 +254,8 @@ class HUD(object):
     def __init__(self, width, height):
         self.dim = (width, height)
         font = pygame.font.Font(pygame.font.get_default_font(), 20)
-        fonts = [x for x in pygame.font.get_fonts() if 'mono' in x]
+        font_name = 'courier' if os.name == 'nt' else 'mono'
+        fonts = [x for x in pygame.font.get_fonts() if font_name in x]
         default_font = 'ubuntumono'
         mono = default_font if default_font in fonts else fonts[0]
         mono = pygame.font.match_font(mono)


### PR DESCRIPTION
### Description

- Changed the Docs to explain how to set up the environment variables for Windows
- The _default_font_ for the manual_control fails at Windows. Added a check so that it doesn't happen (copied the one at CARLA's manual_control).

Fixes  #580 #367

#### Where has this been tested?

  * **Platform(s):** Windows 10
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.9

#### Possible Drawbacks

Hopefully no copy paste errors happened when passing the commands to Linux

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/581)
<!-- Reviewable:end -->
