### PR TITLE
Added sensor barrier to agents

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -10,6 +10,8 @@
 * [CARLA ScenarioRunner 0.9.2](#carla-scenariorunner-092)
 
 ## Latest Changes
+### :rocket: New Features
+- Added a sensor barrier for the agents to ensure that the simulation waits for them to render their data.
 
 ## CARLA ScenarioRunner 0.9.10
 ### :rocket: New Features

--- a/srunner/autoagents/agent_wrapper.py
+++ b/srunner/autoagents/agent_wrapper.py
@@ -81,10 +81,8 @@ class AgentWrapper(object):
             sensor.listen(CallBack(sensor_spec['id'], sensor, self._agent.sensor_interface))
             self._sensors_list.append(sensor)
 
-        while not self._agent.all_sensors_ready():
-            if debug_mode:
-                print(" waiting for one data reading from sensors...")
-            CarlaDataProvider.get_world().tick()
+        # Tick once to spawn the sensors
+        CarlaDataProvider.get_world().tick()
 
     def cleanup(self):
         """

--- a/srunner/autoagents/autonomous_agent.py
+++ b/srunner/autoagents/autonomous_agent.py
@@ -97,13 +97,6 @@ class AutonomousAgent(object):
 
         return control
 
-    def all_sensors_ready(self):
-        """
-        Check if all sensors are ready
-        Returns true if sensors are ready
-        """
-        return self.sensor_interface.all_sensors_ready()
-
     def set_global_plan(self, global_plan_gps, global_plan_world_coord):
         """
         Set the plan (route) for the agent

--- a/srunner/autoagents/sensor_interface.py
+++ b/srunner/autoagents/sensor_interface.py
@@ -160,6 +160,6 @@ class SensorInterface(object):
                 data_dict[sensor_data[0]] = ((sensor_data[1], sensor_data[2]))
 
         except Empty:
-            raise SensorReceivedNoData("A sensor took too long to send their data")
+            raise SensorReceivedNoData("A sensor took too long to send its data")
 
         return data_dict

--- a/srunner/autoagents/sensor_interface.py
+++ b/srunner/autoagents/sensor_interface.py
@@ -29,9 +29,6 @@ class SensorReceivedNoData(Exception):
     Exceptions thrown when the sensors used by the agent take too long to receive data
     """
 
-    def __init__(self, message):
-        super(SensorReceivedNoData, self).__init__(message)
-
 
 class CallBack(object):
 

--- a/srunner/autoagents/sensor_interface.py
+++ b/srunner/autoagents/sensor_interface.py
@@ -10,14 +10,21 @@ handling the use of sensors for the agents
 
 import copy
 import logging
-import numpy as np
 
-from queue import Queue
-from queue import Empty
+try:
+    from queue import Queue
+    from queue import Empty
+except ImportError:
+    from Queue import Queue
+    from Queue import Empty
+
+import numpy as np
 
 import carla
 
+
 class SensorReceivedNoData(Exception):
+
     """
     Exceptions thrown when the sensors used by the agent take too long to receive data
     """
@@ -108,7 +115,7 @@ class CallBack(object):
                           imu_data.gyroscope.y,
                           imu_data.gyroscope.z,
                           imu_data.compass,
-                         ], dtype=np.float64)
+                          ], dtype=np.float64)
         self._data_provider.update_sensor(tag, array, imu_data.frame)
 
 


### PR DESCRIPTION
### Description

Currently the **CARLA pipeline has a problem in sync mode** causing the simulation to not wait for the sensors to be rendered (as this is done in parallel to the main thread). Therefore, a **sensor barrier** is needed at the client side to ensure that the simulation is blocked until all sensor data is rendered.

Regarding SR, the **sensor data is now stored at a **Queue**** instead of a dictionary. Queue's are optimized to insert and remove elements, which is perfect for this use-case. When the data is received, the Queue is filled and the agents asks for the data, it is removed from the queue. Additionally, the *get* function is a blocking one, allowing the client to block the simulation in case the queue has some missing elements.

**Removed *all_sensors_ready*** function as its functionality is now part of the Queue. Additionally, this function didn't take into account the timestamp of the data plus due to its multiple ticks to the simulation, slower sensors such as the camera could be out of sync with the rest.


**Added IMU and RADAR** sensors + LIDAR now has 4 channels, not 3

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.10.1

### Possible Drawbacks

The simulation is now blocked until sensor data is received (up to 10s). Even though there is a watchdog (which will trigger if this happens), this might cause other unseen issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/652)
<!-- Reviewable:end -->
