### PR TITLE
Fixed exception when using OSC scenarios without environment init

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -13,6 +13,9 @@
 ### :rocket: New Features
 * Added a sensor barrier for the agents to ensure that the simulation waits for them to render their data.
 * Added an option to produce a machine-readable JSON version of the scenario report.
+### :bug: Bug Fixes
+* Fixed exception when using OSC scenarios without EnvironmentAction inside Storyboard-Init 
+
 
 ## CARLA ScenarioRunner 0.9.10
 ### :rocket: New Features

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -220,7 +220,7 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
                     elif entry.tag == "MiscObject":
                         self._extract_misc_information(entry, rolename, entry, args)
                     else:
-                        self.logger.error(
+                        self.logger.debug(
                             " A CatalogReference specifies a reference that is not an Entity. Skipping...")
 
                 for vehicle in obj.iter("Vehicle"):

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -269,7 +269,10 @@ class OpenScenarioParser(object):
         returns:
            friction (float)
         """
-        set_environment = next(xml_tree.iter("EnvironmentAction"))
+        if xml_tree.find("EnvironmentAction") is not None:
+            set_environment = next(xml_tree.iter("EnvironmentAction"))
+        else:
+            return 1.0
 
         if sum(1 for _ in set_environment.iter("Weather")) != 0:
             environment = set_environment.find("Environment")
@@ -298,7 +301,10 @@ class OpenScenarioParser(object):
         returns:
            Weather (srunner.scenariomanager.weather_sim.Weather)
         """
-        set_environment = next(xml_tree.iter("EnvironmentAction"))
+        if xml_tree.find("EnvironmentAction") is not None:
+            set_environment = next(xml_tree.iter("EnvironmentAction"))
+        else:
+            return Weather(carla.WeatherParameters())
 
         if sum(1 for _ in set_environment.iter("Weather")) != 0:
             environment = set_environment.find("Environment")


### PR DESCRIPTION
OpenSCENARIO based scenarios that do not use an EnvironmentAction
inside the Storyboard Init part, are no longer throwing an exception.

First part to address #655 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/656)
<!-- Reviewable:end -->
