### PR TITLE
Cleanup controllers

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -68,6 +68,7 @@
     - Changed the inputs to TrafficLightStateSetter to match the other atomics, but the functionality remains unchanged
 
 ### :bug: Bug Fixes
+* Add cleanup of instantiated OpenSCENARIO controllers
 * Do not register SIGHUP signal in windows
 * Fixed initial speed of vehicles using OpenSCENARIO
 * Fixed bug causing an exception when calling BasicScenario's *_initialize_actors* with no other_actors.

--- a/srunner/scenarios/basic_scenario.py
+++ b/srunner/scenarios/basic_scenario.py
@@ -11,6 +11,7 @@ This module provide BasicScenario, the basic class of all the scenarios.
 
 from __future__ import print_function
 
+import operator
 import py_trees
 
 import carla
@@ -294,3 +295,13 @@ class Scenario(object):
         # Set status to INVALID
         for node in node_list:
             node.terminate(py_trees.common.Status.INVALID)
+
+        # Cleanup all instantiated controllers
+        try:
+            check_actors = operator.attrgetter("ActorsWithController")
+            actor_dict = check_actors(py_trees.blackboard.Blackboard())
+        except AttributeError:
+            pass
+        for actor_id in actor_dict:
+            actor_dict[actor_id].reset()
+        py_trees.blackboard.Blackboard().set("ActorsWithController", {}, overwrite=True)


### PR DESCRIPTION
## Description

Attached controllers were not cleaned up correctly (i.e. reset() was never called).
#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2.7
  * **CARLA version:** 0.9.9.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/591)
<!-- Reviewable:end -->
