### PR TITLE
[WIP] Expose traffic manager port.

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -82,7 +82,8 @@
 * Fixed bug causing NoSignalJunctionCrossing to not output the results of the scenario
 * Fixed bug causing SyncArrival to fail when the actor was destroyed after the behavior ended
 * Fixed bug with ending roads near stop signals to break the simulation
-
+### :ghost: Maintenance
+* Exposed traffic manager port flag to enable the execution of multiple scenarios on a single machine.
 
 ## CARLA ScenarioRunner 0.9.9
 ### :rocket: New Features

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -279,8 +279,6 @@ class ScenarioRunner(object):
                             time.sleep(1)
                             break
 
-        CarlaDataProvider.set_traffic_manager_port(int(self._args.trafficManagerPort))
-
         self.world = self.client.get_world()
 
         if self._args.sync:
@@ -291,6 +289,7 @@ class ScenarioRunner(object):
 
         CarlaDataProvider.set_client(self.client)
         CarlaDataProvider.set_world(self.world)
+        CarlaDataProvider.set_traffic_manager_port(int(self._args.trafficManagerPort))
 
         # Wait for the world to be ready
         if CarlaDataProvider.is_sync_mode():

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -279,6 +279,8 @@ class ScenarioRunner(object):
                             time.sleep(1)
                             break
 
+        CarlaDataProvider.set_traffic_manager_port(int(self._args.trafficManagerPort))
+
         self.world = self.client.get_world()
 
         if self._args.sync:
@@ -464,6 +466,8 @@ def main():
                         help='IP of the host server (default: localhost)')
     parser.add_argument('--port', default='2000',
                         help='TCP port to listen to (default: 2000)')
+    parser.add_argument('--trafficManagerPort', default='8000',
+                        help='Port to use for the TrafficManager (default: 8000)')
     parser.add_argument('--sync', action='store_true',
                         help='Forces the simulation to run synchronously')
     parser.add_argument('--debug', action="store_true", help='Run with debug output')

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -59,6 +59,7 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
     _spawn_index = 0
     _blueprint_library = None
     _ego_vehicle_route = None
+    _traffic_manager_port = 8000
     _rng = random.RandomState(2000)
 
     @staticmethod
@@ -595,7 +596,8 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
 
             # Get the command
             command = SpawnActor(blueprint, _spawn_point)
-            command.then(SetAutopilot(FutureActor, actor.autopilot))
+            command.then(SetAutopilot(FutureActor, actor.autopilot,
+                                      CarlaDataProvider._traffic_manager_port))
 
             if actor.category == 'misc':
                 command.then(PhysicsCommand(FutureActor, True))
@@ -656,7 +658,9 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
                     break
 
             if spawn_point:
-                batch.append(SpawnActor(blueprint, spawn_point).then(SetAutopilot(FutureActor, autopilot)))
+                batch.append(SpawnActor(blueprint, spawn_point).then(
+                    SetAutopilot(FutureActor, autopilot,
+                                 CarlaDataProvider._traffic_manager_port)))
 
         actors = CarlaDataProvider.handle_actor_batch(batch)
 
@@ -736,6 +740,20 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
 
         # Remove all keys with None values
         CarlaDataProvider._carla_actor_pool = dict({k: v for k, v in CarlaDataProvider._carla_actor_pool.items() if v})
+
+    @staticmethod
+    def get_traffic_manager_port():
+        """
+        Get the port of the traffic manager.
+        """
+        return CarlaDataProvider._traffic_manager_port
+
+    @staticmethod
+    def set_traffic_manager_port(tm_port):
+        """
+        Set the port to use for the traffic manager.
+        """
+        CarlaDataProvider._traffic_manager_port = tm_port
 
     @staticmethod
     def cleanup():

--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -1036,7 +1036,8 @@ class ChangeAutoPilot(AtomicBehavior):
         super(ChangeAutoPilot, self).__init__(name, actor)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._activate = activate
-        self._tm = CarlaDataProvider.get_client().get_trafficmanager()
+        self._tm = CarlaDataProvider.get_client().get_trafficmanager(
+            CarlaDataProvider.get_traffic_manager_port())
         self._parameters = parameters
 
     def update(self):


### PR DESCRIPTION
I'm creating this WIP PR to discuss what's the best way to set the traffic manager port so that one can run multiple simulators and scenarios on a single machine. 

To make this change, I've started from the points where the code invokes `get_trafficmanager()` or `SetAutoPilot` and propagated up the traffic manager port. However, it looks like this requires the port to be passed to BasicScenario, and hence to the constructors of all the different scenarios. What do you think, is this the right approach or is there a more contained way to make this change?

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...
  * **CARLA version:** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/608)
<!-- Reviewable:end -->
