### PR TITLE
Add 'six' to the requirements

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -75,6 +75,7 @@
     - Changed the inputs to TrafficLightStateSetter to match the other atomics, but the functionality remains unchanged
 
 ### :bug: Bug Fixes
+* Fixed missing 'six' in requirements.txt
 * Support OpenSCENARIO parameters also if they're only part of a string value
 * Support Routes in Catalogs
 * Fix parsing of properties within ControllerCatalogs

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tabulate
 opencv-python==4.2.0.32
 numpy
 matplotlib
+six


### PR DESCRIPTION
This is explicitly used by srunner/scenariomanager/carla_data_provider.py

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary (unnecessary)
  - [x] Code compiles correctly and runs (checked)
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh (no python changes)
  - [x] Changelog is updated

#### Description

When installing in a sandboxed environment that pulls in requirements.txt and executing the follow lead vehicle scenario:

```
Traceback (most recent call last):
  File "/mnt/mervin/workspaces/devel/scenarios/scenario_runner/scenario_runner.py", line 33, in <module>
    from srunner.scenarioconfigs.openscenario_configuration import OpenScenarioConfiguration
  File "/mnt/mervin/workspaces/devel/scenarios/scenario_runner/srunner/scenarioconfigs/openscenario_configuration.py", line 27, in <module>
    from srunner.scenariomanager.carla_data_provider import CarlaDataProvider  # workaround
  File "/mnt/mervin/workspaces/devel/scenarios/scenario_runner/srunner/scenariomanager/carla_data_provider.py", line 18, in <module>
    from six import iteritems
ModuleNotFoundError: No module named 'six'
```

Fixes

requirements.txt

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.9.4 and master

#### Possible Drawbacks

None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/637)
<!-- Reviewable:end -->
