### PR TITLE
sergi-e/docs-index-fix

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -19,35 +19,35 @@ CARLA forum</a>
 
 ## Quick start
   <p style="padding-left:30px;line-height:1.8">
-    [__Get ScenarioRunner__](getting_scenariorunner.md)
-        — Tutorial on how to download and launch ScenarioRunner.  
-    [__First steps__](getting_started.md)
-        — Brief tutorials on how to run different types of scenarios.  
-    [__Create a new scenario__](creating_new_scenario.md)
-        — Tutorial on how to create a new scenario using ScenarioRunner.  
-    [__Metrics module__](metrics_module.md)
-        — Explanation of the metrics module.  
-    [__F.A.Q.__](FAQ.md)
-        — Some of the most frequent installation issues.  
-    [__Release notes__](CHANGELOG.md)
-        — Features, fixes and other changes listed per release.  
+    <a href="getting_scenariorunner"><b>Get ScenarioRunner</b></a>
+        — Tutorial on how to download and launch ScenarioRunner.<br>
+    <a href="getting_started"><b>First steps</b></a>
+        — Brief tutorials on how to run different types of scenarios.<br>
+    <a href="creating_new_scenario"><b>Create a new scenario</b></a>
+        — Tutorial on how to create a new scenario using ScenarioRunner.<br>
+    <a href="metrics_module"><b>Metrics module</b></a>
+        — Explanation of the metrics module.<br>
+    <a href="FAQ"><b>F.A.Q.</b></a>
+        — Some of the most frequent installation issues.<br>
+    <a href="CHANGELOG"><b>Release notes</b></a>
+        — Features, fixes and other changes listed per release.<br>
   </p>
 
 ## References
   <p style="padding-left:30px;line-height:1.8">
-    [__List of scenarios__](list_of_scenarios.md)
-        — Example scenarios available in ScenarioRunner.  
-    [__OpenScenario support__](getting_started.md)
-        — Support status of OpenSCENARIO features.  
+    <a href="list_of_scenarios"><b>List of scenarios</b></a>
+        — Example scenarios available in ScenarioRunner.<br>
+    <a href="getting_started"><b>OpenScenario support</b></a>
+        — Support status of OpenSCENARIO features.<br>
   </p>
 
 ## Contributing
   <p style="padding-left:30px;line-height:1.8">
-    [__Code of conduct__](CODE_OF_CONDUCT.md)
-        — Standard rights and duties for contributors.
-    [__Coding standard__](coding_standard.md)
-        — Guidelines to write proper code.  
-    [__Contribution guidelines__](CONTRIBUTING.md)
-        — The different ways to contribute to ScenarioRunner.
+    <a href="CODE_OF_CONDUCT"><b>Code of conduct</b></a>
+        — Standard rights and duties for contributors.<br>
+    <a href="coding_standard"><b>Coding standard</b></a>
+        — Guidelines to write proper code.<br>
+    <a href="CONTRIBUTING"><b>Contribution guidelines</b></a>
+        — The different ways to contribute to ScenarioRunner.<br>
   </p>
 


### PR DESCRIPTION
#### Description

- The formatting of index in the landing page of the docs is not working. Local visualization and RtD final version do not correspond.

- Fixed by using only HTML. 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04.4
  * **Python version(s):** 3.6.9
  * **Unreal Engine version(s):** 4.24

#### Possible Drawbacks

- localhost may still be different than RtD version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/664)
<!-- Reviewable:end -->
