### PR TITLE
Fixed use of OSC Parameters within OSC Catalogs

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -48,6 +48,9 @@
     - The RoadNetwork can be defined as global Parameter
     - Fixed handling of relative positions with negative offset
     - Added support for local ParamaterDeclarations
+    - Added support for Parameters within Catalogs
+    - Added support for ParameterAssignments for CatalogReferences
+    - Fixed name handling of Parameters: Parameter declerations must not start with a leading '$', but when the parameter is used a leading '$' is required.
     - Fixed use of relative initial positions for any actor
     - Added possibility to use synchronous execution mode with OpenSCENARIO
     - Fixed use of relative paths in CustomCommandAction

--- a/srunner/examples/CatalogExample.xosc
+++ b/srunner/examples/CatalogExample.xosc
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <OpenSCENARIO>
   <FileHeader revMajor="1" revMinor="0" date="2020-03-24T12:00:00" description="CARLA:PedestrianCrossing" author=""/>
+  <ParameterDeclarations>
+    <ParameterDeclaration name="weather" parameterType="string" value="ClearMidnight" />
+    <ParameterDeclaration name="carcolor" parameterType="string" value="122,122,122" />
+  </ParameterDeclarations>
   <CatalogLocations>
     <VehicleCatalog>
       <Directory path="catalogs"/>
@@ -24,10 +28,14 @@
   </RoadNetwork>
   <Entities>
     <ScenarioObject name="hero">
-      <CatalogReference catalogName="VehicleCatalog" entryName="vehicle.volkswagen.t2"/>
+      <CatalogReference catalogName="VehicleCatalog" entryName="vehicle.volkswagen.t2"/> 
     </ScenarioObject>
     <ScenarioObject name="vehicle">
-      <CatalogReference catalogName="VehicleCatalog" entryName="vehicle.tesla.model3"/>
+      <CatalogReference catalogName="VehicleCatalog" entryName="vehicle.tesla.model3">
+        <ParameterAssignments>
+          <ParameterAssignment parameterRef="carcolor" value="255,255,0" />
+        </ParameterAssignments>
+      </CatalogReference>
     </ScenarioObject>
     <ScenarioObject name="adversary">
       <CatalogReference catalogName="PedestrianCatalog" entryName="Pedestrian1"/>
@@ -41,7 +49,7 @@
       <Actions>
         <GlobalAction>
           <EnvironmentAction>
-            <CatalogReference catalogName="EnvironmentCatalog" entryName="ClearMidnight"/>
+            <CatalogReference catalogName="EnvironmentCatalog" entryName="$weather"/>
           </EnvironmentAction>
         </GlobalAction>
         <Private entityRef="hero">

--- a/srunner/examples/FollowLeadingVehicle.xosc
+++ b/srunner/examples/FollowLeadingVehicle.xosc
@@ -2,7 +2,7 @@
 <OpenSCENARIO>
   <FileHeader revMajor="1" revMinor="0" date="2020-03-20T12:00:00" description="CARLA:FollowLeadingVehicle" author=""/>
   <ParameterDeclarations>
-    <ParameterDeclaration name="$leadingSpeed" parameterType="double" value="2.0"/>
+    <ParameterDeclaration name="leadingSpeed" parameterType="double" value="2.0"/>
   </ParameterDeclarations>
   <CatalogLocations/>
   <RoadNetwork>

--- a/srunner/examples/catalogs/EnvironmentCatalog.xosc
+++ b/srunner/examples/catalogs/EnvironmentCatalog.xosc
@@ -14,7 +14,7 @@
     <Environment name="ClearMidnight">
       <TimeOfDay animation="false" dateTime="2020-01-01T00:00:00"/>
       <Weather cloudState="free">
-        <Sun intensity="1.0" azimuth="0.0" elevation="1.5"/>
+        <Sun intensity="1.0" azimuth="0.26" elevation="-1.1"/>
         <Fog visualRange="10000.0"/>
         <Precipitation precipitationType="dry" intensity="0.0"/>
       </Weather>

--- a/srunner/examples/catalogs/VehicleCatalog.xosc
+++ b/srunner/examples/catalogs/VehicleCatalog.xosc
@@ -18,7 +18,9 @@
       </Properties>
     </Vehicle>
     <Vehicle name="vehicle.tesla.model3" vehicleCategory="car">
-      <ParameterDeclarations/>
+      <ParameterDeclarations>
+        <ParameterDeclaration name="carcolor" parameterType="string" value="0,255,255" />
+      </ParameterDeclarations>
       <Performance maxSpeed="69.444" maxAcceleration="200" maxDeceleration="10.0"/>
       <BoundingBox>
         <Center x="1.5" y="0.0" z="0.9"/>
@@ -28,7 +30,9 @@
         <FrontAxle maxSteering="0.5" wheelDiameter="0.6" trackWidth="1.8" positionX="3.1" positionZ="0.3"/>
         <RearAxle maxSteering="0.0" wheelDiameter="0.6" trackWidth="1.8" positionX="0.0" positionZ="0.3"/>
       </Axles>
-      <Properties/>
+      <Properties>
+        <Property name="color" value="$carcolor"/>
+      </Properties>
     </Vehicle>
   </Catalog>
 </OpenSCENARIO>

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -9,8 +9,6 @@
 This module provides the key configuration parameters for a scenario based on OpenSCENARIO
 """
 
-from __future__ import print_function
-
 import logging
 import os
 import xml.etree.ElementTree as ET
@@ -54,6 +52,8 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
 
         logging.basicConfig()
         self.logger = logging.getLogger("[SR:OpenScenarioConfiguration]")
+
+        self._global_parameters = {}
 
         self._set_parameters()
         self._parse_openscenario_configuration()
@@ -184,13 +184,17 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
         """
         Parse the complete scenario definition file, and replace all parameter references
         with the actual values
+
+        Set _global_parameters.
         """
 
-        self.xml_tree = OpenScenarioParser.set_parameters(self.xml_tree)
+        self.xml_tree, self._global_parameters = OpenScenarioParser.set_parameters(self.xml_tree)
 
         for elem in self.xml_tree.iter():
             if elem.find('ParameterDeclarations') is not None:
-                elem = OpenScenarioParser.set_parameters(elem)
+                elem, _ = OpenScenarioParser.set_parameters(elem)
+
+        OpenScenarioParser.set_global_parameters(self._global_parameters)
 
     def _set_actor_information(self):
         """
@@ -208,8 +212,7 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
                     args[key] = value
 
                 for catalog_reference in obj.iter("CatalogReference"):
-                    entry = self.catalogs[catalog_reference.attrib.get(
-                        "catalogName")][catalog_reference.attrib.get("entryName")]
+                    entry = OpenScenarioParser.get_catalog_entry(self.catalogs, catalog_reference)
                     if entry.tag == "Vehicle":
                         self._extract_vehicle_information(entry, rolename, entry, args)
                     elif entry.tag == "Pedestrian":

--- a/srunner/scenarios/open_scenario.py
+++ b/srunner/scenarios/open_scenario.py
@@ -224,8 +224,7 @@ class OpenScenario(BasicScenario):
                         if private.attrib.get('entityRef', None) == actor.rolename:
                             for private_action in private.iter("PrivateAction"):
                                 for controller_action in private_action.iter('ControllerAction'):
-                                    module, args = OpenScenarioParser.get_controller(
-                                        controller_action, self.config.catalogs)
+                                    module, args = OpenScenarioParser.get_controller(controller_action)
                                     controller_atomic = ChangeActorControl(
                                         carla_actor, control_py_module=module, args=args)
 
@@ -289,8 +288,7 @@ class OpenScenario(BasicScenario):
                    # Collect catalog reference maneuvers in order to process them at the same time as normal maneuvers
                     catalog_maneuver_list = []
                     for catalog_reference in sequence.iter("CatalogReference"):
-                        catalog_maneuver = self.config.catalogs[catalog_reference.attrib.get(
-                            "catalogName")][catalog_reference.attrib.get("entryName")]
+                        catalog_maneuver = OpenScenarioParser.get_catalog_entry(self.config.catalogs, catalog_reference)
                         catalog_maneuver_list.append(catalog_maneuver)
                     all_maneuvers = itertools.chain(iter(catalog_maneuver_list), sequence.iter("Maneuver"))
                     single_sequence_iteration = py_trees.composites.Parallel(
@@ -312,7 +310,7 @@ class OpenScenario(BasicScenario):
                                         maneuver_behavior = StoryElementStatusToBlackboard(
                                             maneuver_behavior, "ACTION", child.attrib.get('name'))
                                         parallel_actions.add_child(
-                                            oneshot_behavior(variable_name=# See note in get_xml_path
+                                            oneshot_behavior(variable_name=  # See note in get_xml_path
                                                              get_xml_path(self.config.story, sequence) + '>' + \
                                                              get_xml_path(maneuver, child),
                                                              behaviour=maneuver_behavior))


### PR DESCRIPTION
Reworked OSC Parameter Handling

- Added support for ParameterAssignment
- Added support for parameters inside OSC Catalogs
  (Note: by OSC 1.0 definition all parameters used in catalogs must be
   defined within the catalog)
- ParameterDeceleration must no longer start with '$', only when the
  parameter is used, a '$' has to be added. This change was required to be
  aligned with the standard.
- Updated example scenarios

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/605)
<!-- Reviewable:end -->
