### PR TITLE
Fixed OSC parameter usage of multiple catalog instances

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -51,6 +51,7 @@
     - Added support for Parameters within Catalogs
     - Added support for ParameterAssignments for CatalogReferences
     - Fixed name handling of Parameters: Parameter declerations must not start with a leading '$', but when the parameter is used a leading '$' is required.
+    - Fixed use of Parameters for multiple instances of the same Catalog element
     - Fixed use of relative initial positions for any actor
     - Added possibility to use synchronous execution mode with OpenSCENARIO
     - Fixed use of relative paths in CustomCommandAction

--- a/srunner/examples/CatalogExample.xosc
+++ b/srunner/examples/CatalogExample.xosc
@@ -2,7 +2,7 @@
 <OpenSCENARIO>
   <FileHeader revMajor="1" revMinor="0" date="2020-03-24T12:00:00" description="CARLA:PedestrianCrossing" author=""/>
   <ParameterDeclarations>
-    <ParameterDeclaration name="weather" parameterType="string" value="ClearMidnight" />
+    <ParameterDeclaration name="weather" parameterType="string" value="ClearNoon" />
     <ParameterDeclaration name="carcolor" parameterType="string" value="122,122,122" />
   </ParameterDeclarations>
   <CatalogLocations>
@@ -37,6 +37,13 @@
       <CatalogReference catalogName="VehicleCatalog" entryName="vehicle.tesla.model3">
         <ParameterAssignments>
           <ParameterAssignment parameterRef="carcolor" value="255,255,0" />
+        </ParameterAssignments>
+      </CatalogReference>
+    </ScenarioObject>
+    <ScenarioObject name="vehicle2">
+      <CatalogReference catalogName="VehicleCatalog" entryName="vehicle.tesla.model3">
+        <ParameterAssignments>
+          <ParameterAssignment parameterRef="carcolor" value="122,122,122" />
         </ParameterAssignments>
       </CatalogReference>
     </ScenarioObject>
@@ -84,6 +91,15 @@
             <TeleportAction>
               <Position>
                 <WorldPosition x="150" y="55" z="0" h="3.14159265359"/>
+              </Position>
+            </TeleportAction>
+          </PrivateAction>
+        </Private>
+        <Private entityRef="vehicle2">
+          <PrivateAction>
+            <TeleportAction>
+              <Position>
+                <WorldPosition x="150" y="60" z="0" h="3.14159265359"/>
               </Position>
             </TeleportAction>
           </PrivateAction>

--- a/srunner/examples/catalogs/VehicleCatalog.xosc
+++ b/srunner/examples/catalogs/VehicleCatalog.xosc
@@ -19,7 +19,7 @@
     </Vehicle>
     <Vehicle name="vehicle.tesla.model3" vehicleCategory="car">
       <ParameterDeclarations>
-        <ParameterDeclaration name="carcolor" parameterType="string" value="0,255,255" />
+        <ParameterDeclaration name="carcolor" parameterType="string" value="0,0,0" />
       </ParameterDeclarations>
       <Performance maxSpeed="69.444" maxAcceleration="200" maxDeceleration="10.0"/>
       <BoundingBox>

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -10,6 +10,7 @@ This module provides a parser for scenario configuration files based on OpenSCEN
 """
 
 from distutils.util import strtobool
+import copy
 import datetime
 import math
 import operator
@@ -207,7 +208,9 @@ class OpenScenarioParser(object):
         """
 
         entry = catalogs[catalog_reference.attrib.get("catalogName")][catalog_reference.attrib.get("entryName")]
-        entry = OpenScenarioParser.assign_catalog_parameters(entry, catalog_reference)
+        entry_copy = copy.deepcopy(entry)
+        catalog_copy = copy.deepcopy(catalog_reference)
+        entry = OpenScenarioParser.assign_catalog_parameters(entry_copy, catalog_copy)
 
         return entry
 


### PR DESCRIPTION
Fixed a bug that led to the problem that all instances of a catalog
element used the same parameter value.

Fixes #619 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/620)
<!-- Reviewable:end -->
