### PR TITLE
Fixed OSC RelativeTargetSpeed error

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -75,6 +75,7 @@
     - Changed the inputs to TrafficLightStateSetter to match the other atomics, but the functionality remains unchanged
 
 ### :bug: Bug Fixes
+* Fixed bug causing parsing RelativeTargetSpeed tag to fail. 
 * Fixed missing 'six' in requirements.txt
 * Support OpenSCENARIO parameters also if they're only part of a string value
 * Support Routes in Catalogs

--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -460,6 +460,17 @@ class ChangeActorTargetSpeed(AtomicBehavior):
         self._start_time = GameTime.get_time()
         self._start_location = CarlaDataProvider.get_location(self._actor)
 
+        if self._relative_actor:
+            relative_velocity = CarlaDataProvider.get_velocity(self._relative_actor)
+
+            # get target velocity
+            if self._value_type == 'delta':
+                self._target_speed = relative_velocity + self._value
+            elif self._value_type == 'factor':
+                self._target_speed = relative_velocity * self._value
+            else:
+                print('self._value_type must be delta or factor')
+
         actor_dict[self._actor.id].update_target_speed(self._target_speed, start_time=self._start_time)
 
         if self._init_speed:

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -980,7 +980,7 @@ class OpenScenarioParser(object):
                                 obj_actor = traffic_actor
 
                         atomic = ChangeActorTargetSpeed(actor,
-                                                        target_speed,
+                                                        target_speed=0.0,
                                                         relative_actor=obj_actor,
                                                         value=value,
                                                         value_type=value_type,


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

-->

#### Description
For RelativeTargetSpeed `target_speed` value was not initialised as it was not possible to find this value before the event is triggered. so the `target_speed` is initialised to 0.0 when parsed.

When the ChangeActorTargetSpeed is initialised `target_speed` is set to reference actor speed.

Fixes   #632

#### Where has this been tested?

  * **Platform(s):**Ubuntu 18.04
  * **Python version(s):**  2.7
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:**  0.9.9.4 & 0.9.10

#### Possible Drawbacks

None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/639)
<!-- Reviewable:end -->
