### PR TITLE
Fixed OSC Parameter issue

### DIFF
--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -178,7 +178,7 @@ class OpenScenarioParser(object):
 
         for node in xml_tree.iter():
             for key in node.attrib:
-                for param in parameter_dict:
+                for param in sorted(parameter_dict, key=len, reverse=True):
                     if "$" + param in node.attrib[key]:
                         node.attrib[key] = node.attrib[key].replace("$" + param, parameter_dict[param])
 
@@ -247,7 +247,7 @@ class OpenScenarioParser(object):
 
         for node in entry_instance.iter():
             for key in node.attrib:
-                for param in parameter_dict:
+                for param in sorted(parameter_dict, key=len, reverse=True):
                     if "$" + param in node.attrib[key]:
                         node.attrib[key] = node.attrib[key].replace("$" + param, parameter_dict[param])
 


### PR DESCRIPTION
Having 2+ parameters, where one parameter included the name of one of the others
(e.g. xy and xyz), resulted in a corrupted parameter-value replacement. This
commit should fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/622)
<!-- Reviewable:end -->
