### PR TITLE
Fixed OSC CustomCommandAction with relativ paths

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -50,6 +50,7 @@
     - Added support for local ParamaterDeclarations
     - Fixed use of relative initial positions for any actor
     - Added possibility to use synchronous execution mode with OpenSCENARIO
+    - Fixed use of relative paths in CustomCommandAction
 * Atomics:
     - Several new atomics to enable usage of OSC controllers
     - WeatherBehavior to simulate weather over time

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -82,6 +82,8 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
         """
         Parse the given OpenSCENARIO config file, set and validate parameters
         """
+        OpenScenarioParser.set_osc_filepath(os.path.dirname(self._filename))
+
         self._check_version()
         self._load_catalogs()
         self._set_scenario_name()

--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -142,22 +142,26 @@ class RunScript(AtomicBehavior):
     Args:
         script (str): String containing the interpreter, scriptpath and arguments
             Example: "python /path/to/script.py --arg1"
+        base_path (str): String containing the base path of for the script
 
     Attributes:
         _script (str): String containing the interpreter, scriptpath and arguments
             Example: "python /path/to/script.py --arg1"
+        _base_path (str): String containing the base path of for the script
+            Example: "/path/to/"
 
     Note:
         This is intended for the use with OpenSCENARIO. Be aware of security side effects.
     """
 
-    def __init__(self, script, name="RunScript"):
+    def __init__(self, script, base_path=None, name="RunScript"):
         """
         Setup parameters
         """
         super(RunScript, self).__init__(name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._script = script
+        self._base_path = base_path
 
     def update(self):
         """
@@ -169,10 +173,12 @@ class RunScript(AtomicBehavior):
             path = script_components[1]
 
         if not os.path.isfile(path):
+            path = os.path.join(self._base_path, path)
+        if not os.path.isfile(path):
             new_status = py_trees.common.Status.FAILURE
             print("Script file does not exists {}".format(path))
         else:
-            subprocess.Popen(self._script, shell=True)
+            subprocess.Popen(self._script, shell=True, cwd=self._base_path)
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -89,6 +89,7 @@ class OpenScenarioParser(object):
     }
 
     use_carla_coordinate_system = False
+    osc_filepath = None
 
     @staticmethod
     def get_traffic_light_from_osc_name(name):
@@ -121,6 +122,14 @@ class OpenScenarioParser(object):
             raise AttributeError("Unknown  traffic light {}".format(name))
 
         return traffic_light
+
+    @staticmethod
+    def set_osc_filepath(filepath):
+        """
+        Set path of OSC file. This is required if for example custom commands are provided with
+        relative paths.
+        """
+        OpenScenarioParser.osc_filepath = filepath
 
     @staticmethod
     def set_use_carla_coordinate_system():
@@ -804,7 +813,7 @@ class OpenScenarioParser(object):
             user_defined_action = action.find('UserDefinedAction')
             if user_defined_action.find('CustomCommandAction') is not None:
                 command = user_defined_action.find('CustomCommandAction').attrib.get('type')
-                atomic = RunScript(command, name=maneuver_name)
+                atomic = RunScript(command, base_path=OpenScenarioParser.osc_filepath, name=maneuver_name)
         elif action.find('PrivateAction') is not None:
             private_action = action.find('PrivateAction')
 


### PR DESCRIPTION
The CustomCommandAction script can now be provided with a path
relative to the OSC scenario file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/590)
<!-- Reviewable:end -->
