### PR TITLE
Fixed next waypoint bug at RunningStopTest

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -81,6 +81,7 @@
 * Fixed bug causing CollisionTest to ignore multiple collisions with scene objects
 * Fixed bug causing NoSignalJunctionCrossing to not output the results of the scenario
 * Fixed bug causing SyncArrival to fail when the actor was destroyed after the behavior ended
+* Fixed bug with ending roads near stop signals to break the simulation
 
 
 ## CARLA ScenarioRunner 0.9.9

--- a/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
@@ -1951,7 +1951,10 @@ class RunningStopTest(Criterion):
         waypoint = self._map.get_waypoint(current_location)
         for _ in range(multi_step):
             if waypoint:
-                waypoint = waypoint.next(self.WAYPOINT_STEP)[0]
+                next_wps = waypoint.next(self.WAYPOINT_STEP)
+                if not next_wps:
+                    break
+                waypoint = next_wps[0]
                 if not waypoint:
                     break
                 list_locations.append(waypoint.transform.location)


### PR DESCRIPTION
### Description

Divided a *waypoint.next()* call in two at the *RunningStopTest* to avoid breaking the simulation with ending roads

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** current master

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/607)
<!-- Reviewable:end -->
