### PR TITLE
Changed walker physics

### DIFF
--- a/srunner/scenarios/object_crash_vehicle.py
+++ b/srunner/scenarios/object_crash_vehicle.py
@@ -364,7 +364,7 @@ class DynamicObjectCrossing(BasicScenario):
 
         root.add_child(scenario_sequence)
         scenario_sequence.add_child(ActorTransformSetter(self.other_actors[0], self.transform,
-                                                         name='TransformSetterTS3walker', physics=False))
+                                                         name='TransformSetterTS3walker'))
         scenario_sequence.add_child(ActorTransformSetter(self.other_actors[1], self.transform2,
                                                          name='TransformSetterTS3coca', physics=False))
         scenario_sequence.add_child(HandBrakeVehicle(self.other_actors[0], True))


### PR DESCRIPTION
### Description

**DO NOT MERGE UNTIL CARLA 0.9.10.1 IS RELEASED**

There has been a fix at the CARLA main repository that has fixed a walkers bug causing the *set_simulate_physics* to wrongly interact with them.

This affects the DynamicObjectCrossing scenario as it was unintentionally moving walkers without physics. As this is no longer possible, this has to be fixed. Now, when the pedestrian are moved to the ground level (from z=-500), the physics are correctly set up to True (ActorTransformSetter sets physics to True by default).

#### Where has this been tested?

  * **Platform(s):** 3.6
  * **Python version(s):** 18.04
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.10

#### Possible Drawbacks

This might happen at other places which haven't been detected and changed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/649)
<!-- Reviewable:end -->
