### PR TITLE
Fixed bug with Sync Arrival

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -74,6 +74,7 @@
 * Fixed bug causing FollowLeadingVehicle and FollowLeadingVehicleWithObstacle scenarios to not properly end
 * Fixed bug causing CollisionTest to ignore multiple collisions with scene objects
 * Fixed bug causing NoSignalJunctionCrossing to not output the results of the scenario
+* Fixed bug causing SyncArrival to fail when the actor was destroyed after the behavior ended
 
 
 ## CARLA ScenarioRunner 0.9.9

--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -1188,9 +1188,10 @@ class SyncArrival(AtomicBehavior):
         On termination of this behavior, the throttle should be set back to 0.,
         to avoid further acceleration.
         """
-        self._control.throttle = 0.0
-        self._control.brake = 0.0
-        self._actor.apply_control(self._control)
+        if self._actor is not None and self._actor.is_alive:
+            self._control.throttle = 0.0
+            self._control.brake = 0.0
+            self._actor.apply_control(self._control)
         super(SyncArrival, self).terminate(new_status)
 
 


### PR DESCRIPTION
### Description

Fixed bug with SyncArrival behavior causing the atomic to fail if the actor was destroyed during the simulation. To do so, a check has been placed before trying to apply the control

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.9.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/585)
<!-- Reviewable:end -->
