### PR TITLE
Rotate point bug

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -97,6 +97,7 @@
 * Fixed exception bug in spawn function of CarlaDataProvider
 * Fixed access to private member of CARLA LocalPlanner inside OSC NpcVehicleControl
 * Fixed handling of OSC LanePosition (#625)
+* Fixed bug causing the rotate_point function inside RunningRedLightTest to not function properly.
 ### :ghost: Maintenance
 * Exposed traffic manager port flag to enable the execution of multiple scenarios on a single machine.
 

--- a/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_criteria.py
@@ -1831,7 +1831,7 @@ class RunningRedLightTest(Criterion):
         rotate a given point by a given angle
         """
         x_ = math.cos(math.radians(angle)) * point.x - math.sin(math.radians(angle)) * point.y
-        y_ = math.sin(math.radians(angle)) * point.x - math.cos(math.radians(angle)) * point.y
+        y_ = math.sin(math.radians(angle)) * point.x + math.cos(math.radians(angle)) * point.y
         return carla.Vector3D(x_, y_, point.z)
 
     def get_traffic_light_waypoints(self, traffic_light):


### PR DESCRIPTION
### Description

Fixed a bug at *rotate_point* function inside RunningRedLightTest criteria causing vectors to not be rotated properly. This doesn't change the criteria, as all the vectors rotated had no *y* component.

Fixes #643

#### Where has this been tested?

  * **Platform(s):** Ubutu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/644)
<!-- Reviewable:end -->
