### PR TITLE
Removed unused blackboard variables

### DIFF
--- a/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
@@ -359,9 +359,6 @@ class CollisionTest(Criterion):
             self._collision_sensor.destroy()
         self._collision_sensor = None
 
-        # Blackboard variable
-        blackv = py_trees.blackboard.Blackboard()
-        _ = blackv.set("Collision", self.actual_value)
         super(CollisionTest, self).terminate(new_status)
 
     @staticmethod
@@ -1215,10 +1212,6 @@ class OutsideRouteLanesTest(Criterion):
 
             percentage = self._wrong_distance / self._total_distance * 100
 
-            # Blackboard variable
-            blackv = py_trees.blackboard.Blackboard()
-            _ = blackv.set("OutsideRouteLanes", round(percentage, 2))
-
             outside_lane = TrafficEvent(event_type=TrafficEventType.OUTSIDE_ROUTE_LANES_INFRACTION)
             outside_lane.set_message(
                 "Agent went outside its route lanes for about {} meters "
@@ -1234,10 +1227,6 @@ class OutsideRouteLanesTest(Criterion):
             self._wrong_distance = 0
             self.list_traffic_events.append(outside_lane)
             self.actual_value = round(percentage, 2)
-        else:
-            # Blackboard variable
-            blackv = py_trees.blackboard.Blackboard()
-            _ = blackv.set("OutsideRouteLanes", 0)
 
         super(OutsideRouteLanesTest, self).terminate(new_status)
 
@@ -1678,6 +1667,7 @@ class RouteCompletionTest(Criterion):
                 route_completion_event.set_message("Destination was successfully reached")
                 self.list_traffic_events.append(route_completion_event)
                 self.test_status = "SUCCESS"
+                self._percentage_route_completed = 100
 
         elif self.test_status == "SUCCESS":
             new_status = py_trees.common.Status.SUCCESS
@@ -1691,9 +1681,6 @@ class RouteCompletionTest(Criterion):
         Set test status to failure if not successful and terminate
         """
         self.actual_value = round(self._percentage_route_completed, 2)
-        # Blackboard variable
-        blackv = py_trees.blackboard.Blackboard()
-        _ = blackv.set("RouteCompletion", round(self._percentage_route_completed, 2))
 
         if self.test_status == "INIT":
             self.test_status = "FAILURE"
@@ -1886,16 +1873,6 @@ class RunningRedLightTest(Criterion):
 
         return area_loc, wps
 
-    def terminate(self, new_status):
-        """
-        If there is currently an event running, it is registered
-        """
-        # Blackboard variable
-        blackv = py_trees.blackboard.Blackboard()
-        _ = blackv.set("RunningRedLight", self.actual_value)
-
-        super(RunningRedLightTest, self).terminate(new_status)
-
 
 class RunningStopTest(Criterion):
 
@@ -2066,13 +2043,3 @@ class RunningStopTest(Criterion):
         self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
-
-    def terminate(self, new_status):
-        """
-        If there is currently an event running, it is registered
-        """
-        # Blackboard variable
-        blackv = py_trees.blackboard.Blackboard()
-        _ = blackv.set("RunningStop", self.actual_value)
-
-        super(RunningStopTest, self).terminate(new_status)


### PR DESCRIPTION
### Description

Removed the creation of some blackboard variables at the criteria used at routes. These were used at the leaderboard to print the results through the console, but that part has been remade and they are no longer needed.

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.9.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/598)
<!-- Reviewable:end -->
