### PR TITLE
Defined a new class for TimeToCollisionCondition along with freespace implementation

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -121,6 +121,7 @@
     - Added support to use a non-CARLA OpenDRIVE map (instead of CARLA towns)
     - Added support for TimeOfDay tag
     - Added support for scenarios with no actors
+    - Added support for TimeToCollisionCondition with freespace.
 * Scenario updates:
     - Scenarios that are part of RouteScenario have had their triggering condition modified. This will only activate when a certain parameter is set, and if not, the old trigger condition will still be applied.
 * Atomics:

--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -122,6 +122,7 @@
     - Added support for TimeOfDay tag
     - Added support for scenarios with no actors
     - Added support for TimeToCollisionCondition with freespace.
+    - Added support for TimeHeadwayCondition with freespace.
 * Scenario updates:
     - Scenarios that are part of RouteScenario have had their triggering condition modified. This will only activate when a certain parameter is set, and if not, the old trigger condition will still be applied.
 * Atomics:

--- a/Docs/openscenario_support.md
+++ b/Docs/openscenario_support.md
@@ -321,11 +321,11 @@ The following two tables list the support status for each.
 <tr>
 <td><code>TimeHeadwayCondition</code></td>
 <td>&#9989;</td>
-<td>*freespace* attribute is still not supported</td>
+<td></td>
 <tr>
 <td><code>TimeToCollisionCondition</code></td>
 <td>&#9989;</td>
-<td>*freespace* attribute is still not supported</td>
+<td></td>
 <tr>
 <td><code>TraveledDistanceCondition</code></td>
 <td>&#9989;</td>

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -9,11 +9,9 @@
 This module provides all atomic scenario behaviors that reflect
 trigger conditions to either activate another behavior, or to stop
 another behavior.
-
 For example, such a condition could be "InTriggerRegion", which checks
 that a given actor reached a certain region on the map, and then starts/stops
 a behavior of this actor.
-
 The atomics are implemented with py_trees and make use of the AtomicCondition
 base class
 """
@@ -40,11 +38,10 @@ EPSILON = 0.001
 
 
 class AtomicCondition(py_trees.behaviour.Behaviour):
+
     """
     Base class for all atomic conditions used to setup a scenario
-
     *All behaviors should use this class as parent*
-
     Important parameters:
     - name: Name of the atomic condition
     """
@@ -54,55 +51,44 @@ class AtomicCondition(py_trees.behaviour.Behaviour):
         Default init. Has to be called via super from derived class
         """
         super(AtomicCondition, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self.name = name
 
     def setup(self, unused_timeout=15):
         """
         Default setup
         """
-        self.logger.debug("%s.setup()" % self.__class__.__name__)
+        self.logger.debug("%s.setup()" % (self.__class__.__name__))
         return True
 
     def initialise(self):
         """
         Initialise setup
         """
-        self.logger.debug("%s.initialise()" % self.__class__.__name__)
+        self.logger.debug("%s.initialise()" % (self.__class__.__name__))
 
     def terminate(self, new_status):
         """
         Default terminate. Can be extended in derived class
         """
-        self.logger.debug(
-            "%s.terminate()[%s->%s]"
-            % (self.__class__.__name__, self.status, new_status)
-        )
+        self.logger.debug("%s.terminate()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
 
 class InTriggerDistanceToOSCPosition(AtomicCondition):
+
     """
     OpenSCENARIO atomic
     This class contains the trigger condition for a distance to an OpenSCENARIO position
-
     Args:
         actor (carla.Actor): CARLA actor to execute the behavior
         osc_position (str): OpenSCENARIO position
         distance (float): Trigger distance between the actor and the target location in meters
         name (str): Name of the condition
-
     The condition terminates with SUCCESS, when the actor reached the target distance to the openSCENARIO position
     """
 
-    def __init__(
-        self,
-        actor,
-        osc_position,
-        distance,
-        along_route=False,
-        comparison_operator=operator.lt,
-        name="InTriggerDistanceToOSCPosition",
-    ):
+    def __init__(self, actor, osc_position, distance, along_route=False,
+                 comparison_operator=operator.lt, name="InTriggerDistanceToOSCPosition"):
         """
         Setup parameters
         """
@@ -143,14 +129,10 @@ class InTriggerDistanceToOSCPosition(AtomicCondition):
 
             if self._along_route:
                 # Global planner needs a location at a driving lane
-                actor_location = self._map.get_waypoint(
-                    actor_location
-                ).transform.location
-                osc_location = self._map.get_waypoint(
-                    osc_location).transform.location
+                actor_location = self._map.get_waypoint(actor_location).transform.location
+                osc_location = self._map.get_waypoint(osc_location).transform.location
 
-            distance = calculate_distance(
-                actor_location, osc_location, self._grp)
+            distance = calculate_distance(actor_location, osc_location, self._grp)
 
             if self._comparison_operator(distance, self._distance):
                 new_status = py_trees.common.Status.SUCCESS
@@ -159,28 +141,20 @@ class InTriggerDistanceToOSCPosition(AtomicCondition):
 
 
 class InTimeToArrivalToOSCPosition(AtomicCondition):
+
     """
     OpenSCENARIO atomic
     This class contains a trigger if an actor arrives within a given time to an OpenSCENARIO position
-
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - osc_position: OpenSCENARIO position
     - time: The behavior is successful, if TTA is less than _time_ in seconds
     - name: Name of the condition
-
     The condition terminates with SUCCESS, when the actor can reach the position within the given time
     """
 
-    def __init__(
-        self,
-        actor,
-        osc_position,
-        time,
-        along_route=False,
-        comparison_operator=operator.lt,
-        name="InTimeToArrivalToOSCPosition",
-    ):
+    def __init__(self, actor, osc_position, time, along_route=False,
+                 comparison_operator=operator.lt, name="InTimeToArrivalToOSCPosition"):
         """
         Setup parameters
         """
@@ -225,13 +199,10 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
 
         if self._along_route:
             # Global planner needs a location at a driving lane
-            actor_location = self._map.get_waypoint(
-                actor_location).transform.location
-            target_location = self._map.get_waypoint(
-                target_location).transform.location
+            actor_location = self._map.get_waypoint(actor_location).transform.location
+            target_location = self._map.get_waypoint(target_location).transform.location
 
-        distance = calculate_distance(
-            actor_location, target_location, self._grp)
+        distance = calculate_distance(actor_location, target_location, self._grp)
 
         actor_velocity = CarlaDataProvider.get_velocity(self._actor)
 
@@ -241,7 +212,7 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
         elif distance == 0:
             time_to_arrival = 0
         else:
-            time_to_arrival = float("inf")
+            time_to_arrival = float('inf')
 
         if self._comparison_operator(time_to_arrival, self._time):
             new_status = py_trees.common.Status.SUCCESS
@@ -249,14 +220,13 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
 
 
 class StandStill(AtomicCondition):
+
     """
     This class contains a standstill behavior of a scenario
-
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - duration: Duration of the behavior in seconds
-
     The condition terminates with SUCCESS, when the actor does not move
     """
 
@@ -265,7 +235,7 @@ class StandStill(AtomicCondition):
         Setup actor
         """
         super(StandStill, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._actor = actor
 
         self._duration = duration
@@ -292,19 +262,17 @@ class StandStill(AtomicCondition):
         if GameTime.get_time() - self._start_time > self._duration:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class RelativeVelocityToOtherActor(AtomicCondition):
+
     """
     Atomic containing a comparison between an actor's velocity
     and another actor's one. The behavior returns SUCCESS when the
     expected comparison (greater than / less than / equal to) is achieved
-
     Args:
         actor (carla.Actor): actor from which the velocity is taken
         other_actor (carla.Actor): The actor with the reference velocity
@@ -313,19 +281,13 @@ class RelativeVelocityToOtherActor(AtomicCondition):
         comparison_operator: Type "operator", used to compare the two velocities
     """
 
-    def __init__(
-        self,
-        actor,
-        other_actor,
-        speed,
-        comparison_operator=operator.gt,
-        name="RelativeVelocityToOtherActor",
-    ):
+    def __init__(self, actor, other_actor, speed, comparison_operator=operator.gt,
+                 name="RelativeVelocityToOtherActor"):
         """
         Setup the parameters
         """
         super(RelativeVelocityToOtherActor, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._actor = actor
         self._other_actor = other_actor
         self._relative_speed = speed
@@ -334,7 +296,6 @@ class RelativeVelocityToOtherActor(AtomicCondition):
     def update(self):
         """
         Gets the speed of the two actors and compares them according to the comparison operator
-
         returns:
             py_trees.common.Status.RUNNING when the comparison fails and
             py_trees.common.Status.SUCCESS when it succeeds
@@ -349,19 +310,17 @@ class RelativeVelocityToOtherActor(AtomicCondition):
         if self._comparison_operator(relative_speed, self._relative_speed):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class TriggerVelocity(AtomicCondition):
+
     """
     Atomic containing a comparison between an actor's speed and a reference one.
     The behavior returns SUCCESS when the expected comparison (greater than /
     less than / equal to) is achieved.
-
     Args:
         actor (carla.Actor): CARLA actor from which the speed will be taken.
         name (string): Name of the atomic
@@ -369,18 +328,12 @@ class TriggerVelocity(AtomicCondition):
         comparison_operator: Type "operator", used to compare the two velocities
     """
 
-    def __init__(
-        self,
-        actor,
-        target_velocity,
-        comparison_operator=operator.gt,
-        name="TriggerVelocity",
-    ):
+    def __init__(self, actor, target_velocity, comparison_operator=operator.gt, name="TriggerVelocity"):
         """
         Setup the atomic parameters
         """
         super(TriggerVelocity, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._actor = actor
         self._target_velocity = target_velocity
         self._comparison_operator = comparison_operator
@@ -388,7 +341,6 @@ class TriggerVelocity(AtomicCondition):
     def update(self):
         """
         Gets the speed of the actor and compares it with the reference one
-
         returns:
             py_trees.common.Status.RUNNING when the comparison fails and
             py_trees.common.Status.SUCCESS when it succeeds
@@ -400,19 +352,17 @@ class TriggerVelocity(AtomicCondition):
         if self._comparison_operator(actor_speed, self._target_velocity):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class TriggerAcceleration(AtomicCondition):
+
     """
     Atomic containing a comparison between an actor's acceleration
     and a reference one. The behavior returns SUCCESS when the
     expected comparison (greater than / less than / equal to) is achieved
-
     Args:
         actor (carla.Actor): CARLA actor to execute the behavior
         name (str): Name of the condition
@@ -420,18 +370,12 @@ class TriggerAcceleration(AtomicCondition):
         comparison_operator (operator): Type "operator", used to compare the two acceleration
     """
 
-    def __init__(
-        self,
-        actor,
-        target_acceleration,
-        comparison_operator=operator.gt,
-        name="TriggerAcceleration",
-    ):
+    def __init__(self, actor, target_acceleration, comparison_operator=operator.gt, name="TriggerAcceleration"):
         """
         Setup trigger acceleration
         """
         super(TriggerAcceleration, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._actor = actor
         self._target_acceleration = target_acceleration
         self._comparison_operator = comparison_operator
@@ -439,7 +383,6 @@ class TriggerAcceleration(AtomicCondition):
     def update(self):
         """
         Gets the accleration of the actor and compares it with the reference one
-
         returns:
             py_trees.common.Status.RUNNING when the comparison fails and
             py_trees.common.Status.SUCCESS when it succeeds
@@ -447,28 +390,24 @@ class TriggerAcceleration(AtomicCondition):
         new_status = py_trees.common.Status.RUNNING
 
         acceleration = self._actor.get_acceleration()
-        linear_accel = math.sqrt(
-            math.pow(acceleration.x, 2)
-            + math.pow(acceleration.y, 2)
-            + math.pow(acceleration.z, 2)
-        )
+        linear_accel = math.sqrt(math.pow(acceleration.x, 2) +
+                                 math.pow(acceleration.y, 2) +
+                                 math.pow(acceleration.z, 2))
 
         if self._comparison_operator(linear_accel, self._target_acceleration):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class TimeOfDayComparison(AtomicCondition):
+
     """
     Atomic containing a comparison between the current time of day of the simulation
     and a given one. The behavior returns SUCCESS when the
     expected comparison (greater than / less than / equal to) is achieved
-
     Args:
         datetime (datetime): CARLA actor to execute the behavior
         name (str): Name of the condition
@@ -476,22 +415,17 @@ class TimeOfDayComparison(AtomicCondition):
         comparison_operator (operator): Type "operator", used to compare the two acceleration
     """
 
-    def __init__(
-            self,
-            dattime,
-            comparison_operator=operator.gt,
-            name="TimeOfDayComparison"):
-        """"""
+    def __init__(self, dattime, comparison_operator=operator.gt, name="TimeOfDayComparison"):
+        """
+        """
         super(TimeOfDayComparison, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
-        self._datetime = datetime.datetime.strptime(
-            dattime, "%Y-%m-%dT%H:%M:%S")
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self._datetime = datetime.datetime.strptime(dattime, "%Y-%m-%dT%H:%M:%S")
         self._comparison_operator = comparison_operator
 
     def update(self):
         """
         Gets the time of day of the simulation and compares it with the reference one
-
         returns:
             py_trees.common.Status.RUNNING when the comparison fails and
             py_trees.common.Status.SUCCESS when it succeeds
@@ -507,36 +441,28 @@ class TimeOfDayComparison(AtomicCondition):
         if self._comparison_operator(dtime, self._datetime):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class OSCStartEndCondition(AtomicCondition):
+
     """
     This class contains a check if a named story element has started/terminated.
-
     Important parameters:
     - element_name: The story element's name attribute
     - element_type: The element type [act,scene,maneuver,event,action]
     - rule: Either START or END
-
     The condition terminates with SUCCESS, when the named story element starts
     """
 
-    def __init__(
-            self,
-            element_type,
-            element_name,
-            rule,
-            name="OSCStartEndCondition"):
+    def __init__(self, element_type, element_name, rule, name="OSCStartEndCondition"):
         """
         Setup element details
         """
         super(OSCStartEndCondition, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._element_type = element_type.upper()
         self._element_name = element_name
         self._rule = rule.upper()
@@ -557,46 +483,34 @@ class OSCStartEndCondition(AtomicCondition):
         new_status = py_trees.common.Status.RUNNING
 
         if new_status == py_trees.common.Status.RUNNING:
-            blackboard_variable_name = "({}){}-{}".format(
-                self._element_type, self._element_name, self._rule
-            )
+            blackboard_variable_name = "({}){}-{}".format(self._element_type, self._element_name, self._rule)
             element_start_time = self._blackboard.get(blackboard_variable_name)
             if element_start_time and element_start_time >= self._start_time:
                 new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class InTriggerRegion(AtomicCondition):
+
     """
     This class contains the trigger region (condition) of a scenario
-
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - min_x, max_x, min_y, max_y: bounding box of the trigger region
-
     The condition terminates with SUCCESS, when the actor reached the target region
     """
 
-    def __init__(
-            self,
-            actor,
-            min_x,
-            max_x,
-            min_y,
-            max_y,
-            name="TriggerRegion"):
+    def __init__(self, actor, min_x, max_x, min_y, max_y, name="TriggerRegion"):
         """
         Setup trigger region (rectangle provided by
         [min_x,min_y] and [max_x,max_y]
         """
         super(InTriggerRegion, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._actor = actor
         self._min_x = min_x
         self._max_x = max_x
@@ -608,52 +522,43 @@ class InTriggerRegion(AtomicCondition):
         Check if the _actor location is within trigger region
         """
         new_status = py_trees.common.Status.RUNNING
+
         location = CarlaDataProvider.get_location(self._actor)
 
         if location is None:
             return new_status
 
-        not_in_region = (
-            location.x < self._min_x or location.x > self._max_x) or (
-            location.y < self._min_y or location.y > self._max_y)
+        not_in_region = (location.x < self._min_x or location.x > self._max_x) or \
+                        (location.y < self._min_y or location.y > self._max_y)
         if not not_in_region:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class InTriggerDistanceToVehicle(AtomicCondition):
+
     """
     This class contains the trigger distance (condition) between to actors
     of a scenario
-
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - reference_actor: Reference CARLA actor
     - name: Name of the condition
     - distance: Trigger distance between the two actors in meters
     - dx, dy, dz: distance to reference_location (location of reference_actor)
-
     The condition terminates with SUCCESS, when the actor reached the target distance to the other actor
     """
 
-    def __init__(
-        self,
-        reference_actor,
-        actor,
-        distance,
-        comparison_operator=operator.lt,
-        name="TriggerDistanceToVehicle",
-    ):
+    def __init__(self, reference_actor, actor, distance, comparison_operator=operator.lt,
+                 name="TriggerDistanceToVehicle"):
         """
         Setup trigger distance
         """
         super(InTriggerDistanceToVehicle, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._reference_actor = reference_actor
         self._actor = actor
         self._distance = distance
@@ -666,51 +571,43 @@ class InTriggerDistanceToVehicle(AtomicCondition):
         new_status = py_trees.common.Status.RUNNING
 
         location = CarlaDataProvider.get_location(self._actor)
-        reference_location = CarlaDataProvider.get_location(
-            self._reference_actor)
+        reference_location = CarlaDataProvider.get_location(self._reference_actor)
 
         if location is None or reference_location is None:
             return new_status
 
-        if self._comparison_operator(
-            calculate_distance(location, reference_location), self._distance
-        ):
+        if self._comparison_operator(calculate_distance(location, reference_location), self._distance):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class InTriggerDistanceToLocation(AtomicCondition):
+
     """
     This class contains the trigger (condition) for a distance to a fixed
     location of a scenario
-
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - target_location: Reference location (carla.location)
     - name: Name of the condition
     - distance: Trigger distance between the actor and the target location in meters
-
     The condition terminates with SUCCESS, when the actor reached the target distance to the given location
     """
 
-    def __init__(
-        self,
-        actor,
-        target_location,
-        distance,
-        comparison_operator=operator.lt,
-        name="InTriggerDistanceToLocation",
-    ):
+    def __init__(self,
+                 actor,
+                 target_location,
+                 distance,
+                 comparison_operator=operator.lt,
+                 name="InTriggerDistanceToLocation"):
         """
         Setup trigger distance
         """
         super(InTriggerDistanceToLocation, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._target_location = target_location
         self._actor = actor
         self._distance = distance
@@ -728,41 +625,33 @@ class InTriggerDistanceToLocation(AtomicCondition):
         if location is None:
             return new_status
 
-        if self._comparison_operator(
-            calculate_distance(location, self._target_location), self._distance
-        ):
+        if self._comparison_operator(calculate_distance(
+                location, self._target_location), self._distance):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class InTriggerDistanceToNextIntersection(AtomicCondition):
+
     """
     This class contains the trigger (condition) for a distance to the
     next intersection of a scenario
-
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - distance: Trigger distance between the actor and the next intersection in meters
-
     The condition terminates with SUCCESS, when the actor reached the target distance to the next intersection
     """
 
-    def __init__(
-            self,
-            actor,
-            distance,
-            name="InTriggerDistanceToNextIntersection"):
+    def __init__(self, actor, distance, name="InTriggerDistanceToNextIntersection"):
         """
         Setup trigger distance
         """
         super(InTriggerDistanceToNextIntersection, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._actor = actor
         self._distance = distance
         self._map = CarlaDataProvider.get_map()
@@ -779,47 +668,33 @@ class InTriggerDistanceToNextIntersection(AtomicCondition):
         """
         new_status = py_trees.common.Status.RUNNING
 
-        current_waypoint = self._map.get_waypoint(
-            CarlaDataProvider.get_location(self._actor)
-        )
-        distance = calculate_distance(
-            current_waypoint.transform.location, self._final_location
-        )
+        current_waypoint = self._map.get_waypoint(CarlaDataProvider.get_location(self._actor))
+        distance = calculate_distance(current_waypoint.transform.location, self._final_location)
 
         if distance < self._distance:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
+
     """
     Implementation for a behavior that will check if a given actor
     is within a given distance to a given location considering a given route
-
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - distance: Trigger distance between the actor and the next intersection in meters
     - route: Route to be checked
     - location: Location on the route to be checked
-
     The condition terminates with SUCCESS, when the actor reached the target distance
     along its route to the given location
     """
 
-    def __init__(
-        self,
-        actor,
-        route,
-        location,
-        distance,
-        name="InTriggerDistanceToLocationAlongRoute",
-    ):
+    def __init__(self, actor, route, location, distance, name="InTriggerDistanceToLocationAlongRoute"):
         """
         Setup class members
         """
@@ -830,9 +705,7 @@ class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
         self._route = route
         self._distance = distance
 
-        self._location_distance, _ = get_distance_along_route(
-            self._route, self._location
-        )
+        self._location_distance, _ = get_distance_along_route(self._route, self._location)
 
     def update(self):
         new_status = py_trees.common.Status.RUNNING
@@ -844,48 +717,38 @@ class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
 
         if current_location.distance(self._location) < self._distance + 20:
 
-            actor_distance, _ = get_distance_along_route(
-                self._route, current_location)
+            actor_distance, _ = get_distance_along_route(self._route, current_location)
 
             # If closer than self._distance and hasn't passed the trigger point
-            if (
-                self._location_distance < actor_distance + self._distance
-                and actor_distance < self._location_distance
-            ) or self._location_distance < 1.0:
+            if (self._location_distance < actor_distance + self._distance and
+                actor_distance < self._location_distance) or \
+                    self._location_distance < 1.0:
                 new_status = py_trees.common.Status.SUCCESS
 
         return new_status
 
 
 class InTimeToArrivalToLocation(AtomicCondition):
+
     """
     This class contains a check if a actor arrives within a given time
     at a given location.
-
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - time: The behavior is successful, if TTA is less than _time_ in seconds
     - location: Location to be checked in this behavior
-
     The condition terminates with SUCCESS, when the actor can reach the target location within the given time
     """
 
-    _max_time_to_arrival = float("inf")  # time to arrival in seconds
+    _max_time_to_arrival = float('inf')  # time to arrival in seconds
 
-    def __init__(
-        self,
-        actor,
-        time,
-        location,
-        comparison_operator=operator.lt,
-        name="TimeToArrival",
-    ):
+    def __init__(self, actor, time, location, comparison_operator=operator.lt, name="TimeToArrival"):
         """
         Setup parameters
         """
         super(InTimeToArrivalToLocation, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._actor = actor
         self._time = time
         self._target_location = location
@@ -913,43 +776,33 @@ class InTimeToArrivalToLocation(AtomicCondition):
         if self._comparison_operator(time_to_arrival, self._time):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class InTimeToArrivalToVehicle(AtomicCondition):
+
     """
     This class contains a check if a actor arrives within a given time
     at another actor.
-
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - time: The behavior is successful, if TTA is less than _time_ in seconds
     - other_actor: Reference actor used in this behavior
-
     The condition terminates with SUCCESS, when the actor can reach the other vehicle within the given time
     """
 
-    _max_time_to_arrival = float("inf")  # time to arrival in seconds
+    _max_time_to_arrival = float('inf')  # time to arrival in seconds
 
-    def __init__(
-        self,
-        actor,
-        other_actor,
-        time,
-        along_route=False,
-        comparison_operator=operator.lt,
-        name="TimeToArrival",
-    ):
+    def __init__(self, actor, other_actor, time, along_route=False,
+                 comparison_operator=operator.lt, name="TimeToArrival"):
         """
         Setup parameters
         """
         super(InTimeToArrivalToVehicle, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._map = CarlaDataProvider.get_map()
         self._actor = actor
         self._other_actor = other_actor
@@ -983,63 +836,47 @@ class InTimeToArrivalToVehicle(AtomicCondition):
 
         if self._along_route:
             # Global planner needs a location at a driving lane
-            current_location = self._map.get_waypoint(
-                current_location
-            ).transform.location
-            other_location = self._map.get_waypoint(
-                other_location).transform.location
+            current_location = self._map.get_waypoint(current_location).transform.location
+            other_location = self._map.get_waypoint(other_location).transform.location
 
-        distance = calculate_distance(
-            current_location, other_location, self._grp)
+        distance = calculate_distance(current_location, other_location, self._grp)
 
         # if velocity is too small, simply use a large time to arrival
         time_to_arrival = self._max_time_to_arrival
 
         if current_velocity > other_velocity:
-            time_to_arrival = 2 * distance / \
-                (current_velocity - other_velocity)
+            time_to_arrival = 2 * distance / (current_velocity - other_velocity)
 
         if self._comparison_operator(time_to_arrival, self._time):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class InTimeToCollisionToVehicle(AtomicCondition):
+
     """
     This class contains a check of time to collision between two dynamic actors.
     The distance calculation is done from edge to edge to the actors.
-
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - time: The behavior is successful, if TTA is less than _time_ in seconds
     - other_actor: Reference actor used in this behavior
-
     The condition terminates with SUCCESS, when the actor can reach the other vehicle within the given time
     """
 
-    _max_time_to_arrival = float("inf")  # time to arrival in seconds
+    _max_time_to_arrival = float('inf')  # time to arrival in seconds
 
-    def __init__(
-        self,
-        actor,
-        other_actor,
-        time,
-        condition_freespace,
-        along_route=False,
-        comparison_operator=operator.lt,
-        name="TimeToArrival",
-    ):
+    def __init__(self, actor, other_actor, time, condition_freespace, along_route=False,
+                 comparison_operator=operator.lt, name="TimeToArrival"):
         """
         Setup parameters
         """
         super(InTimeToCollisionToVehicle, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._map = CarlaDataProvider.get_map()
         self._actor = actor
         self._other_actor = other_actor
@@ -1074,63 +911,46 @@ class InTimeToCollisionToVehicle(AtomicCondition):
 
         if self._along_route:
             # Global planner needs a location at a driving lane
-            current_location = self._map.get_waypoint(
-                current_location
-            ).transform.location
-            other_location = self._map.get_waypoint(
-                other_location).transform.location
+            current_location = self._map.get_waypoint(current_location).transform.location
+            other_location = self._map.get_waypoint(other_location).transform.location
 
-        distance = calculate_distance(
-            current_location, other_location, self._grp)
+        distance = calculate_distance(current_location, other_location, self._grp)
 
         # if velocity is too small, simply use a large time to arrival
         time_to_arrival = self._max_time_to_arrival
 
         if self._condition_freespace:
-            time_to_arrival = (
-                distance
-                - self._actor.bounding_box.extent.x
-                - self._other_actor.bounding_box.extent.x
-            ) / abs(other_velocity - current_velocity)
+            time_to_arrival = (distance - self._actor.bounding_box.extent.x -
+                               self._other_actor.bounding_box.extent.x) / abs(other_velocity - current_velocity)
         else:
             time_to_arrival = distance / abs(other_velocity - current_velocity)
 
         if self._comparison_operator(time_to_arrival, self._time):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
+
     """
     This class contains a check if a actor arrives within a given time
     at another actor's side lane. Inherits from InTimeToArrivalToLocation
-
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - time: The behavior is successful, if TTA is less than _time_ in seconds
     - cut_in_lane: the lane from where the other_actor will do the cut in
     - other_actor: Reference actor used in this behavior
-
     The condition terminates with SUCCESS, when the actor can reach the other vehicle within the given time
     """
 
-    _max_time_to_arrival = float("inf")  # time to arrival in seconds
+    _max_time_to_arrival = float('inf')  # time to arrival in seconds
 
-    def __init__(
-        self,
-        actor,
-        other_actor,
-        time,
-        side_lane,
-        comparison_operator=operator.lt,
-        name="InTimeToArrivalToVehicleSideLane",
-    ):
+    def __init__(self, actor, other_actor, time, side_lane,
+                 comparison_operator=operator.lt, name="InTimeToArrivalToVehicleSideLane"):
         """
         Setup parameters
         """
@@ -1143,9 +963,9 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
         other_location = other_actor.get_transform().location
         other_waypoint = self._map.get_waypoint(other_location)
 
-        if self._side_lane == "right":
+        if self._side_lane == 'right':
             other_side_waypoint = other_waypoint.get_left_lane()
-        elif self._side_lane == "left":
+        elif self._side_lane == 'left':
             other_side_waypoint = other_waypoint.get_right_lane()
         else:
             raise Exception("cut_in_lane must be either 'left' or 'right'")
@@ -1153,9 +973,8 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
         other_side_location = other_side_waypoint.transform.location
 
         super(InTimeToArrivalToVehicleSideLane, self).__init__(
-            actor, time, other_side_location, comparison_operator, name
-        )
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+            actor, time, other_side_location, comparison_operator, name)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
     def update(self):
         """
@@ -1166,9 +985,9 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
         other_location = CarlaDataProvider.get_location(self._other_actor)
         other_waypoint = self._map.get_waypoint(other_location)
 
-        if self._side_lane == "right":
+        if self._side_lane == 'right':
             other_side_waypoint = other_waypoint.get_left_lane()
-        elif self._side_lane == "left":
+        elif self._side_lane == 'left':
             other_side_waypoint = other_waypoint.get_right_lane()
         else:
             raise Exception("cut_in_lane must be either 'left' or 'right'")
@@ -1186,9 +1005,9 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
 
 
 class WaitUntilInFront(AtomicCondition):
+
     """
     Behavior that support the creation of cut ins. It waits until the actor has passed another actor
-
     Parameters:
     - actor: the one getting in front of the other actor
     - other_actor: the reference vehicle that the actor will have to get in front of
@@ -1197,13 +1016,7 @@ class WaitUntilInFront(AtomicCondition):
         1: The front of the other_actor and the back of the actor are right next to each other
     """
 
-    def __init__(
-            self,
-            actor,
-            other_actor,
-            factor=1,
-            check_distance=True,
-            name="WaitUntilInFront"):
+    def __init__(self, actor, other_actor, factor=1, check_distance=True, name="WaitUntilInFront"):
         """
         Init
         """
@@ -1221,7 +1034,7 @@ class WaitUntilInFront(AtomicCondition):
         other_extent = self._other_actor.bounding_box.extent.x
         self._length = self._factor * (actor_extent + other_extent)
 
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
     def update(self):
         """
@@ -1250,11 +1063,7 @@ class WaitUntilInFront(AtomicCondition):
         # Wait for the vehicle to be in front
         other_dir = other_next_waypoint.transform.get_forward_vector()
         act_other_dir = actor_location - other_next_waypoint.transform.location
-        dot_ve_wp = (
-            other_dir.x * act_other_dir.x
-            + other_dir.y * act_other_dir.y
-            + other_dir.z * act_other_dir.z
-        )
+        dot_ve_wp = other_dir.x * act_other_dir.x + other_dir.y * act_other_dir.y + other_dir.z * act_other_dir.z
 
         if dot_ve_wp > 0.0:
             in_front = True
@@ -1262,10 +1071,7 @@ class WaitUntilInFront(AtomicCondition):
         # Wait for it to be close-by
         if not self._check_distance:
             close_by = True
-        elif (
-            actor_location.distance(other_next_waypoint.transform.location)
-            < self._distance
-        ):
+        elif actor_location.distance(other_next_waypoint.transform.location) < self._distance:
             close_by = True
 
         if in_front and close_by:
@@ -1275,13 +1081,12 @@ class WaitUntilInFront(AtomicCondition):
 
 
 class DriveDistance(AtomicCondition):
+
     """
     This class contains an atomic behavior to drive a certain distance.
-
     Important parameters:
     - actor: CARLA actor to execute the condition
     - distance: Distance for this condition in meters
-
     The condition terminates with SUCCESS, when the actor drove at least the given distance
     """
 
@@ -1290,7 +1095,7 @@ class DriveDistance(AtomicCondition):
         Setup parameters
         """
         super(DriveDistance, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._target_distance = distance
         self._distance = 0
         self._location = None
@@ -1313,19 +1118,16 @@ class DriveDistance(AtomicCondition):
         if self._distance > self._target_distance:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
         return new_status
 
 
 class AtRightmostLane(AtomicCondition):
+
     """
     This class contains an atomic behavior to check if the actor is at the rightest driving lane.
-
     Important parameters:
     - actor: CARLA actor to execute the condition
-
     The condition terminates with SUCCESS, when the actor enters the rightest lane
     """
 
@@ -1334,7 +1136,7 @@ class AtRightmostLane(AtomicCondition):
         Setup parameters
         """
         super(AtRightmostLane, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._actor = actor
         self._map = CarlaDataProvider.get_map()
 
@@ -1356,21 +1158,18 @@ class AtRightmostLane(AtomicCondition):
         if lane_type != carla.LaneType.Driving:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
         return new_status
 
 
 class WaitForTrafficLightState(AtomicCondition):
+
     """
     This class contains an atomic behavior to wait for a given traffic light
     to have the desired state.
-
     Args:
         actor (carla.TrafficLight): CARLA traffic light to execute the condition
         state (carla.TrafficLightState): State to be checked in this condition
-
     The condition terminates with SUCCESS, when the traffic light switches to the desired state
     """
 
@@ -1379,7 +1178,7 @@ class WaitForTrafficLightState(AtomicCondition):
         Setup traffic_light
         """
         super(WaitForTrafficLightState, self).__init__(name)
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._actor = actor if "traffic_light" in actor.type_id else None
         self._state = state
 
@@ -1395,14 +1194,13 @@ class WaitForTrafficLightState(AtomicCondition):
         if self._actor.state == self._state:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug(
-            "%s.update()[%s->%s]" %
-            (self.__class__.__name__, self.status, new_status))
+        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
 
 class WaitEndIntersection(AtomicCondition):
+
     """
     Atomic behavior that waits until the vehicles has gone outside the junction.
     If currently inside no intersection, it will wait until one is found
@@ -1413,7 +1211,7 @@ class WaitEndIntersection(AtomicCondition):
         self.actor = actor
         self.debug = debug
         self.inside_junction = False
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
     def update(self):
 
@@ -1436,26 +1234,20 @@ class WaitEndIntersection(AtomicCondition):
 
 
 class WaitForBlackboardVariable(AtomicCondition):
+
     """
     Atomic behavior that keeps running until the blackboard variable is set to the corresponding value.
     Used to avoid returning FAILURE if the blackboard comparison fails.
-
     It also initially sets the variable to a given value, if given
     """
 
-    def __init__(
-        self,
-        variable_name,
-        variable_value,
-        var_init_value=None,
-        debug=False,
-        name="WaitForBlackboardVariable",
-    ):
+    def __init__(self, variable_name, variable_value, var_init_value=None,
+                 debug=False, name="WaitForBlackboardVariable"):
         super(WaitForBlackboardVariable, self).__init__(name)
         self._debug = debug
         self._variable_name = variable_name
         self._variable_value = variable_value
-        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
         if var_init_value is not None:
             blackboard = py_trees.blackboard.Blackboard()
@@ -1469,9 +1261,7 @@ class WaitForBlackboardVariable(AtomicCondition):
         value = blackv.get(self._variable_name)
         if value == self._variable_value:
             if self._debug:
-                print(
-                    "Blackboard variable {} set to True".format(
-                        self._variable_name))
+                print("Blackboard variable {} set to True".format(self._variable_name))
             new_status = py_trees.common.Status.SUCCESS
 
         return new_status

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -555,8 +555,8 @@ class InTriggerRegion(AtomicCondition):
         if location is None:
             return new_status
 
-        not_in_region = (location.x < self._min_x or location.x > self._max_x) or (
-            location.y < self._min_y or location.y > self._max_y)
+        not_in_region = (location.x < self._min_x or location.x > self._max_x) or \
+                        (location.y < self._min_y or location.y > self._max_y)
         if not not_in_region:
             new_status = py_trees.common.Status.SUCCESS
 

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -54,21 +54,21 @@ class AtomicCondition(py_trees.behaviour.Behaviour):
         Default init. Has to be called via super from derived class
         """
         super(AtomicCondition, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self.name = name
 
     def setup(self, unused_timeout=15):
         """
         Default setup
         """
-        self.logger.debug("%s.setup()" % (self.__class__.__name__))
+        self.logger.debug("%s.setup()" % self.__class__.__name__)
         return True
 
     def initialise(self):
         """
         Initialise setup
         """
-        self.logger.debug("%s.initialise()" % (self.__class__.__name__))
+        self.logger.debug("%s.initialise()" % self.__class__.__name__)
 
     def terminate(self, new_status):
         """
@@ -135,8 +135,7 @@ class InTriggerDistanceToOSCPosition(AtomicCondition):
 
         # calculate transform with method in openscenario_parser.py
         osc_transform = srunner.tools.openscenario_parser.OpenScenarioParser.convert_position_to_transform(
-            self._osc_position
-        )
+            self._osc_position)
 
         if osc_transform is not None:
             osc_location = osc_transform.location
@@ -147,9 +146,11 @@ class InTriggerDistanceToOSCPosition(AtomicCondition):
                 actor_location = self._map.get_waypoint(
                     actor_location
                 ).transform.location
-                osc_location = self._map.get_waypoint(osc_location).transform.location
+                osc_location = self._map.get_waypoint(
+                    osc_location).transform.location
 
-            distance = calculate_distance(actor_location, osc_location, self._grp)
+            distance = calculate_distance(
+                actor_location, osc_location, self._grp)
 
             if self._comparison_operator(distance, self._distance):
                 new_status = py_trees.common.Status.SUCCESS
@@ -213,8 +214,7 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
         # calculate transform with method in openscenario_parser.py
         try:
             osc_transform = srunner.tools.openscenario_parser.OpenScenarioParser.convert_position_to_transform(
-                self._osc_position
-            )
+                self._osc_position)
         except AttributeError:
             return py_trees.common.Status.FAILURE
         target_location = osc_transform.location
@@ -225,10 +225,13 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
 
         if self._along_route:
             # Global planner needs a location at a driving lane
-            actor_location = self._map.get_waypoint(actor_location).transform.location
-            target_location = self._map.get_waypoint(target_location).transform.location
+            actor_location = self._map.get_waypoint(
+                actor_location).transform.location
+            target_location = self._map.get_waypoint(
+                target_location).transform.location
 
-        distance = calculate_distance(actor_location, target_location, self._grp)
+        distance = calculate_distance(
+            actor_location, target_location, self._grp)
 
         actor_velocity = CarlaDataProvider.get_velocity(self._actor)
 
@@ -262,7 +265,7 @@ class StandStill(AtomicCondition):
         Setup actor
         """
         super(StandStill, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._actor = actor
 
         self._duration = duration
@@ -290,8 +293,8 @@ class StandStill(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -322,7 +325,7 @@ class RelativeVelocityToOtherActor(AtomicCondition):
         Setup the parameters
         """
         super(RelativeVelocityToOtherActor, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._actor = actor
         self._other_actor = other_actor
         self._relative_speed = speed
@@ -347,8 +350,8 @@ class RelativeVelocityToOtherActor(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -377,7 +380,7 @@ class TriggerVelocity(AtomicCondition):
         Setup the atomic parameters
         """
         super(TriggerVelocity, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._actor = actor
         self._target_velocity = target_velocity
         self._comparison_operator = comparison_operator
@@ -398,8 +401,8 @@ class TriggerVelocity(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -428,7 +431,7 @@ class TriggerAcceleration(AtomicCondition):
         Setup trigger acceleration
         """
         super(TriggerAcceleration, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._actor = actor
         self._target_acceleration = target_acceleration
         self._comparison_operator = comparison_operator
@@ -454,8 +457,8 @@ class TriggerAcceleration(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -474,12 +477,15 @@ class TimeOfDayComparison(AtomicCondition):
     """
 
     def __init__(
-        self, dattime, comparison_operator=operator.gt, name="TimeOfDayComparison"
-    ):
+            self,
+            dattime,
+            comparison_operator=operator.gt,
+            name="TimeOfDayComparison"):
         """"""
         super(TimeOfDayComparison, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
-        self._datetime = datetime.datetime.strptime(dattime, "%Y-%m-%dT%H:%M:%S")
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
+        self._datetime = datetime.datetime.strptime(
+            dattime, "%Y-%m-%dT%H:%M:%S")
         self._comparison_operator = comparison_operator
 
     def update(self):
@@ -502,8 +508,8 @@ class TimeOfDayComparison(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -520,12 +526,17 @@ class OSCStartEndCondition(AtomicCondition):
     The condition terminates with SUCCESS, when the named story element starts
     """
 
-    def __init__(self, element_type, element_name, rule, name="OSCStartEndCondition"):
+    def __init__(
+            self,
+            element_type,
+            element_name,
+            rule,
+            name="OSCStartEndCondition"):
         """
         Setup element details
         """
         super(OSCStartEndCondition, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._element_type = element_type.upper()
         self._element_name = element_name
         self._rule = rule.upper()
@@ -554,8 +565,8 @@ class OSCStartEndCondition(AtomicCondition):
                 new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -572,13 +583,20 @@ class InTriggerRegion(AtomicCondition):
     The condition terminates with SUCCESS, when the actor reached the target region
     """
 
-    def __init__(self, actor, min_x, max_x, min_y, max_y, name="TriggerRegion"):
+    def __init__(
+            self,
+            actor,
+            min_x,
+            max_x,
+            min_y,
+            max_y,
+            name="TriggerRegion"):
         """
         Setup trigger region (rectangle provided by
         [min_x,min_y] and [max_x,max_y]
         """
         super(InTriggerRegion, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._actor = actor
         self._min_x = min_x
         self._max_x = max_x
@@ -595,15 +613,15 @@ class InTriggerRegion(AtomicCondition):
         if location is None:
             return new_status
 
-        not_in_region = (location.x < self._min_x or location.x > self._max_x) or (
-            location.y < self._min_y or location.y > self._max_y
-        )
+        not_in_region = (
+            location.x < self._min_x or location.x > self._max_x) or (
+            location.y < self._min_y or location.y > self._max_y)
         if not not_in_region:
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -635,7 +653,7 @@ class InTriggerDistanceToVehicle(AtomicCondition):
         Setup trigger distance
         """
         super(InTriggerDistanceToVehicle, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._reference_actor = reference_actor
         self._actor = actor
         self._distance = distance
@@ -648,7 +666,8 @@ class InTriggerDistanceToVehicle(AtomicCondition):
         new_status = py_trees.common.Status.RUNNING
 
         location = CarlaDataProvider.get_location(self._actor)
-        reference_location = CarlaDataProvider.get_location(self._reference_actor)
+        reference_location = CarlaDataProvider.get_location(
+            self._reference_actor)
 
         if location is None or reference_location is None:
             return new_status
@@ -659,8 +678,8 @@ class InTriggerDistanceToVehicle(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -691,7 +710,7 @@ class InTriggerDistanceToLocation(AtomicCondition):
         Setup trigger distance
         """
         super(InTriggerDistanceToLocation, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._target_location = target_location
         self._actor = actor
         self._distance = distance
@@ -715,8 +734,8 @@ class InTriggerDistanceToLocation(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -734,12 +753,16 @@ class InTriggerDistanceToNextIntersection(AtomicCondition):
     The condition terminates with SUCCESS, when the actor reached the target distance to the next intersection
     """
 
-    def __init__(self, actor, distance, name="InTriggerDistanceToNextIntersection"):
+    def __init__(
+            self,
+            actor,
+            distance,
+            name="InTriggerDistanceToNextIntersection"):
         """
         Setup trigger distance
         """
         super(InTriggerDistanceToNextIntersection, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._actor = actor
         self._distance = distance
         self._map = CarlaDataProvider.get_map()
@@ -767,8 +790,8 @@ class InTriggerDistanceToNextIntersection(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -821,7 +844,8 @@ class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
 
         if current_location.distance(self._location) < self._distance + 20:
 
-            actor_distance, _ = get_distance_along_route(self._route, current_location)
+            actor_distance, _ = get_distance_along_route(
+                self._route, current_location)
 
             # If closer than self._distance and hasn't passed the trigger point
             if (
@@ -861,7 +885,7 @@ class InTimeToArrivalToLocation(AtomicCondition):
         Setup parameters
         """
         super(InTimeToArrivalToLocation, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._actor = actor
         self._time = time
         self._target_location = location
@@ -890,8 +914,8 @@ class InTimeToArrivalToLocation(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -925,7 +949,7 @@ class InTimeToArrivalToVehicle(AtomicCondition):
         Setup parameters
         """
         super(InTimeToArrivalToVehicle, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._map = CarlaDataProvider.get_map()
         self._actor = actor
         self._other_actor = other_actor
@@ -962,22 +986,25 @@ class InTimeToArrivalToVehicle(AtomicCondition):
             current_location = self._map.get_waypoint(
                 current_location
             ).transform.location
-            other_location = self._map.get_waypoint(other_location).transform.location
+            other_location = self._map.get_waypoint(
+                other_location).transform.location
 
-        distance = calculate_distance(current_location, other_location, self._grp)
+        distance = calculate_distance(
+            current_location, other_location, self._grp)
 
         # if velocity is too small, simply use a large time to arrival
         time_to_arrival = self._max_time_to_arrival
 
         if current_velocity > other_velocity:
-            time_to_arrival = 2 * distance / (current_velocity - other_velocity)
+            time_to_arrival = 2 * distance / \
+                (current_velocity - other_velocity)
 
         if self._comparison_operator(time_to_arrival, self._time):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -1012,7 +1039,7 @@ class InTimeToCollisionToVehicle(AtomicCondition):
         Setup parameters
         """
         super(InTimeToCollisionToVehicle, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._map = CarlaDataProvider.get_map()
         self._actor = actor
         self._other_actor = other_actor
@@ -1050,9 +1077,11 @@ class InTimeToCollisionToVehicle(AtomicCondition):
             current_location = self._map.get_waypoint(
                 current_location
             ).transform.location
-            other_location = self._map.get_waypoint(other_location).transform.location
+            other_location = self._map.get_waypoint(
+                other_location).transform.location
 
-        distance = calculate_distance(current_location, other_location, self._grp)
+        distance = calculate_distance(
+            current_location, other_location, self._grp)
 
         # if velocity is too small, simply use a large time to arrival
         time_to_arrival = self._max_time_to_arrival
@@ -1070,8 +1099,8 @@ class InTimeToCollisionToVehicle(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -1126,7 +1155,7 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
         super(InTimeToArrivalToVehicleSideLane, self).__init__(
             actor, time, other_side_location, comparison_operator, name
         )
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
 
     def update(self):
         """
@@ -1169,8 +1198,12 @@ class WaitUntilInFront(AtomicCondition):
     """
 
     def __init__(
-        self, actor, other_actor, factor=1, check_distance=True, name="WaitUntilInFront"
-    ):
+            self,
+            actor,
+            other_actor,
+            factor=1,
+            check_distance=True,
+            name="WaitUntilInFront"):
         """
         Init
         """
@@ -1188,7 +1221,7 @@ class WaitUntilInFront(AtomicCondition):
         other_extent = self._other_actor.bounding_box.extent.x
         self._length = self._factor * (actor_extent + other_extent)
 
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
 
     def update(self):
         """
@@ -1257,7 +1290,7 @@ class DriveDistance(AtomicCondition):
         Setup parameters
         """
         super(DriveDistance, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._target_distance = distance
         self._distance = 0
         self._location = None
@@ -1281,8 +1314,8 @@ class DriveDistance(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
         return new_status
 
 
@@ -1301,7 +1334,7 @@ class AtRightmostLane(AtomicCondition):
         Setup parameters
         """
         super(AtRightmostLane, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._actor = actor
         self._map = CarlaDataProvider.get_map()
 
@@ -1324,8 +1357,8 @@ class AtRightmostLane(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
         return new_status
 
 
@@ -1346,7 +1379,7 @@ class WaitForTrafficLightState(AtomicCondition):
         Setup traffic_light
         """
         super(WaitForTrafficLightState, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
         self._actor = actor if "traffic_light" in actor.type_id else None
         self._state = state
 
@@ -1363,8 +1396,8 @@ class WaitForTrafficLightState(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
-        )
+            "%s.update()[%s->%s]" %
+            (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -1380,7 +1413,7 @@ class WaitEndIntersection(AtomicCondition):
         self.actor = actor
         self.debug = debug
         self.inside_junction = False
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
 
     def update(self):
 
@@ -1422,7 +1455,7 @@ class WaitForBlackboardVariable(AtomicCondition):
         self._debug = debug
         self._variable_name = variable_name
         self._variable_value = variable_value
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
+        self.logger.debug("%s.__init__()" % self.__class__.__name__)
 
         if var_init_value is not None:
             blackboard = py_trees.blackboard.Blackboard()
@@ -1436,7 +1469,9 @@ class WaitForBlackboardVariable(AtomicCondition):
         value = blackv.get(self._variable_name)
         if value == self._variable_value:
             if self._debug:
-                print("Blackboard variable {} set to True".format(self._variable_name))
+                print(
+                    "Blackboard variable {} set to True".format(
+                        self._variable_name))
             new_status = py_trees.common.Status.SUCCESS
 
         return new_status

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -830,89 +830,12 @@ class InTimeToArrivalToVehicle(AtomicCondition):
 
     _max_time_to_arrival = float('inf')  # time to arrival in seconds
 
-    def __init__(self, actor, other_actor, time, along_route=False,
-                 comparison_operator=operator.lt, name="TimeToArrival"):
+    def __init__(self, actor, other_actor, time, condition_freespace=False,
+                 along_route=False, comparison_operator=operator.lt, name="TimeToArrival"):
         """
         Setup parameters
         """
         super(InTimeToArrivalToVehicle, self).__init__(name)
-        self.logger.debug("%s.__init__()" % (self.__class__.__name__))
-        self._map = CarlaDataProvider.get_map()
-        self._actor = actor
-        self._other_actor = other_actor
-        self._time = time
-        self._along_route = along_route
-        self._comparison_operator = comparison_operator
-
-        if self._along_route:
-            # Get the global route planner, used to calculate the route
-            dao = GlobalRoutePlannerDAO(self._map, 0.5)
-            grp = GlobalRoutePlanner(dao)
-            grp.setup()
-            self._grp = grp
-        else:
-            self._grp = None
-
-    def update(self):
-        """
-        Check if the ego vehicle can arrive at other actor within time
-        """
-        new_status = py_trees.common.Status.RUNNING
-
-        current_location = CarlaDataProvider.get_location(self._actor)
-        other_location = CarlaDataProvider.get_location(self._other_actor)
-
-        if current_location is None or other_location is None:
-            return new_status
-
-        current_velocity = CarlaDataProvider.get_velocity(self._actor)
-        other_velocity = CarlaDataProvider.get_velocity(self._other_actor)
-
-        if self._along_route:
-            # Global planner needs a location at a driving lane
-            current_location = self._map.get_waypoint(current_location).transform.location
-            other_location = self._map.get_waypoint(other_location).transform.location
-
-        distance = calculate_distance(current_location, other_location, self._grp)
-
-        # if velocity is too small, simply use a large time to arrival
-        time_to_arrival = self._max_time_to_arrival
-
-        if current_velocity > other_velocity:
-            time_to_arrival = 2 * distance / (current_velocity - other_velocity)
-
-        if self._comparison_operator(time_to_arrival, self._time):
-            new_status = py_trees.common.Status.SUCCESS
-
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
-
-        return new_status
-
-
-class InTimeToCollisionToVehicle(AtomicCondition):
-
-    """
-    This class contains a check of time to collision between two dynamic actors.
-
-    The distance calculation is done from edge to edge to the actors.
-
-    Important parameters:
-    - actor: CARLA actor to execute the behavior
-    - name: Name of the condition
-    - time: The behavior is successful, if TTA is less than _time_ in seconds
-    - other_actor: Reference actor used in this behavior
-
-    The condition terminates with SUCCESS, when the actor can reach the other vehicle within the given time
-    """
-
-    _max_time_to_arrival = float('inf')  # time to arrival in seconds
-
-    def __init__(self, actor, other_actor, time, condition_freespace, along_route=False,
-                 comparison_operator=operator.lt, name="TimeToArrival"):
-        """
-        Setup parameters
-        """
-        super(InTimeToCollisionToVehicle, self).__init__(name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
         self._map = CarlaDataProvider.get_map()
         self._actor = actor
@@ -956,11 +879,12 @@ class InTimeToCollisionToVehicle(AtomicCondition):
         # if velocity is too small, simply use a large time to arrival
         time_to_arrival = self._max_time_to_arrival
 
-        if self._condition_freespace:
-            time_to_arrival = (distance - self._actor.bounding_box.extent.x -
-                               self._other_actor.bounding_box.extent.x) / abs(other_velocity - current_velocity)
-        else:
-            time_to_arrival = distance / abs(other_velocity - current_velocity)
+        if current_velocity > other_velocity:
+            if self._condition_freespace:
+                time_to_arrival = (distance - self._actor.bounding_box.extent.x -
+                                   self._other_actor.bounding_box.extent.x) / (current_velocity - other_velocity)
+            else:
+                time_to_arrival = distance / (current_velocity - other_velocity)
 
         if self._comparison_operator(time_to_arrival, self._time):
             new_status = py_trees.common.Status.SUCCESS

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -75,7 +75,9 @@ class AtomicCondition(py_trees.behaviour.Behaviour):
         Default terminate. Can be extended in derived class
         """
         self.logger.debug(
-            "%s.terminate()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.terminate()[%s->%s]"
+            % (self.__class__.__name__, self.status, new_status)
+        )
 
 
 class InTriggerDistanceToOSCPosition(AtomicCondition):
@@ -92,8 +94,15 @@ class InTriggerDistanceToOSCPosition(AtomicCondition):
     The condition terminates with SUCCESS, when the actor reached the target distance to the openSCENARIO position
     """
 
-    def __init__(self, actor, osc_position, distance, along_route=False,
-                 comparison_operator=operator.lt, name="InTriggerDistanceToOSCPosition"):
+    def __init__(
+        self,
+        actor,
+        osc_position,
+        distance,
+        along_route=False,
+        comparison_operator=operator.lt,
+        name="InTriggerDistanceToOSCPosition",
+    ):
         """
         Setup parameters
         """
@@ -126,7 +135,8 @@ class InTriggerDistanceToOSCPosition(AtomicCondition):
 
         # calculate transform with method in openscenario_parser.py
         osc_transform = srunner.tools.openscenario_parser.OpenScenarioParser.convert_position_to_transform(
-            self._osc_position)
+            self._osc_position
+        )
 
         if osc_transform is not None:
             osc_location = osc_transform.location
@@ -135,12 +145,11 @@ class InTriggerDistanceToOSCPosition(AtomicCondition):
             if self._along_route:
                 # Global planner needs a location at a driving lane
                 actor_location = self._map.get_waypoint(
-                    actor_location).transform.location
-                osc_location = self._map.get_waypoint(
-                    osc_location).transform.location
+                    actor_location
+                ).transform.location
+                osc_location = self._map.get_waypoint(osc_location).transform.location
 
-            distance = calculate_distance(
-                actor_location, osc_location, self._grp)
+            distance = calculate_distance(actor_location, osc_location, self._grp)
 
             if self._comparison_operator(distance, self._distance):
                 new_status = py_trees.common.Status.SUCCESS
@@ -162,8 +171,15 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
     The condition terminates with SUCCESS, when the actor can reach the position within the given time
     """
 
-    def __init__(self, actor, osc_position, time, along_route=False,
-                 comparison_operator=operator.lt, name="InTimeToArrivalToOSCPosition"):
+    def __init__(
+        self,
+        actor,
+        osc_position,
+        time,
+        along_route=False,
+        comparison_operator=operator.lt,
+        name="InTimeToArrivalToOSCPosition",
+    ):
         """
         Setup parameters
         """
@@ -197,7 +213,8 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
         # calculate transform with method in openscenario_parser.py
         try:
             osc_transform = srunner.tools.openscenario_parser.OpenScenarioParser.convert_position_to_transform(
-                self._osc_position)
+                self._osc_position
+            )
         except AttributeError:
             return py_trees.common.Status.FAILURE
         target_location = osc_transform.location
@@ -208,13 +225,10 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
 
         if self._along_route:
             # Global planner needs a location at a driving lane
-            actor_location = self._map.get_waypoint(
-                actor_location).transform.location
-            target_location = self._map.get_waypoint(
-                target_location).transform.location
+            actor_location = self._map.get_waypoint(actor_location).transform.location
+            target_location = self._map.get_waypoint(target_location).transform.location
 
-        distance = calculate_distance(
-            actor_location, target_location, self._grp)
+        distance = calculate_distance(actor_location, target_location, self._grp)
 
         actor_velocity = CarlaDataProvider.get_velocity(self._actor)
 
@@ -224,7 +238,7 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
         elif distance == 0:
             time_to_arrival = 0
         else:
-            time_to_arrival = float('inf')
+            time_to_arrival = float("inf")
 
         if self._comparison_operator(time_to_arrival, self._time):
             new_status = py_trees.common.Status.SUCCESS
@@ -276,7 +290,8 @@ class StandStill(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -295,8 +310,14 @@ class RelativeVelocityToOtherActor(AtomicCondition):
         comparison_operator: Type "operator", used to compare the two velocities
     """
 
-    def __init__(self, actor, other_actor, speed, comparison_operator=operator.gt,
-                 name="RelativeVelocityToOtherActor"):
+    def __init__(
+        self,
+        actor,
+        other_actor,
+        speed,
+        comparison_operator=operator.gt,
+        name="RelativeVelocityToOtherActor",
+    ):
         """
         Setup the parameters
         """
@@ -326,7 +347,8 @@ class RelativeVelocityToOtherActor(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -344,7 +366,13 @@ class TriggerVelocity(AtomicCondition):
         comparison_operator: Type "operator", used to compare the two velocities
     """
 
-    def __init__(self, actor, target_velocity, comparison_operator=operator.gt, name="TriggerVelocity"):
+    def __init__(
+        self,
+        actor,
+        target_velocity,
+        comparison_operator=operator.gt,
+        name="TriggerVelocity",
+    ):
         """
         Setup the atomic parameters
         """
@@ -370,7 +398,8 @@ class TriggerVelocity(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -388,7 +417,13 @@ class TriggerAcceleration(AtomicCondition):
         comparison_operator (operator): Type "operator", used to compare the two acceleration
     """
 
-    def __init__(self, actor, target_acceleration, comparison_operator=operator.gt, name="TriggerAcceleration"):
+    def __init__(
+        self,
+        actor,
+        target_acceleration,
+        comparison_operator=operator.gt,
+        name="TriggerAcceleration",
+    ):
         """
         Setup trigger acceleration
         """
@@ -409,15 +444,18 @@ class TriggerAcceleration(AtomicCondition):
         new_status = py_trees.common.Status.RUNNING
 
         acceleration = self._actor.get_acceleration()
-        linear_accel = math.sqrt(math.pow(acceleration.x, 2) +
-                                 math.pow(acceleration.y, 2) +
-                                 math.pow(acceleration.z, 2))
+        linear_accel = math.sqrt(
+            math.pow(acceleration.x, 2)
+            + math.pow(acceleration.y, 2)
+            + math.pow(acceleration.z, 2)
+        )
 
         if self._comparison_operator(linear_accel, self._target_acceleration):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -435,13 +473,13 @@ class TimeOfDayComparison(AtomicCondition):
         comparison_operator (operator): Type "operator", used to compare the two acceleration
     """
 
-    def __init__(self, dattime, comparison_operator=operator.gt, name="TimeOfDayComparison"):
-        """
-        """
+    def __init__(
+        self, dattime, comparison_operator=operator.gt, name="TimeOfDayComparison"
+    ):
+        """"""
         super(TimeOfDayComparison, self).__init__(name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
-        self._datetime = datetime.datetime.strptime(
-            dattime, "%Y-%m-%dT%H:%M:%S")
+        self._datetime = datetime.datetime.strptime(dattime, "%Y-%m-%dT%H:%M:%S")
         self._comparison_operator = comparison_operator
 
     def update(self):
@@ -464,7 +502,8 @@ class TimeOfDayComparison(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -508,13 +547,15 @@ class OSCStartEndCondition(AtomicCondition):
 
         if new_status == py_trees.common.Status.RUNNING:
             blackboard_variable_name = "({}){}-{}".format(
-                self._element_type, self._element_name, self._rule)
+                self._element_type, self._element_name, self._rule
+            )
             element_start_time = self._blackboard.get(blackboard_variable_name)
             if element_start_time and element_start_time >= self._start_time:
                 new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -549,19 +590,20 @@ class InTriggerRegion(AtomicCondition):
         Check if the _actor location is within trigger region
         """
         new_status = py_trees.common.Status.RUNNING
-
         location = CarlaDataProvider.get_location(self._actor)
 
         if location is None:
             return new_status
 
-        not_in_region = (location.x < self._min_x or location.x > self._max_x) or \
-                        (location.y < self._min_y or location.y > self._max_y)
+        not_in_region = (location.x < self._min_x or location.x > self._max_x) or (
+            location.y < self._min_y or location.y > self._max_y
+        )
         if not not_in_region:
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -581,8 +623,14 @@ class InTriggerDistanceToVehicle(AtomicCondition):
     The condition terminates with SUCCESS, when the actor reached the target distance to the other actor
     """
 
-    def __init__(self, reference_actor, actor, distance, comparison_operator=operator.lt,
-                 name="TriggerDistanceToVehicle"):
+    def __init__(
+        self,
+        reference_actor,
+        actor,
+        distance,
+        comparison_operator=operator.lt,
+        name="TriggerDistanceToVehicle",
+    ):
         """
         Setup trigger distance
         """
@@ -600,17 +648,19 @@ class InTriggerDistanceToVehicle(AtomicCondition):
         new_status = py_trees.common.Status.RUNNING
 
         location = CarlaDataProvider.get_location(self._actor)
-        reference_location = CarlaDataProvider.get_location(
-            self._reference_actor)
+        reference_location = CarlaDataProvider.get_location(self._reference_actor)
 
         if location is None or reference_location is None:
             return new_status
 
-        if self._comparison_operator(calculate_distance(location, reference_location), self._distance):
+        if self._comparison_operator(
+            calculate_distance(location, reference_location), self._distance
+        ):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -629,12 +679,14 @@ class InTriggerDistanceToLocation(AtomicCondition):
     The condition terminates with SUCCESS, when the actor reached the target distance to the given location
     """
 
-    def __init__(self,
-                 actor,
-                 target_location,
-                 distance,
-                 comparison_operator=operator.lt,
-                 name="InTriggerDistanceToLocation"):
+    def __init__(
+        self,
+        actor,
+        target_location,
+        distance,
+        comparison_operator=operator.lt,
+        name="InTriggerDistanceToLocation",
+    ):
         """
         Setup trigger distance
         """
@@ -657,12 +709,14 @@ class InTriggerDistanceToLocation(AtomicCondition):
         if location is None:
             return new_status
 
-        if self._comparison_operator(calculate_distance(
-                location, self._target_location), self._distance):
+        if self._comparison_operator(
+            calculate_distance(location, self._target_location), self._distance
+        ):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -703,15 +757,18 @@ class InTriggerDistanceToNextIntersection(AtomicCondition):
         new_status = py_trees.common.Status.RUNNING
 
         current_waypoint = self._map.get_waypoint(
-            CarlaDataProvider.get_location(self._actor))
+            CarlaDataProvider.get_location(self._actor)
+        )
         distance = calculate_distance(
-            current_waypoint.transform.location, self._final_location)
+            current_waypoint.transform.location, self._final_location
+        )
 
         if distance < self._distance:
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -732,7 +789,14 @@ class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
     along its route to the given location
     """
 
-    def __init__(self, actor, route, location, distance, name="InTriggerDistanceToLocationAlongRoute"):
+    def __init__(
+        self,
+        actor,
+        route,
+        location,
+        distance,
+        name="InTriggerDistanceToLocationAlongRoute",
+    ):
         """
         Setup class members
         """
@@ -744,7 +808,8 @@ class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
         self._distance = distance
 
         self._location_distance, _ = get_distance_along_route(
-            self._route, self._location)
+            self._route, self._location
+        )
 
     def update(self):
         new_status = py_trees.common.Status.RUNNING
@@ -756,13 +821,13 @@ class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
 
         if current_location.distance(self._location) < self._distance + 20:
 
-            actor_distance, _ = get_distance_along_route(
-                self._route, current_location)
+            actor_distance, _ = get_distance_along_route(self._route, current_location)
 
             # If closer than self._distance and hasn't passed the trigger point
-            if (self._location_distance < actor_distance + self._distance and
-                actor_distance < self._location_distance) or \
-                    self._location_distance < 1.0:
+            if (
+                self._location_distance < actor_distance + self._distance
+                and actor_distance < self._location_distance
+            ) or self._location_distance < 1.0:
                 new_status = py_trees.common.Status.SUCCESS
 
         return new_status
@@ -782,9 +847,16 @@ class InTimeToArrivalToLocation(AtomicCondition):
     The condition terminates with SUCCESS, when the actor can reach the target location within the given time
     """
 
-    _max_time_to_arrival = float('inf')  # time to arrival in seconds
+    _max_time_to_arrival = float("inf")  # time to arrival in seconds
 
-    def __init__(self, actor, time, location, comparison_operator=operator.lt, name="TimeToArrival"):
+    def __init__(
+        self,
+        actor,
+        time,
+        location,
+        comparison_operator=operator.lt,
+        name="TimeToArrival",
+    ):
         """
         Setup parameters
         """
@@ -818,7 +890,8 @@ class InTimeToArrivalToLocation(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -837,10 +910,17 @@ class InTimeToArrivalToVehicle(AtomicCondition):
     The condition terminates with SUCCESS, when the actor can reach the other vehicle within the given time
     """
 
-    _max_time_to_arrival = float('inf')  # time to arrival in seconds
+    _max_time_to_arrival = float("inf")  # time to arrival in seconds
 
-    def __init__(self, actor, other_actor, time, along_route=False,
-                 comparison_operator=operator.lt, name="TimeToArrival"):
+    def __init__(
+        self,
+        actor,
+        other_actor,
+        time,
+        along_route=False,
+        comparison_operator=operator.lt,
+        name="TimeToArrival",
+    ):
         """
         Setup parameters
         """
@@ -880,25 +960,24 @@ class InTimeToArrivalToVehicle(AtomicCondition):
         if self._along_route:
             # Global planner needs a location at a driving lane
             current_location = self._map.get_waypoint(
-                current_location).transform.location
-            other_location = self._map.get_waypoint(
-                other_location).transform.location
+                current_location
+            ).transform.location
+            other_location = self._map.get_waypoint(other_location).transform.location
 
-        distance = calculate_distance(
-            current_location, other_location, self._grp)
+        distance = calculate_distance(current_location, other_location, self._grp)
 
         # if velocity is too small, simply use a large time to arrival
         time_to_arrival = self._max_time_to_arrival
 
         if current_velocity > other_velocity:
-            time_to_arrival = 2 * distance / \
-                (current_velocity - other_velocity)
+            time_to_arrival = 2 * distance / (current_velocity - other_velocity)
 
         if self._comparison_operator(time_to_arrival, self._time):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -917,10 +996,18 @@ class InTimeToCollisionToVehicle(AtomicCondition):
     The condition terminates with SUCCESS, when the actor can reach the other vehicle within the given time
     """
 
-    _max_time_to_arrival = float('inf')  # time to arrival in seconds
+    _max_time_to_arrival = float("inf")  # time to arrival in seconds
 
-    def __init__(self, actor, other_actor, time, condition_freespace, along_route=False,
-                 comparison_operator=operator.lt, name="TimeToArrival"):
+    def __init__(
+        self,
+        actor,
+        other_actor,
+        time,
+        condition_freespace,
+        along_route=False,
+        comparison_operator=operator.lt,
+        name="TimeToArrival",
+    ):
         """
         Setup parameters
         """
@@ -961,19 +1048,21 @@ class InTimeToCollisionToVehicle(AtomicCondition):
         if self._along_route:
             # Global planner needs a location at a driving lane
             current_location = self._map.get_waypoint(
-                current_location).transform.location
-            other_location = self._map.get_waypoint(
-                other_location).transform.location
+                current_location
+            ).transform.location
+            other_location = self._map.get_waypoint(other_location).transform.location
 
-        distance = calculate_distance(
-            current_location, other_location, self._grp)
+        distance = calculate_distance(current_location, other_location, self._grp)
 
         # if velocity is too small, simply use a large time to arrival
         time_to_arrival = self._max_time_to_arrival
 
         if self._condition_freespace:
-            time_to_arrival = (distance - self._actor.bounding_box.extent.x -
-                               self._other_actor.bounding_box.extent.x) / abs(other_velocity - current_velocity)
+            time_to_arrival = (
+                distance
+                - self._actor.bounding_box.extent.x
+                - self._other_actor.bounding_box.extent.x
+            ) / abs(other_velocity - current_velocity)
         else:
             time_to_arrival = distance / abs(other_velocity - current_velocity)
 
@@ -981,7 +1070,8 @@ class InTimeToCollisionToVehicle(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -1001,10 +1091,17 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
     The condition terminates with SUCCESS, when the actor can reach the other vehicle within the given time
     """
 
-    _max_time_to_arrival = float('inf')  # time to arrival in seconds
+    _max_time_to_arrival = float("inf")  # time to arrival in seconds
 
-    def __init__(self, actor, other_actor, time, side_lane,
-                 comparison_operator=operator.lt, name="InTimeToArrivalToVehicleSideLane"):
+    def __init__(
+        self,
+        actor,
+        other_actor,
+        time,
+        side_lane,
+        comparison_operator=operator.lt,
+        name="InTimeToArrivalToVehicleSideLane",
+    ):
         """
         Setup parameters
         """
@@ -1017,9 +1114,9 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
         other_location = other_actor.get_transform().location
         other_waypoint = self._map.get_waypoint(other_location)
 
-        if self._side_lane == 'right':
+        if self._side_lane == "right":
             other_side_waypoint = other_waypoint.get_left_lane()
-        elif self._side_lane == 'left':
+        elif self._side_lane == "left":
             other_side_waypoint = other_waypoint.get_right_lane()
         else:
             raise Exception("cut_in_lane must be either 'left' or 'right'")
@@ -1027,7 +1124,8 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
         other_side_location = other_side_waypoint.transform.location
 
         super(InTimeToArrivalToVehicleSideLane, self).__init__(
-            actor, time, other_side_location, comparison_operator, name)
+            actor, time, other_side_location, comparison_operator, name
+        )
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
 
     def update(self):
@@ -1039,9 +1137,9 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
         other_location = CarlaDataProvider.get_location(self._other_actor)
         other_waypoint = self._map.get_waypoint(other_location)
 
-        if self._side_lane == 'right':
+        if self._side_lane == "right":
             other_side_waypoint = other_waypoint.get_left_lane()
-        elif self._side_lane == 'left':
+        elif self._side_lane == "left":
             other_side_waypoint = other_waypoint.get_right_lane()
         else:
             raise Exception("cut_in_lane must be either 'left' or 'right'")
@@ -1070,7 +1168,9 @@ class WaitUntilInFront(AtomicCondition):
         1: The front of the other_actor and the back of the actor are right next to each other
     """
 
-    def __init__(self, actor, other_actor, factor=1, check_distance=True, name="WaitUntilInFront"):
+    def __init__(
+        self, actor, other_actor, factor=1, check_distance=True, name="WaitUntilInFront"
+    ):
         """
         Init
         """
@@ -1117,8 +1217,11 @@ class WaitUntilInFront(AtomicCondition):
         # Wait for the vehicle to be in front
         other_dir = other_next_waypoint.transform.get_forward_vector()
         act_other_dir = actor_location - other_next_waypoint.transform.location
-        dot_ve_wp = other_dir.x * act_other_dir.x + other_dir.y * \
-            act_other_dir.y + other_dir.z * act_other_dir.z
+        dot_ve_wp = (
+            other_dir.x * act_other_dir.x
+            + other_dir.y * act_other_dir.y
+            + other_dir.z * act_other_dir.z
+        )
 
         if dot_ve_wp > 0.0:
             in_front = True
@@ -1126,7 +1229,10 @@ class WaitUntilInFront(AtomicCondition):
         # Wait for it to be close-by
         if not self._check_distance:
             close_by = True
-        elif actor_location.distance(other_next_waypoint.transform.location) < self._distance:
+        elif (
+            actor_location.distance(other_next_waypoint.transform.location)
+            < self._distance
+        ):
             close_by = True
 
         if in_front and close_by:
@@ -1175,7 +1281,8 @@ class DriveDistance(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
         return new_status
 
 
@@ -1217,7 +1324,8 @@ class AtRightmostLane(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
         return new_status
 
 
@@ -1255,7 +1363,8 @@ class WaitForTrafficLightState(AtomicCondition):
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug(
-            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status)
+        )
 
         return new_status
 
@@ -1301,8 +1410,14 @@ class WaitForBlackboardVariable(AtomicCondition):
     It also initially sets the variable to a given value, if given
     """
 
-    def __init__(self, variable_name, variable_value, var_init_value=None,
-                 debug=False, name="WaitForBlackboardVariable"):
+    def __init__(
+        self,
+        variable_name,
+        variable_value,
+        var_init_value=None,
+        debug=False,
+        name="WaitForBlackboardVariable",
+    ):
         super(WaitForBlackboardVariable, self).__init__(name)
         self._debug = debug
         self._variable_name = variable_name
@@ -1321,8 +1436,7 @@ class WaitForBlackboardVariable(AtomicCondition):
         value = blackv.get(self._variable_name)
         if value == self._variable_value:
             if self._debug:
-                print("Blackboard variable {} set to True".format(
-                    self._variable_name))
+                print("Blackboard variable {} set to True".format(self._variable_name))
             new_status = py_trees.common.Status.SUCCESS
 
         return new_status

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -40,7 +40,6 @@ EPSILON = 0.001
 
 
 class AtomicCondition(py_trees.behaviour.Behaviour):
-
     """
     Base class for all atomic conditions used to setup a scenario
 
@@ -79,7 +78,6 @@ class AtomicCondition(py_trees.behaviour.Behaviour):
 
 
 class InTriggerDistanceToOSCPosition(AtomicCondition):
-
     """
     OpenSCENARIO atomic
     This class contains the trigger condition for a distance to an OpenSCENARIO position
@@ -147,7 +145,6 @@ class InTriggerDistanceToOSCPosition(AtomicCondition):
 
 
 class InTimeToArrivalToOSCPosition(AtomicCondition):
-
     """
     OpenSCENARIO atomic
     This class contains a trigger if an actor arrives within a given time to an OpenSCENARIO position
@@ -228,7 +225,6 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
 
 
 class StandStill(AtomicCondition):
-
     """
     This class contains a standstill behavior of a scenario
 
@@ -278,7 +274,6 @@ class StandStill(AtomicCondition):
 
 
 class RelativeVelocityToOtherActor(AtomicCondition):
-
     """
     Atomic containing a comparison between an actor's velocity
     and another actor's one. The behavior returns SUCCESS when the
@@ -328,7 +323,6 @@ class RelativeVelocityToOtherActor(AtomicCondition):
 
 
 class TriggerVelocity(AtomicCondition):
-
     """
     Atomic containing a comparison between an actor's speed and a reference one.
     The behavior returns SUCCESS when the expected comparison (greater than /
@@ -372,7 +366,6 @@ class TriggerVelocity(AtomicCondition):
 
 
 class TriggerAcceleration(AtomicCondition):
-
     """
     Atomic containing a comparison between an actor's acceleration
     and a reference one. The behavior returns SUCCESS when the
@@ -419,7 +412,6 @@ class TriggerAcceleration(AtomicCondition):
 
 
 class TimeOfDayComparison(AtomicCondition):
-
     """
     Atomic containing a comparison between the current time of day of the simulation
     and a given one. The behavior returns SUCCESS when the
@@ -465,7 +457,6 @@ class TimeOfDayComparison(AtomicCondition):
 
 
 class OSCStartEndCondition(AtomicCondition):
-
     """
     This class contains a check if a named story element has started/terminated.
 
@@ -514,7 +505,6 @@ class OSCStartEndCondition(AtomicCondition):
 
 
 class InTriggerRegion(AtomicCondition):
-
     """
     This class contains the trigger region (condition) of a scenario
 
@@ -551,7 +541,7 @@ class InTriggerRegion(AtomicCondition):
             return new_status
 
         not_in_region = (location.x < self._min_x or location.x > self._max_x) or (
-            location.y < self._min_y or location.y > self._max_y)
+                location.y < self._min_y or location.y > self._max_y)
         if not not_in_region:
             new_status = py_trees.common.Status.SUCCESS
 
@@ -561,7 +551,6 @@ class InTriggerRegion(AtomicCondition):
 
 
 class InTriggerDistanceToVehicle(AtomicCondition):
-
     """
     This class contains the trigger distance (condition) between to actors
     of a scenario
@@ -609,7 +598,6 @@ class InTriggerDistanceToVehicle(AtomicCondition):
 
 
 class InTriggerDistanceToLocation(AtomicCondition):
-
     """
     This class contains the trigger (condition) for a distance to a fixed
     location of a scenario
@@ -661,7 +649,6 @@ class InTriggerDistanceToLocation(AtomicCondition):
 
 
 class InTriggerDistanceToNextIntersection(AtomicCondition):
-
     """
     This class contains the trigger (condition) for a distance to the
     next intersection of a scenario
@@ -708,7 +695,6 @@ class InTriggerDistanceToNextIntersection(AtomicCondition):
 
 
 class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
-
     """
     Implementation for a behavior that will check if a given actor
     is within a given distance to a given location considering a given route
@@ -759,7 +745,6 @@ class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
 
 
 class InTimeToArrivalToLocation(AtomicCondition):
-
     """
     This class contains a check if a actor arrives within a given time
     at a given location.
@@ -814,7 +799,6 @@ class InTimeToArrivalToLocation(AtomicCondition):
 
 
 class InTimeToArrivalToVehicle(AtomicCondition):
-
     """
     This class contains a check if a actor arrives within a given time
     at another actor.
@@ -890,7 +874,6 @@ class InTimeToArrivalToVehicle(AtomicCondition):
 
 
 class InTimeToCollisionToVehicle(AtomicCondition):
-
     """
     This class contains a check of time to collision between two dynamic actors.
     The distance calculation is done from edge to edge to the actors.
@@ -957,7 +940,7 @@ class InTimeToCollisionToVehicle(AtomicCondition):
 
         if self._condition_freespace:
             time_to_arrival = (distance - self._actor.bounding_box.extent.x -
-                                self._other_actor.bounding_box.extent.x) / abs(other_velocity - current_velocity)
+                               self._other_actor.bounding_box.extent.x) / abs(other_velocity - current_velocity)
         else:
             time_to_arrival = distance / abs(other_velocity - current_velocity)
 
@@ -970,7 +953,6 @@ class InTimeToCollisionToVehicle(AtomicCondition):
 
 
 class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
-
     """
     This class contains a check if a actor arrives within a given time
     at another actor's side lane. Inherits from InTimeToArrivalToLocation
@@ -1043,7 +1025,6 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
 
 
 class WaitUntilInFront(AtomicCondition):
-
     """
     Behavior that support the creation of cut ins. It waits until the actor has passed another actor
 
@@ -1120,7 +1101,6 @@ class WaitUntilInFront(AtomicCondition):
 
 
 class DriveDistance(AtomicCondition):
-
     """
     This class contains an atomic behavior to drive a certain distance.
 
@@ -1164,7 +1144,6 @@ class DriveDistance(AtomicCondition):
 
 
 class AtRightmostLane(AtomicCondition):
-
     """
     This class contains an atomic behavior to check if the actor is at the rightest driving lane.
 
@@ -1206,7 +1185,6 @@ class AtRightmostLane(AtomicCondition):
 
 
 class WaitForTrafficLightState(AtomicCondition):
-
     """
     This class contains an atomic behavior to wait for a given traffic light
     to have the desired state.
@@ -1245,7 +1223,6 @@ class WaitForTrafficLightState(AtomicCondition):
 
 
 class WaitEndIntersection(AtomicCondition):
-
     """
     Atomic behavior that waits until the vehicles has gone outside the junction.
     If currently inside no intersection, it will wait until one is found
@@ -1279,7 +1256,6 @@ class WaitEndIntersection(AtomicCondition):
 
 
 class WaitForBlackboardVariable(AtomicCondition):
-
     """
     Atomic behavior that keeps running until the blackboard variable is set to the corresponding value.
     Used to avoid returning FAILURE if the blackboard comparison fails.

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -9,9 +9,11 @@
 This module provides all atomic scenario behaviors that reflect
 trigger conditions to either activate another behavior, or to stop
 another behavior.
+
 For example, such a condition could be "InTriggerRegion", which checks
 that a given actor reached a certain region on the map, and then starts/stops
 a behavior of this actor.
+
 The atomics are implemented with py_trees and make use of the AtomicCondition
 base class
 """
@@ -41,7 +43,9 @@ class AtomicCondition(py_trees.behaviour.Behaviour):
 
     """
     Base class for all atomic conditions used to setup a scenario
+
     *All behaviors should use this class as parent*
+
     Important parameters:
     - name: Name of the atomic condition
     """
@@ -79,11 +83,13 @@ class InTriggerDistanceToOSCPosition(AtomicCondition):
     """
     OpenSCENARIO atomic
     This class contains the trigger condition for a distance to an OpenSCENARIO position
+
     Args:
         actor (carla.Actor): CARLA actor to execute the behavior
         osc_position (str): OpenSCENARIO position
         distance (float): Trigger distance between the actor and the target location in meters
         name (str): Name of the condition
+
     The condition terminates with SUCCESS, when the actor reached the target distance to the openSCENARIO position
     """
 
@@ -145,11 +151,13 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
     """
     OpenSCENARIO atomic
     This class contains a trigger if an actor arrives within a given time to an OpenSCENARIO position
+
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - osc_position: OpenSCENARIO position
     - time: The behavior is successful, if TTA is less than _time_ in seconds
     - name: Name of the condition
+
     The condition terminates with SUCCESS, when the actor can reach the position within the given time
     """
 
@@ -223,10 +231,12 @@ class StandStill(AtomicCondition):
 
     """
     This class contains a standstill behavior of a scenario
+
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - duration: Duration of the behavior in seconds
+
     The condition terminates with SUCCESS, when the actor does not move
     """
 
@@ -273,6 +283,7 @@ class RelativeVelocityToOtherActor(AtomicCondition):
     Atomic containing a comparison between an actor's velocity
     and another actor's one. The behavior returns SUCCESS when the
     expected comparison (greater than / less than / equal to) is achieved
+
     Args:
         actor (carla.Actor): actor from which the velocity is taken
         other_actor (carla.Actor): The actor with the reference velocity
@@ -296,6 +307,7 @@ class RelativeVelocityToOtherActor(AtomicCondition):
     def update(self):
         """
         Gets the speed of the two actors and compares them according to the comparison operator
+
         returns:
             py_trees.common.Status.RUNNING when the comparison fails and
             py_trees.common.Status.SUCCESS when it succeeds
@@ -321,6 +333,7 @@ class TriggerVelocity(AtomicCondition):
     Atomic containing a comparison between an actor's speed and a reference one.
     The behavior returns SUCCESS when the expected comparison (greater than /
     less than / equal to) is achieved.
+
     Args:
         actor (carla.Actor): CARLA actor from which the speed will be taken.
         name (string): Name of the atomic
@@ -341,6 +354,7 @@ class TriggerVelocity(AtomicCondition):
     def update(self):
         """
         Gets the speed of the actor and compares it with the reference one
+
         returns:
             py_trees.common.Status.RUNNING when the comparison fails and
             py_trees.common.Status.SUCCESS when it succeeds
@@ -363,6 +377,7 @@ class TriggerAcceleration(AtomicCondition):
     Atomic containing a comparison between an actor's acceleration
     and a reference one. The behavior returns SUCCESS when the
     expected comparison (greater than / less than / equal to) is achieved
+
     Args:
         actor (carla.Actor): CARLA actor to execute the behavior
         name (str): Name of the condition
@@ -383,6 +398,7 @@ class TriggerAcceleration(AtomicCondition):
     def update(self):
         """
         Gets the accleration of the actor and compares it with the reference one
+
         returns:
             py_trees.common.Status.RUNNING when the comparison fails and
             py_trees.common.Status.SUCCESS when it succeeds
@@ -408,6 +424,7 @@ class TimeOfDayComparison(AtomicCondition):
     Atomic containing a comparison between the current time of day of the simulation
     and a given one. The behavior returns SUCCESS when the
     expected comparison (greater than / less than / equal to) is achieved
+
     Args:
         datetime (datetime): CARLA actor to execute the behavior
         name (str): Name of the condition
@@ -426,6 +443,7 @@ class TimeOfDayComparison(AtomicCondition):
     def update(self):
         """
         Gets the time of day of the simulation and compares it with the reference one
+
         returns:
             py_trees.common.Status.RUNNING when the comparison fails and
             py_trees.common.Status.SUCCESS when it succeeds
@@ -450,10 +468,12 @@ class OSCStartEndCondition(AtomicCondition):
 
     """
     This class contains a check if a named story element has started/terminated.
+
     Important parameters:
     - element_name: The story element's name attribute
     - element_type: The element type [act,scene,maneuver,event,action]
     - rule: Either START or END
+
     The condition terminates with SUCCESS, when the named story element starts
     """
 
@@ -497,10 +517,12 @@ class InTriggerRegion(AtomicCondition):
 
     """
     This class contains the trigger region (condition) of a scenario
+
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - min_x, max_x, min_y, max_y: bounding box of the trigger region
+
     The condition terminates with SUCCESS, when the actor reached the target region
     """
 
@@ -543,12 +565,14 @@ class InTriggerDistanceToVehicle(AtomicCondition):
     """
     This class contains the trigger distance (condition) between to actors
     of a scenario
+
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - reference_actor: Reference CARLA actor
     - name: Name of the condition
     - distance: Trigger distance between the two actors in meters
     - dx, dy, dz: distance to reference_location (location of reference_actor)
+
     The condition terminates with SUCCESS, when the actor reached the target distance to the other actor
     """
 
@@ -589,11 +613,13 @@ class InTriggerDistanceToLocation(AtomicCondition):
     """
     This class contains the trigger (condition) for a distance to a fixed
     location of a scenario
+
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - target_location: Reference location (carla.location)
     - name: Name of the condition
     - distance: Trigger distance between the actor and the target location in meters
+
     The condition terminates with SUCCESS, when the actor reached the target distance to the given location
     """
 
@@ -639,10 +665,12 @@ class InTriggerDistanceToNextIntersection(AtomicCondition):
     """
     This class contains the trigger (condition) for a distance to the
     next intersection of a scenario
+
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - distance: Trigger distance between the actor and the next intersection in meters
+
     The condition terminates with SUCCESS, when the actor reached the target distance to the next intersection
     """
 
@@ -684,12 +712,14 @@ class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
     """
     Implementation for a behavior that will check if a given actor
     is within a given distance to a given location considering a given route
+
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - distance: Trigger distance between the actor and the next intersection in meters
     - route: Route to be checked
     - location: Location on the route to be checked
+
     The condition terminates with SUCCESS, when the actor reached the target distance
     along its route to the given location
     """
@@ -733,11 +763,13 @@ class InTimeToArrivalToLocation(AtomicCondition):
     """
     This class contains a check if a actor arrives within a given time
     at a given location.
+
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - time: The behavior is successful, if TTA is less than _time_ in seconds
     - location: Location to be checked in this behavior
+
     The condition terminates with SUCCESS, when the actor can reach the target location within the given time
     """
 
@@ -786,11 +818,13 @@ class InTimeToArrivalToVehicle(AtomicCondition):
     """
     This class contains a check if a actor arrives within a given time
     at another actor.
+
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - time: The behavior is successful, if TTA is less than _time_ in seconds
     - other_actor: Reference actor used in this behavior
+
     The condition terminates with SUCCESS, when the actor can reach the other vehicle within the given time
     """
 
@@ -859,12 +893,15 @@ class InTimeToCollisionToVehicle(AtomicCondition):
 
     """
     This class contains a check of time to collision between two dynamic actors.
+
     The distance calculation is done from edge to edge to the actors.
+
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - time: The behavior is successful, if TTA is less than _time_ in seconds
     - other_actor: Reference actor used in this behavior
+
     The condition terminates with SUCCESS, when the actor can reach the other vehicle within the given time
     """
 
@@ -938,12 +975,14 @@ class InTimeToArrivalToVehicleSideLane(InTimeToArrivalToLocation):
     """
     This class contains a check if a actor arrives within a given time
     at another actor's side lane. Inherits from InTimeToArrivalToLocation
+
     Important parameters:
     - actor: CARLA actor to execute the behavior
     - name: Name of the condition
     - time: The behavior is successful, if TTA is less than _time_ in seconds
     - cut_in_lane: the lane from where the other_actor will do the cut in
     - other_actor: Reference actor used in this behavior
+
     The condition terminates with SUCCESS, when the actor can reach the other vehicle within the given time
     """
 
@@ -1008,6 +1047,7 @@ class WaitUntilInFront(AtomicCondition):
 
     """
     Behavior that support the creation of cut ins. It waits until the actor has passed another actor
+
     Parameters:
     - actor: the one getting in front of the other actor
     - other_actor: the reference vehicle that the actor will have to get in front of
@@ -1084,9 +1124,11 @@ class DriveDistance(AtomicCondition):
 
     """
     This class contains an atomic behavior to drive a certain distance.
+
     Important parameters:
     - actor: CARLA actor to execute the condition
     - distance: Distance for this condition in meters
+
     The condition terminates with SUCCESS, when the actor drove at least the given distance
     """
 
@@ -1126,8 +1168,10 @@ class AtRightmostLane(AtomicCondition):
 
     """
     This class contains an atomic behavior to check if the actor is at the rightest driving lane.
+
     Important parameters:
     - actor: CARLA actor to execute the condition
+
     The condition terminates with SUCCESS, when the actor enters the rightest lane
     """
 
@@ -1167,9 +1211,11 @@ class WaitForTrafficLightState(AtomicCondition):
     """
     This class contains an atomic behavior to wait for a given traffic light
     to have the desired state.
+
     Args:
         actor (carla.TrafficLight): CARLA traffic light to execute the condition
         state (carla.TrafficLightState): State to be checked in this condition
+
     The condition terminates with SUCCESS, when the traffic light switches to the desired state
     """
 
@@ -1238,6 +1284,7 @@ class WaitForBlackboardVariable(AtomicCondition):
     """
     Atomic behavior that keeps running until the blackboard variable is set to the corresponding value.
     Used to avoid returning FAILURE if the blackboard comparison fails.
+
     It also initially sets the variable to a given value, if given
     """
 

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -74,7 +74,8 @@ class AtomicCondition(py_trees.behaviour.Behaviour):
         """
         Default terminate. Can be extended in derived class
         """
-        self.logger.debug("%s.terminate()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.terminate()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
 
 class InTriggerDistanceToOSCPosition(AtomicCondition):
@@ -133,10 +134,13 @@ class InTriggerDistanceToOSCPosition(AtomicCondition):
 
             if self._along_route:
                 # Global planner needs a location at a driving lane
-                actor_location = self._map.get_waypoint(actor_location).transform.location
-                osc_location = self._map.get_waypoint(osc_location).transform.location
+                actor_location = self._map.get_waypoint(
+                    actor_location).transform.location
+                osc_location = self._map.get_waypoint(
+                    osc_location).transform.location
 
-            distance = calculate_distance(actor_location, osc_location, self._grp)
+            distance = calculate_distance(
+                actor_location, osc_location, self._grp)
 
             if self._comparison_operator(distance, self._distance):
                 new_status = py_trees.common.Status.SUCCESS
@@ -204,10 +208,13 @@ class InTimeToArrivalToOSCPosition(AtomicCondition):
 
         if self._along_route:
             # Global planner needs a location at a driving lane
-            actor_location = self._map.get_waypoint(actor_location).transform.location
-            target_location = self._map.get_waypoint(target_location).transform.location
+            actor_location = self._map.get_waypoint(
+                actor_location).transform.location
+            target_location = self._map.get_waypoint(
+                target_location).transform.location
 
-        distance = calculate_distance(actor_location, target_location, self._grp)
+        distance = calculate_distance(
+            actor_location, target_location, self._grp)
 
         actor_velocity = CarlaDataProvider.get_velocity(self._actor)
 
@@ -268,7 +275,8 @@ class StandStill(AtomicCondition):
         if GameTime.get_time() - self._start_time > self._duration:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -317,7 +325,8 @@ class RelativeVelocityToOtherActor(AtomicCondition):
         if self._comparison_operator(relative_speed, self._relative_speed):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -360,7 +369,8 @@ class TriggerVelocity(AtomicCondition):
         if self._comparison_operator(actor_speed, self._target_velocity):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -406,7 +416,8 @@ class TriggerAcceleration(AtomicCondition):
         if self._comparison_operator(linear_accel, self._target_acceleration):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -429,7 +440,8 @@ class TimeOfDayComparison(AtomicCondition):
         """
         super(TimeOfDayComparison, self).__init__(name)
         self.logger.debug("%s.__init__()" % (self.__class__.__name__))
-        self._datetime = datetime.datetime.strptime(dattime, "%Y-%m-%dT%H:%M:%S")
+        self._datetime = datetime.datetime.strptime(
+            dattime, "%Y-%m-%dT%H:%M:%S")
         self._comparison_operator = comparison_operator
 
     def update(self):
@@ -451,7 +463,8 @@ class TimeOfDayComparison(AtomicCondition):
         if self._comparison_operator(dtime, self._datetime):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -494,12 +507,14 @@ class OSCStartEndCondition(AtomicCondition):
         new_status = py_trees.common.Status.RUNNING
 
         if new_status == py_trees.common.Status.RUNNING:
-            blackboard_variable_name = "({}){}-{}".format(self._element_type, self._element_name, self._rule)
+            blackboard_variable_name = "({}){}-{}".format(
+                self._element_type, self._element_name, self._rule)
             element_start_time = self._blackboard.get(blackboard_variable_name)
             if element_start_time and element_start_time >= self._start_time:
                 new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -545,7 +560,8 @@ class InTriggerRegion(AtomicCondition):
         if not not_in_region:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -584,7 +600,8 @@ class InTriggerDistanceToVehicle(AtomicCondition):
         new_status = py_trees.common.Status.RUNNING
 
         location = CarlaDataProvider.get_location(self._actor)
-        reference_location = CarlaDataProvider.get_location(self._reference_actor)
+        reference_location = CarlaDataProvider.get_location(
+            self._reference_actor)
 
         if location is None or reference_location is None:
             return new_status
@@ -592,7 +609,8 @@ class InTriggerDistanceToVehicle(AtomicCondition):
         if self._comparison_operator(calculate_distance(location, reference_location), self._distance):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -643,7 +661,8 @@ class InTriggerDistanceToLocation(AtomicCondition):
                 location, self._target_location), self._distance):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -683,13 +702,16 @@ class InTriggerDistanceToNextIntersection(AtomicCondition):
         """
         new_status = py_trees.common.Status.RUNNING
 
-        current_waypoint = self._map.get_waypoint(CarlaDataProvider.get_location(self._actor))
-        distance = calculate_distance(current_waypoint.transform.location, self._final_location)
+        current_waypoint = self._map.get_waypoint(
+            CarlaDataProvider.get_location(self._actor))
+        distance = calculate_distance(
+            current_waypoint.transform.location, self._final_location)
 
         if distance < self._distance:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -721,7 +743,8 @@ class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
         self._route = route
         self._distance = distance
 
-        self._location_distance, _ = get_distance_along_route(self._route, self._location)
+        self._location_distance, _ = get_distance_along_route(
+            self._route, self._location)
 
     def update(self):
         new_status = py_trees.common.Status.RUNNING
@@ -733,7 +756,8 @@ class InTriggerDistanceToLocationAlongRoute(AtomicCondition):
 
         if current_location.distance(self._location) < self._distance + 20:
 
-            actor_distance, _ = get_distance_along_route(self._route, current_location)
+            actor_distance, _ = get_distance_along_route(
+                self._route, current_location)
 
             # If closer than self._distance and hasn't passed the trigger point
             if (self._location_distance < actor_distance + self._distance and
@@ -793,7 +817,8 @@ class InTimeToArrivalToLocation(AtomicCondition):
         if self._comparison_operator(time_to_arrival, self._time):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -854,21 +879,26 @@ class InTimeToArrivalToVehicle(AtomicCondition):
 
         if self._along_route:
             # Global planner needs a location at a driving lane
-            current_location = self._map.get_waypoint(current_location).transform.location
-            other_location = self._map.get_waypoint(other_location).transform.location
+            current_location = self._map.get_waypoint(
+                current_location).transform.location
+            other_location = self._map.get_waypoint(
+                other_location).transform.location
 
-        distance = calculate_distance(current_location, other_location, self._grp)
+        distance = calculate_distance(
+            current_location, other_location, self._grp)
 
         # if velocity is too small, simply use a large time to arrival
         time_to_arrival = self._max_time_to_arrival
 
         if current_velocity > other_velocity:
-            time_to_arrival = 2 * distance / (current_velocity - other_velocity)
+            time_to_arrival = 2 * distance / \
+                (current_velocity - other_velocity)
 
         if self._comparison_operator(time_to_arrival, self._time):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -930,10 +960,13 @@ class InTimeToCollisionToVehicle(AtomicCondition):
 
         if self._along_route:
             # Global planner needs a location at a driving lane
-            current_location = self._map.get_waypoint(current_location).transform.location
-            other_location = self._map.get_waypoint(other_location).transform.location
+            current_location = self._map.get_waypoint(
+                current_location).transform.location
+            other_location = self._map.get_waypoint(
+                other_location).transform.location
 
-        distance = calculate_distance(current_location, other_location, self._grp)
+        distance = calculate_distance(
+            current_location, other_location, self._grp)
 
         # if velocity is too small, simply use a large time to arrival
         time_to_arrival = self._max_time_to_arrival
@@ -947,7 +980,8 @@ class InTimeToCollisionToVehicle(AtomicCondition):
         if self._comparison_operator(time_to_arrival, self._time):
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -1083,7 +1117,8 @@ class WaitUntilInFront(AtomicCondition):
         # Wait for the vehicle to be in front
         other_dir = other_next_waypoint.transform.get_forward_vector()
         act_other_dir = actor_location - other_next_waypoint.transform.location
-        dot_ve_wp = other_dir.x * act_other_dir.x + other_dir.y * act_other_dir.y + other_dir.z * act_other_dir.z
+        dot_ve_wp = other_dir.x * act_other_dir.x + other_dir.y * \
+            act_other_dir.y + other_dir.z * act_other_dir.z
 
         if dot_ve_wp > 0.0:
             in_front = True
@@ -1139,7 +1174,8 @@ class DriveDistance(AtomicCondition):
         if self._distance > self._target_distance:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
         return new_status
 
 
@@ -1180,7 +1216,8 @@ class AtRightmostLane(AtomicCondition):
         if lane_type != carla.LaneType.Driving:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
         return new_status
 
 
@@ -1217,7 +1254,8 @@ class WaitForTrafficLightState(AtomicCondition):
         if self._actor.state == self._state:
             new_status = py_trees.common.Status.SUCCESS
 
-        self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
+        self.logger.debug(
+            "%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))
 
         return new_status
 
@@ -1283,7 +1321,8 @@ class WaitForBlackboardVariable(AtomicCondition):
         value = blackv.get(self._variable_name)
         if value == self._variable_value:
             if self._debug:
-                print("Blackboard variable {} set to True".format(self._variable_name))
+                print("Blackboard variable {} set to True".format(
+                    self._variable_name))
             new_status = py_trees.common.Status.SUCCESS
 
         return new_status

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -541,7 +541,7 @@ class InTriggerRegion(AtomicCondition):
             return new_status
 
         not_in_region = (location.x < self._min_x or location.x > self._max_x) or (
-                location.y < self._min_y or location.y > self._max_y)
+            location.y < self._min_y or location.y > self._max_y)
         if not not_in_region:
             new_status = py_trees.common.Status.SUCCESS
 

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -68,7 +68,6 @@ from srunner.tools.py_trees_port import oneshot_behavior
 
 
 class OpenScenarioParser(object):
-
     """
     Pure static class providing conversions from OpenSCENARIO elements to ScenarioRunner elements
     """
@@ -614,7 +613,7 @@ class OpenScenarioParser(object):
 
         if condition.find('ByEntityCondition') is not None:
 
-            trigger_actor = None    # A-priori validation ensures that this will be not None
+            trigger_actor = None  # A-priori validation ensures that this will be not None
             triggered_actor = None
 
             for triggering_entities in condition.find('ByEntityCondition').iter('TriggeringEntities'):

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -54,7 +54,6 @@ from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import (I
                                                                                InTriggerDistanceToOSCPosition,
                                                                                InTimeToArrivalToOSCPosition,
                                                                                InTimeToArrivalToVehicle,
-                                                                               InTimeToCollisionToVehicle,
                                                                                DriveDistance,
                                                                                StandStill,
                                                                                OSCStartEndCondition,
@@ -678,10 +677,7 @@ class OpenScenarioParser(object):
                     condition_rule = headtime_condition.attrib.get('rule')
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
-                    condition_freespace = strtobool(headtime_condition.attrib.get('freespace', False))
-                    if condition_freespace:
-                        raise NotImplementedError(
-                            "TimeHeadwayCondition: freespace attribute is currently not implemented")
+                    condition_freespace = strtobool(headtime_condition.attrib.get('freespace'))
                     condition_along_route = strtobool(headtime_condition.attrib.get('alongRoute', False))
 
                     for actor in actor_list:
@@ -693,7 +689,7 @@ class OpenScenarioParser(object):
                             headtime_condition.attrib.get('entityRef', None)))
 
                     atomic = InTimeToArrivalToVehicle(
-                        trigger_actor, triggered_actor, condition_value,
+                        trigger_actor, triggered_actor, condition_value, condition_freespace,
                         condition_along_route, condition_operator, condition_name
                     )
 
@@ -723,7 +719,7 @@ class OpenScenarioParser(object):
                             raise AttributeError("Cannot find actor '{}' for condition".format(
                                 entity_ref_.attrib.get('entityRef', None)))
 
-                        atomic = InTimeToCollisionToVehicle(
+                        atomic = InTimeToArrivalToVehicle(
                             trigger_actor, triggered_actor, condition_value, condition_freespace,
                             condition_along_route, condition_operator, condition_name)
                 elif entity_condition.find('AccelerationCondition') is not None:

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -20,49 +20,57 @@ import carla
 
 from srunner.scenariomanager.carla_data_provider import CarlaDataProvider
 from srunner.scenariomanager.weather_sim import Weather
-from srunner.scenariomanager.scenarioatomics.atomic_behaviors import (TrafficLightStateSetter,
-                                                                      ActorTransformSetterToOSCPosition,
-                                                                      RunScript,
-                                                                      ChangeWeather,
-                                                                      ChangeAutoPilot,
-                                                                      ChangeRoadFriction,
-                                                                      ChangeActorTargetSpeed,
-                                                                      ChangeActorControl,
-                                                                      ChangeActorWaypoints,
-                                                                      ChangeActorWaypointsToReachPosition,
-                                                                      ChangeActorLateralMotion,
-                                                                      Idle)
+from srunner.scenariomanager.scenarioatomics.atomic_behaviors import (
+    TrafficLightStateSetter,
+    ActorTransformSetterToOSCPosition,
+    RunScript,
+    ChangeWeather,
+    ChangeAutoPilot,
+    ChangeRoadFriction,
+    ChangeActorTargetSpeed,
+    ChangeActorControl,
+    ChangeActorWaypoints,
+    ChangeActorWaypointsToReachPosition,
+    ChangeActorLateralMotion,
+    Idle,
+)
+
 # pylint: disable=unused-import
 # For the following includes the pylint check is disabled, as these are accessed via globals()
-from srunner.scenariomanager.scenarioatomics.atomic_criteria import (CollisionTest,
-                                                                     MaxVelocityTest,
-                                                                     DrivenDistanceTest,
-                                                                     AverageVelocityTest,
-                                                                     KeepLaneTest,
-                                                                     ReachedRegionTest,
-                                                                     OnSidewalkTest,
-                                                                     WrongLaneTest,
-                                                                     InRadiusRegionTest,
-                                                                     InRouteTest,
-                                                                     RouteCompletionTest,
-                                                                     RunningRedLightTest,
-                                                                     RunningStopTest,
-                                                                     OffRoadTest,
-                                                                     EndofRoadTest)
+from srunner.scenariomanager.scenarioatomics.atomic_criteria import (
+    CollisionTest,
+    MaxVelocityTest,
+    DrivenDistanceTest,
+    AverageVelocityTest,
+    KeepLaneTest,
+    ReachedRegionTest,
+    OnSidewalkTest,
+    WrongLaneTest,
+    InRadiusRegionTest,
+    InRouteTest,
+    RouteCompletionTest,
+    RunningRedLightTest,
+    RunningStopTest,
+    OffRoadTest,
+    EndofRoadTest,
+)
+
 # pylint: enable=unused-import
-from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import (InTriggerDistanceToVehicle,
-                                                                               InTriggerDistanceToOSCPosition,
-                                                                               InTimeToArrivalToOSCPosition,
-                                                                               InTimeToArrivalToVehicle,
-                                                                               InTimeToCollisionToVehicle,
-                                                                               DriveDistance,
-                                                                               StandStill,
-                                                                               OSCStartEndCondition,
-                                                                               TriggerAcceleration,
-                                                                               RelativeVelocityToOtherActor,
-                                                                               TimeOfDayComparison,
-                                                                               TriggerVelocity,
-                                                                               WaitForTrafficLightState)
+from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import (
+    InTriggerDistanceToVehicle,
+    InTriggerDistanceToOSCPosition,
+    InTimeToArrivalToOSCPosition,
+    InTimeToArrivalToVehicle,
+    InTimeToCollisionToVehicle,
+    DriveDistance,
+    StandStill,
+    OSCStartEndCondition,
+    TriggerAcceleration,
+    RelativeVelocityToOtherActor,
+    TimeOfDayComparison,
+    TriggerVelocity,
+    WaitForTrafficLightState,
+)
 from srunner.scenariomanager.timer import TimeOut, SimulationTimeCondition
 from srunner.tools.py_trees_port import oneshot_behavior
 
@@ -71,16 +79,17 @@ class OpenScenarioParser(object):
     """
     Pure static class providing conversions from OpenSCENARIO elements to ScenarioRunner elements
     """
+
     operators = {
         "greaterThan": operator.gt,
         "lessThan": operator.lt,
-        "equalTo": operator.eq
+        "equalTo": operator.eq,
     }
 
     actor_types = {
         "pedestrian": "walker",
         "vehicle": "vehicle",
-        "miscellaneous": "miscellaneous"
+        "miscellaneous": "miscellaneous",
     }
 
     tl_states = {
@@ -104,7 +113,11 @@ class OpenScenarioParser(object):
         # Given by id
         if name.startswith("id="):
             tl_id = name[3:]
-            for carla_tl in CarlaDataProvider.get_world().get_actors().filter('traffic.traffic_light'):
+            for carla_tl in (
+                CarlaDataProvider.get_world()
+                .get_actors()
+                .filter("traffic.traffic_light")
+            ):
                 if carla_tl.id == tl_id:
                     traffic_light = carla_tl
                     break
@@ -112,11 +125,15 @@ class OpenScenarioParser(object):
         elif name.startswith("pos="):
             tl_pos = name[4:]
             pos = tl_pos.split(",")
-            for carla_tl in CarlaDataProvider.get_world().get_actors().filter('traffic.traffic_light'):
+            for carla_tl in (
+                CarlaDataProvider.get_world()
+                .get_actors()
+                .filter("traffic.traffic_light")
+            ):
                 carla_tl_location = carla_tl.get_transform().location
-                distance = carla_tl_location.distance(carla.Location(float(pos[0]),
-                                                                     float(pos[1]),
-                                                                     carla_tl_location.z))
+                distance = carla_tl_location.distance(
+                    carla.Location(float(pos[0]), float(pos[1]), carla_tl_location.z)
+                )
                 if distance < 2.0:
                     traffic_light = carla_tl
                     break
@@ -164,7 +181,7 @@ class OpenScenarioParser(object):
         parameter_dict = dict()
         if additional_parameter_dict is not None:
             parameter_dict = additional_parameter_dict
-        parameters = xml_tree.find('ParameterDeclarations')
+        parameters = xml_tree.find("ParameterDeclarations")
 
         if parameters is None and not parameter_dict:
             return xml_tree, parameter_dict
@@ -173,15 +190,17 @@ class OpenScenarioParser(object):
             parameters = []
 
         for parameter in parameters:
-            name = parameter.attrib.get('name')
-            value = parameter.attrib.get('value')
+            name = parameter.attrib.get("name")
+            value = parameter.attrib.get("value")
             parameter_dict[name] = value
 
         for node in xml_tree.iter():
             for key in node.attrib:
                 for param in sorted(parameter_dict, key=len, reverse=True):
                     if "$" + param in node.attrib[key]:
-                        node.attrib[key] = node.attrib[key].replace("$" + param, parameter_dict[param])
+                        node.attrib[key] = node.attrib[key].replace(
+                            "$" + param, parameter_dict[param]
+                        )
 
         return xml_tree, parameter_dict
 
@@ -208,7 +227,9 @@ class OpenScenarioParser(object):
             Catalog entry (XML ElementTree)
         """
 
-        entry = catalogs[catalog_reference.attrib.get("catalogName")][catalog_reference.attrib.get("entryName")]
+        entry = catalogs[catalog_reference.attrib.get("catalogName")][
+            catalog_reference.attrib.get("entryName")
+        ]
         entry_copy = copy.deepcopy(entry)
         catalog_copy = copy.deepcopy(catalog_reference)
         entry = OpenScenarioParser.assign_catalog_parameters(entry_copy, catalog_copy)
@@ -233,15 +254,17 @@ class OpenScenarioParser(object):
 
         parameter_dict = dict()
         for elem in entry_instance.iter():
-            if elem.find('ParameterDeclarations') is not None:
-                parameters = elem.find('ParameterDeclarations')
+            if elem.find("ParameterDeclarations") is not None:
+                parameters = elem.find("ParameterDeclarations")
                 for parameter in parameters:
-                    name = parameter.attrib.get('name')
-                    value = parameter.attrib.get('value')
+                    name = parameter.attrib.get("name")
+                    value = parameter.attrib.get("value")
                     parameter_dict[name] = value
 
         for parameter_assignments in catalog_reference.iter("ParameterAssignments"):
-            for parameter_assignment in parameter_assignments.iter("ParameterAssignment"):
+            for parameter_assignment in parameter_assignments.iter(
+                "ParameterAssignment"
+            ):
                 parameter = parameter_assignment.attrib.get("parameterRef")
                 value = parameter_assignment.attrib.get("value")
                 parameter_dict[parameter] = value
@@ -250,9 +273,13 @@ class OpenScenarioParser(object):
             for key in node.attrib:
                 for param in sorted(parameter_dict, key=len, reverse=True):
                     if "$" + param in node.attrib[key]:
-                        node.attrib[key] = node.attrib[key].replace("$" + param, parameter_dict[param])
+                        node.attrib[key] = node.attrib[key].replace(
+                            "$" + param, parameter_dict[param]
+                        )
 
-        OpenScenarioParser.set_parameters(entry_instance, OpenScenarioParser.global_osc_parameters)
+        OpenScenarioParser.set_parameters(
+            entry_instance, OpenScenarioParser.global_osc_parameters
+        )
 
         return entry_instance
 
@@ -278,13 +305,15 @@ class OpenScenarioParser(object):
             environment = set_environment.find("Environment")
         elif set_environment.find("CatalogReference") is not None:
             catalog_reference = set_environment.find("CatalogReference")
-            environment = OpenScenarioParser.get_catalog_entry(catalogs, catalog_reference)
+            environment = OpenScenarioParser.get_catalog_entry(
+                catalogs, catalog_reference
+            )
 
         friction = 1.0
 
         road_condition = environment.iter("RoadCondition")
         for condition in road_condition:
-            friction = condition.attrib.get('frictionScaleFactor')
+            friction = condition.attrib.get("frictionScaleFactor")
 
         return friction
 
@@ -310,17 +339,23 @@ class OpenScenarioParser(object):
             environment = set_environment.find("Environment")
         elif set_environment.find("CatalogReference") is not None:
             catalog_reference = set_environment.find("CatalogReference")
-            environment = OpenScenarioParser.get_catalog_entry(catalogs, catalog_reference)
+            environment = OpenScenarioParser.get_catalog_entry(
+                catalogs, catalog_reference
+            )
 
         weather = environment.find("Weather")
         sun = weather.find("Sun")
 
         carla_weather = carla.WeatherParameters()
-        carla_weather.sun_azimuth_angle = math.degrees(float(sun.attrib.get('azimuth', 0)))
-        carla_weather.sun_altitude_angle = math.degrees(float(sun.attrib.get('elevation', 0)))
-        carla_weather.cloudiness = 100 - float(sun.attrib.get('intensity', 0)) * 100
+        carla_weather.sun_azimuth_angle = math.degrees(
+            float(sun.attrib.get("azimuth", 0))
+        )
+        carla_weather.sun_altitude_angle = math.degrees(
+            float(sun.attrib.get("elevation", 0))
+        )
+        carla_weather.cloudiness = 100 - float(sun.attrib.get("intensity", 0)) * 100
         fog = weather.find("Fog")
-        carla_weather.fog_distance = float(fog.attrib.get('visualRange', 'inf'))
+        carla_weather.fog_distance = float(fog.attrib.get("visualRange", "inf"))
         if carla_weather.fog_distance < 1000:
             carla_weather.fog_density = 100
         carla_weather.precipitation = 0
@@ -328,11 +363,13 @@ class OpenScenarioParser(object):
         carla_weather.wetness = 0
         carla_weather.wind_intensity = 0
         precepitation = weather.find("Precipitation")
-        if precepitation.attrib.get('precipitationType') == "rain":
-            carla_weather.precipitation = float(precepitation.attrib.get('intensity')) * 100
+        if precepitation.attrib.get("precipitationType") == "rain":
+            carla_weather.precipitation = (
+                float(precepitation.attrib.get("intensity")) * 100
+            )
             carla_weather.precipitation_deposits = 100  # if it rains, make the road wet
             carla_weather.wetness = carla_weather.precipitation
-        elif precepitation.attrib.get('type') == "snow":
+        elif precepitation.attrib.get("type") == "snow":
             raise AttributeError("CARLA does not support snow precipitation")
 
         time_of_day = environment.find("TimeOfDay")
@@ -360,24 +397,28 @@ class OpenScenarioParser(object):
         assign_action = next(xml_tree.iter("AssignControllerAction"))
 
         properties = None
-        if assign_action.find('Controller') is not None:
-            properties = assign_action.find('Controller').find('Properties')
+        if assign_action.find("Controller") is not None:
+            properties = assign_action.find("Controller").find("Properties")
         elif assign_action.find("CatalogReference") is not None:
             catalog_reference = assign_action.find("CatalogReference")
-            properties = OpenScenarioParser.get_catalog_entry(catalogs, catalog_reference).find('Properties')
+            properties = OpenScenarioParser.get_catalog_entry(
+                catalogs, catalog_reference
+            ).find("Properties")
 
         module = None
         args = {}
         for prop in properties:
-            if prop.attrib.get('name') == "module":
-                module = prop.attrib.get('value')
+            if prop.attrib.get("name") == "module":
+                module = prop.attrib.get("value")
             else:
-                args[prop.attrib.get('name')] = prop.attrib.get('value')
+                args[prop.attrib.get("name")] = prop.attrib.get("value")
 
-        override_action = xml_tree.find('OverrideControllerValueAction')
+        override_action = xml_tree.find("OverrideControllerValueAction")
         for child in override_action:
-            if strtobool(child.attrib.get('active')):
-                raise NotImplementedError("Controller override actions are not yet supported")
+            if strtobool(child.attrib.get("active")):
+                raise NotImplementedError(
+                    "Controller override actions are not yet supported"
+                )
 
         return module, args
 
@@ -396,9 +437,9 @@ class OpenScenarioParser(object):
         """
         route = None
 
-        if xml_tree.find('Route') is not None:
-            route = xml_tree.find('Route')
-        elif xml_tree.find('CatalogReference') is not None:
+        if xml_tree.find("Route") is not None:
+            route = xml_tree.find("Route")
+        elif xml_tree.find("CatalogReference") is not None:
             catalog_reference = xml_tree.find("CatalogReference")
             route = OpenScenarioParser.get_catalog_entry(catalogs, catalog_reference)
         else:
@@ -406,8 +447,8 @@ class OpenScenarioParser(object):
 
         waypoints = []
         if route is not None:
-            for waypoint in route.iter('Waypoint'):
-                position = waypoint.find('Position')
+            for waypoint in route.iter("Waypoint"):
+                position = waypoint.find("Position")
                 transform = OpenScenarioParser.convert_position_to_transform(position)
                 waypoints.append(transform)
 
@@ -424,32 +465,37 @@ class OpenScenarioParser(object):
                        route information
         """
 
-        if position.find('WorldPosition') is not None:
-            world_pos = position.find('WorldPosition')
-            x = float(world_pos.attrib.get('x', 0))
-            y = float(world_pos.attrib.get('y', 0))
-            z = float(world_pos.attrib.get('z', 0))
-            yaw = math.degrees(float(world_pos.attrib.get('h', 0)))
-            pitch = math.degrees(float(world_pos.attrib.get('p', 0)))
-            roll = math.degrees(float(world_pos.attrib.get('r', 0)))
+        if position.find("WorldPosition") is not None:
+            world_pos = position.find("WorldPosition")
+            x = float(world_pos.attrib.get("x", 0))
+            y = float(world_pos.attrib.get("y", 0))
+            z = float(world_pos.attrib.get("z", 0))
+            yaw = math.degrees(float(world_pos.attrib.get("h", 0)))
+            pitch = math.degrees(float(world_pos.attrib.get("p", 0)))
+            roll = math.degrees(float(world_pos.attrib.get("r", 0)))
             if not OpenScenarioParser.use_carla_coordinate_system:
                 y = y * (-1.0)
                 yaw = yaw * (-1.0)
-            return carla.Transform(carla.Location(x=x, y=y, z=z), carla.Rotation(yaw=yaw, pitch=pitch, roll=roll))
+            return carla.Transform(
+                carla.Location(x=x, y=y, z=z),
+                carla.Rotation(yaw=yaw, pitch=pitch, roll=roll),
+            )
 
-        elif ((position.find('RelativeWorldPosition') is not None) or
-              (position.find('RelativeObjectPosition') is not None) or
-              (position.find('RelativeLanePosition') is not None)):
+        elif (
+            (position.find("RelativeWorldPosition") is not None)
+            or (position.find("RelativeObjectPosition") is not None)
+            or (position.find("RelativeLanePosition") is not None)
+        ):
 
-            if position.find('RelativeWorldPosition') is not None:
-                rel_pos = position.find('RelativeWorldPosition')
-            if position.find('RelativeObjectPosition') is not None:
-                rel_pos = position.find('RelativeObjectPosition')
-            if position.find('RelativeLanePosition') is not None:
-                rel_pos = position.find('RelativeLanePosition')
+            if position.find("RelativeWorldPosition") is not None:
+                rel_pos = position.find("RelativeWorldPosition")
+            if position.find("RelativeObjectPosition") is not None:
+                rel_pos = position.find("RelativeObjectPosition")
+            if position.find("RelativeLanePosition") is not None:
+                rel_pos = position.find("RelativeLanePosition")
 
             # get relative object and relative position
-            obj = rel_pos.attrib.get('entityRef')
+            obj = rel_pos.attrib.get("entityRef")
             obj_actor = None
             actor_transform = None
 
@@ -460,25 +506,32 @@ class OpenScenarioParser(object):
                         actor_transform = actor.transform
             else:
                 for actor in CarlaDataProvider.get_world().get_actors():
-                    if 'role_name' in actor.attributes and actor.attributes['role_name'] == obj:
+                    if (
+                        "role_name" in actor.attributes
+                        and actor.attributes["role_name"] == obj
+                    ):
                         obj_actor = actor
                         actor_transform = obj_actor.get_transform()
                         break
 
             if obj_actor is None:
-                raise AttributeError("Object '{}' provided as position reference is not known".format(obj))
+                raise AttributeError(
+                    "Object '{}' provided as position reference is not known".format(
+                        obj
+                    )
+                )
 
             # calculate orientation h, p, r
             is_absolute = False
             dyaw = 0
             dpitch = 0
             droll = 0
-            if rel_pos.find('Orientation') is not None:
-                orientation = rel_pos.find('Orientation')
-                is_absolute = (orientation.attrib.get('type') == "absolute")
-                dyaw = math.degrees(float(orientation.attrib.get('h', 0)))
-                dpitch = math.degrees(float(orientation.attrib.get('p', 0)))
-                droll = math.degrees(float(orientation.attrib.get('r', 0)))
+            if rel_pos.find("Orientation") is not None:
+                orientation = rel_pos.find("Orientation")
+                is_absolute = orientation.attrib.get("type") == "absolute"
+                dyaw = math.degrees(float(orientation.attrib.get("h", 0)))
+                dpitch = math.degrees(float(orientation.attrib.get("p", 0)))
+                droll = math.degrees(float(orientation.attrib.get("r", 0)))
 
             if not OpenScenarioParser.use_carla_coordinate_system:
                 dyaw = dyaw * (-1.0)
@@ -498,11 +551,12 @@ class OpenScenarioParser(object):
 
             # calculate location x, y, z
             # dx, dy, dz
-            if ((position.find('RelativeWorldPosition') is not None) or
-                    (position.find('RelativeObjectPosition') is not None)):
-                dx = float(rel_pos.attrib.get('dx', 0))
-                dy = float(rel_pos.attrib.get('dy', 0))
-                dz = float(rel_pos.attrib.get('dz', 0))
+            if (position.find("RelativeWorldPosition") is not None) or (
+                position.find("RelativeObjectPosition") is not None
+            ):
+                dx = float(rel_pos.attrib.get("dx", 0))
+                dy = float(rel_pos.attrib.get("dy", 0))
+                dz = float(rel_pos.attrib.get("dz", 0))
 
                 if not OpenScenarioParser.use_carla_coordinate_system:
                     dy = dy * (-1.0)
@@ -512,10 +566,10 @@ class OpenScenarioParser(object):
                 z = actor_transform.location.z + dz
 
             # dLane, ds, offset
-            elif position.find('RelativeLanePosition') is not None:
-                dlane = float(rel_pos.attrib.get('dLane'))
-                ds = float(rel_pos.attrib.get('ds'))
-                offset = float(rel_pos.attrib.get('offset', 0.0))
+            elif position.find("RelativeLanePosition") is not None:
+                dlane = float(rel_pos.attrib.get("dLane"))
+                ds = float(rel_pos.attrib.get("ds"))
+                offset = float(rel_pos.attrib.get("offset", 0.0))
 
                 carla_map = CarlaDataProvider.get_map()
                 relative_waypoint = carla_map.get_waypoint(actor_transform.location)
@@ -527,7 +581,11 @@ class OpenScenarioParser(object):
                 elif dlane == 1:
                     wp = relative_waypoint.get_right_lane()
                 if wp is None:
-                    raise AttributeError("Object '{}' position with dLane={} is not valid".format(obj, dlane))
+                    raise AttributeError(
+                        "Object '{}' position with dLane={} is not valid".format(
+                            obj, dlane
+                        )
+                    )
 
                 if ds < 0:
                     ds = (-1.0) * ds
@@ -548,30 +606,35 @@ class OpenScenarioParser(object):
                 y = wp.transform.location.y + y_offset
                 z = wp.transform.location.z
 
-            return carla.Transform(carla.Location(x=x, y=y, z=z), carla.Rotation(yaw=yaw, pitch=pitch, roll=roll))
+            return carla.Transform(
+                carla.Location(x=x, y=y, z=z),
+                carla.Rotation(yaw=yaw, pitch=pitch, roll=roll),
+            )
 
         # Not implemented
-        elif position.find('RoadPosition') is not None:
+        elif position.find("RoadPosition") is not None:
             raise NotImplementedError("Road positions are not yet supported")
-        elif position.find('RelativeRoadPosition') is not None:
+        elif position.find("RelativeRoadPosition") is not None:
             raise NotImplementedError("RelativeRoad positions are not yet supported")
-        elif position.find('LanePosition') is not None:
-            lane_pos = position.find('LanePosition')
-            road_id = int(lane_pos.attrib.get('roadId', 0))
-            lane_id = int(lane_pos.attrib.get('laneId', 0))
-            offset = float(lane_pos.attrib.get('offset', 0))
-            s = float(lane_pos.attrib.get('s', 0))
+        elif position.find("LanePosition") is not None:
+            lane_pos = position.find("LanePosition")
+            road_id = int(lane_pos.attrib.get("roadId", 0))
+            lane_id = int(lane_pos.attrib.get("laneId", 0))
+            offset = float(lane_pos.attrib.get("offset", 0))
+            s = float(lane_pos.attrib.get("s", 0))
             is_absolute = True
-            waypoint = CarlaDataProvider.get_map().get_waypoint_xodr(road_id, lane_id, s)
+            waypoint = CarlaDataProvider.get_map().get_waypoint_xodr(
+                road_id, lane_id, s
+            )
             if waypoint is None:
                 raise AttributeError("Lane position cannot be found")
 
             transform = waypoint.transform
-            if lane_pos.find('Orientation') is not None:
-                orientation = lane_pos.find('Orientation')
-                dyaw = math.degrees(float(orientation.attrib.get('h', 0)))
-                dpitch = math.degrees(float(orientation.attrib.get('p', 0)))
-                droll = math.degrees(float(orientation.attrib.get('r', 0)))
+            if lane_pos.find("Orientation") is not None:
+                orientation = lane_pos.find("Orientation")
+                dyaw = math.degrees(float(orientation.attrib.get("h", 0)))
+                dpitch = math.degrees(float(orientation.attrib.get("p", 0)))
+                droll = math.degrees(float(orientation.attrib.get("r", 0)))
 
                 if not OpenScenarioParser.use_carla_coordinate_system:
                     dyaw = dyaw * (-1.0)
@@ -582,12 +645,18 @@ class OpenScenarioParser(object):
 
             if offset != 0:
                 forward_vector = transform.rotation.get_forward_vector()
-                orthogonal_vector = carla.Vector3D(x=-forward_vector.y, y=forward_vector.x, z=forward_vector.z)
-                transform.location.x = transform.location.x + offset * orthogonal_vector.x
-                transform.location.y = transform.location.y + offset * orthogonal_vector.y
+                orthogonal_vector = carla.Vector3D(
+                    x=-forward_vector.y, y=forward_vector.x, z=forward_vector.z
+                )
+                transform.location.x = (
+                    transform.location.x + offset * orthogonal_vector.x
+                )
+                transform.location.y = (
+                    transform.location.y + offset * orthogonal_vector.y
+                )
 
             return transform
-        elif position.find('RoutePosition') is not None:
+        elif position.find("RoutePosition") is not None:
             raise NotImplementedError("Route positions are not yet supported")
         else:
             raise AttributeError("Unknown position")
@@ -605,281 +674,445 @@ class OpenScenarioParser(object):
 
         atomic = None
         delay_atomic = None
-        condition_name = condition.attrib.get('name')
+        condition_name = condition.attrib.get("name")
 
-        if condition.attrib.get('delay') is not None and str(condition.attrib.get('delay')) != '0':
-            delay = float(condition.attrib.get('delay'))
+        if (
+            condition.attrib.get("delay") is not None
+            and str(condition.attrib.get("delay")) != "0"
+        ):
+            delay = float(condition.attrib.get("delay"))
             delay_atomic = TimeOut(delay)
 
-        if condition.find('ByEntityCondition') is not None:
+        if condition.find("ByEntityCondition") is not None:
 
-            trigger_actor = None  # A-priori validation ensures that this will be not None
+            trigger_actor = (
+                None  # A-priori validation ensures that this will be not None
+            )
             triggered_actor = None
 
-            for triggering_entities in condition.find('ByEntityCondition').iter('TriggeringEntities'):
-                for entity in triggering_entities.iter('EntityRef'):
+            for triggering_entities in condition.find("ByEntityCondition").iter(
+                "TriggeringEntities"
+            ):
+                for entity in triggering_entities.iter("EntityRef"):
                     for actor in actor_list:
-                        if entity.attrib.get('entityRef', None) == actor.attributes['role_name']:
+                        if (
+                            entity.attrib.get("entityRef", None)
+                            == actor.attributes["role_name"]
+                        ):
                             trigger_actor = actor
                             break
 
-            for entity_condition in condition.find('ByEntityCondition').iter('EntityCondition'):
-                if entity_condition.find('EndOfRoadCondition') is not None:
-                    end_road_condition = entity_condition.find('EndOfRoadCondition')
-                    condition_duration = float(end_road_condition.attrib.get('duration'))
+            for entity_condition in condition.find("ByEntityCondition").iter(
+                "EntityCondition"
+            ):
+                if entity_condition.find("EndOfRoadCondition") is not None:
+                    end_road_condition = entity_condition.find("EndOfRoadCondition")
+                    condition_duration = float(
+                        end_road_condition.attrib.get("duration")
+                    )
                     atomic_cls = py_trees.meta.inverter(EndofRoadTest)
                     atomic = atomic_cls(
-                        trigger_actor, condition_duration, terminate_on_failure=True, name=condition_name)
-                elif entity_condition.find('CollisionCondition') is not None:
+                        trigger_actor,
+                        condition_duration,
+                        terminate_on_failure=True,
+                        name=condition_name,
+                    )
+                elif entity_condition.find("CollisionCondition") is not None:
 
-                    collision_condition = entity_condition.find('CollisionCondition')
+                    collision_condition = entity_condition.find("CollisionCondition")
 
-                    if collision_condition.find('EntityRef') is not None:
-                        collision_entity = collision_condition.find('EntityRef')
+                    if collision_condition.find("EntityRef") is not None:
+                        collision_entity = collision_condition.find("EntityRef")
 
                         for actor in actor_list:
-                            if collision_entity.attrib.get('entityRef', None) == actor.attributes['role_name']:
+                            if (
+                                collision_entity.attrib.get("entityRef", None)
+                                == actor.attributes["role_name"]
+                            ):
                                 triggered_actor = actor
                                 break
 
                         if triggered_actor is None:
-                            raise AttributeError("Cannot find actor '{}' for condition".format(
-                                collision_condition.attrib.get('entityRef', None)))
+                            raise AttributeError(
+                                "Cannot find actor '{}' for condition".format(
+                                    collision_condition.attrib.get("entityRef", None)
+                                )
+                            )
 
                         atomic_cls = py_trees.meta.inverter(CollisionTest)
-                        atomic = atomic_cls(trigger_actor, other_actor=triggered_actor,
-                                            terminate_on_failure=True, name=condition_name)
+                        atomic = atomic_cls(
+                            trigger_actor,
+                            other_actor=triggered_actor,
+                            terminate_on_failure=True,
+                            name=condition_name,
+                        )
 
-                    elif collision_condition.find('ByType') is not None:
-                        collision_type = collision_condition.find('ByType').attrib.get('type', None)
+                    elif collision_condition.find("ByType") is not None:
+                        collision_type = collision_condition.find("ByType").attrib.get(
+                            "type", None
+                        )
 
                         triggered_type = OpenScenarioParser.actor_types[collision_type]
 
                         atomic_cls = py_trees.meta.inverter(CollisionTest)
-                        atomic = atomic_cls(trigger_actor, other_actor_type=triggered_type,
-                                            terminate_on_failure=True, name=condition_name)
+                        atomic = atomic_cls(
+                            trigger_actor,
+                            other_actor_type=triggered_type,
+                            terminate_on_failure=True,
+                            name=condition_name,
+                        )
 
                     else:
                         atomic_cls = py_trees.meta.inverter(CollisionTest)
-                        atomic = atomic_cls(trigger_actor, terminate_on_failure=True, name=condition_name)
+                        atomic = atomic_cls(
+                            trigger_actor,
+                            terminate_on_failure=True,
+                            name=condition_name,
+                        )
 
-                elif entity_condition.find('OffroadCondition') is not None:
-                    off_condition = entity_condition.find('OffroadCondition')
-                    condition_duration = float(off_condition.attrib.get('duration'))
+                elif entity_condition.find("OffroadCondition") is not None:
+                    off_condition = entity_condition.find("OffroadCondition")
+                    condition_duration = float(off_condition.attrib.get("duration"))
                     atomic_cls = py_trees.meta.inverter(OffRoadTest)
                     atomic = atomic_cls(
-                        trigger_actor, condition_duration, terminate_on_failure=True, name=condition_name)
-                elif entity_condition.find('TimeHeadwayCondition') is not None:
-                    headtime_condition = entity_condition.find('TimeHeadwayCondition')
+                        trigger_actor,
+                        condition_duration,
+                        terminate_on_failure=True,
+                        name=condition_name,
+                    )
+                elif entity_condition.find("TimeHeadwayCondition") is not None:
+                    headtime_condition = entity_condition.find("TimeHeadwayCondition")
 
-                    condition_value = float(headtime_condition.attrib.get('value'))
+                    condition_value = float(headtime_condition.attrib.get("value"))
 
-                    condition_rule = headtime_condition.attrib.get('rule')
+                    condition_rule = headtime_condition.attrib.get("rule")
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
-                    condition_freespace = strtobool(headtime_condition.attrib.get('freespace', False))
+                    condition_freespace = strtobool(
+                        headtime_condition.attrib.get("freespace", False)
+                    )
                     if condition_freespace:
                         raise NotImplementedError(
-                            "TimeHeadwayCondition: freespace attribute is currently not implemented")
-                    condition_along_route = strtobool(headtime_condition.attrib.get('alongRoute', False))
+                            "TimeHeadwayCondition: freespace attribute is currently not implemented"
+                        )
+                    condition_along_route = strtobool(
+                        headtime_condition.attrib.get("alongRoute", False)
+                    )
 
                     for actor in actor_list:
-                        if headtime_condition.attrib.get('entityRef', None) == actor.attributes['role_name']:
+                        if (
+                            headtime_condition.attrib.get("entityRef", None)
+                            == actor.attributes["role_name"]
+                        ):
                             triggered_actor = actor
                             break
                     if triggered_actor is None:
-                        raise AttributeError("Cannot find actor '{}' for condition".format(
-                            headtime_condition.attrib.get('entityRef', None)))
+                        raise AttributeError(
+                            "Cannot find actor '{}' for condition".format(
+                                headtime_condition.attrib.get("entityRef", None)
+                            )
+                        )
 
                     atomic = InTimeToArrivalToVehicle(
-                        trigger_actor, triggered_actor, condition_value,
-                        condition_along_route, condition_operator, condition_name
+                        trigger_actor,
+                        triggered_actor,
+                        condition_value,
+                        condition_along_route,
+                        condition_operator,
+                        condition_name,
                     )
 
-                elif entity_condition.find('TimeToCollisionCondition') is not None:
-                    ttc_condition = entity_condition.find('TimeToCollisionCondition')
+                elif entity_condition.find("TimeToCollisionCondition") is not None:
+                    ttc_condition = entity_condition.find("TimeToCollisionCondition")
 
-                    condition_rule = ttc_condition.attrib.get('rule')
+                    condition_rule = ttc_condition.attrib.get("rule")
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
-                    condition_value = float(ttc_condition.attrib.get('value'))
-                    condition_target = ttc_condition.find('TimeToCollisionConditionTarget')
-                    entity_ref_ = condition_target.find('EntityRef')
+                    condition_value = float(ttc_condition.attrib.get("value"))
+                    condition_target = ttc_condition.find(
+                        "TimeToCollisionConditionTarget"
+                    )
+                    entity_ref_ = condition_target.find("EntityRef")
 
-                    condition_freespace = strtobool(ttc_condition.attrib.get('freespace'))
-                    condition_along_route = strtobool(ttc_condition.attrib.get('alongRoute', False))
+                    condition_freespace = strtobool(
+                        ttc_condition.attrib.get("freespace")
+                    )
+                    condition_along_route = strtobool(
+                        ttc_condition.attrib.get("alongRoute", False)
+                    )
 
-                    if condition_target.find('Position') is not None:
-                        position = condition_target.find('Position')
+                    if condition_target.find("Position") is not None:
+                        position = condition_target.find("Position")
                         atomic = InTimeToArrivalToOSCPosition(
-                            trigger_actor, position, condition_value, condition_along_route, condition_operator)
+                            trigger_actor,
+                            position,
+                            condition_value,
+                            condition_along_route,
+                            condition_operator,
+                        )
                     else:
                         for actor in actor_list:
-                            if entity_ref_.attrib.get('entityRef', None) == actor.attributes['role_name']:
+                            if (
+                                entity_ref_.attrib.get("entityRef", None)
+                                == actor.attributes["role_name"]
+                            ):
                                 triggered_actor = actor
                                 break
                         if triggered_actor is None:
-                            raise AttributeError("Cannot find actor '{}' for condition".format(
-                                entity_ref_.attrib.get('entityRef', None)))
+                            raise AttributeError(
+                                "Cannot find actor '{}' for condition".format(
+                                    entity_ref_.attrib.get("entityRef", None)
+                                )
+                            )
 
                         atomic = InTimeToCollisionToVehicle(
-                            trigger_actor, triggered_actor, condition_value, condition_freespace,
-                            condition_along_route, condition_operator, condition_name)
-                elif entity_condition.find('AccelerationCondition') is not None:
-                    accel_condition = entity_condition.find('AccelerationCondition')
-                    condition_value = float(accel_condition.attrib.get('value'))
-                    condition_rule = accel_condition.attrib.get('rule')
+                            trigger_actor,
+                            triggered_actor,
+                            condition_value,
+                            condition_freespace,
+                            condition_along_route,
+                            condition_operator,
+                            condition_name,
+                        )
+                elif entity_condition.find("AccelerationCondition") is not None:
+                    accel_condition = entity_condition.find("AccelerationCondition")
+                    condition_value = float(accel_condition.attrib.get("value"))
+                    condition_rule = accel_condition.attrib.get("rule")
                     condition_operator = OpenScenarioParser.operators[condition_rule]
                     atomic = TriggerAcceleration(
-                        trigger_actor, condition_value, condition_operator, condition_name)
-                elif entity_condition.find('StandStillCondition') is not None:
-                    ss_condition = entity_condition.find('StandStillCondition')
-                    duration = float(ss_condition.attrib.get('duration'))
+                        trigger_actor,
+                        condition_value,
+                        condition_operator,
+                        condition_name,
+                    )
+                elif entity_condition.find("StandStillCondition") is not None:
+                    ss_condition = entity_condition.find("StandStillCondition")
+                    duration = float(ss_condition.attrib.get("duration"))
                     atomic = StandStill(trigger_actor, condition_name, duration)
-                elif entity_condition.find('SpeedCondition') is not None:
-                    spd_condition = entity_condition.find('SpeedCondition')
-                    condition_value = float(spd_condition.attrib.get('value'))
-                    condition_rule = spd_condition.attrib.get('rule')
+                elif entity_condition.find("SpeedCondition") is not None:
+                    spd_condition = entity_condition.find("SpeedCondition")
+                    condition_value = float(spd_condition.attrib.get("value"))
+                    condition_rule = spd_condition.attrib.get("rule")
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
                     atomic = TriggerVelocity(
-                        trigger_actor, condition_value, condition_operator, condition_name)
-                elif entity_condition.find('RelativeSpeedCondition') is not None:
-                    relspd_condition = entity_condition.find('RelativeSpeedCondition')
-                    condition_value = float(relspd_condition.attrib.get('value'))
-                    condition_rule = relspd_condition.attrib.get('rule')
+                        trigger_actor,
+                        condition_value,
+                        condition_operator,
+                        condition_name,
+                    )
+                elif entity_condition.find("RelativeSpeedCondition") is not None:
+                    relspd_condition = entity_condition.find("RelativeSpeedCondition")
+                    condition_value = float(relspd_condition.attrib.get("value"))
+                    condition_rule = relspd_condition.attrib.get("rule")
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
                     for actor in actor_list:
-                        if relspd_condition.attrib.get('entityRef', None) == actor.attributes['role_name']:
+                        if (
+                            relspd_condition.attrib.get("entityRef", None)
+                            == actor.attributes["role_name"]
+                        ):
                             triggered_actor = actor
                             break
 
                     if triggered_actor is None:
-                        raise AttributeError("Cannot find actor '{}' for condition".format(
-                            relspd_condition.attrib.get('entityRef', None)))
+                        raise AttributeError(
+                            "Cannot find actor '{}' for condition".format(
+                                relspd_condition.attrib.get("entityRef", None)
+                            )
+                        )
 
                     atomic = RelativeVelocityToOtherActor(
-                        trigger_actor, triggered_actor, condition_value, condition_operator, condition_name)
-                elif entity_condition.find('TraveledDistanceCondition') is not None:
-                    distance_condition = entity_condition.find('TraveledDistanceCondition')
-                    distance_value = float(distance_condition.attrib.get('value'))
-                    atomic = DriveDistance(trigger_actor, distance_value, name=condition_name)
-                elif entity_condition.find('ReachPositionCondition') is not None:
-                    rp_condition = entity_condition.find('ReachPositionCondition')
-                    distance_value = float(rp_condition.attrib.get('tolerance'))
-                    position = rp_condition.find('Position')
+                        trigger_actor,
+                        triggered_actor,
+                        condition_value,
+                        condition_operator,
+                        condition_name,
+                    )
+                elif entity_condition.find("TraveledDistanceCondition") is not None:
+                    distance_condition = entity_condition.find(
+                        "TraveledDistanceCondition"
+                    )
+                    distance_value = float(distance_condition.attrib.get("value"))
+                    atomic = DriveDistance(
+                        trigger_actor, distance_value, name=condition_name
+                    )
+                elif entity_condition.find("ReachPositionCondition") is not None:
+                    rp_condition = entity_condition.find("ReachPositionCondition")
+                    distance_value = float(rp_condition.attrib.get("tolerance"))
+                    position = rp_condition.find("Position")
                     atomic = InTriggerDistanceToOSCPosition(
-                        trigger_actor, position, distance_value, name=condition_name)
-                elif entity_condition.find('DistanceCondition') is not None:
-                    distance_condition = entity_condition.find('DistanceCondition')
+                        trigger_actor, position, distance_value, name=condition_name
+                    )
+                elif entity_condition.find("DistanceCondition") is not None:
+                    distance_condition = entity_condition.find("DistanceCondition")
 
-                    distance_value = float(distance_condition.attrib.get('value'))
+                    distance_value = float(distance_condition.attrib.get("value"))
 
-                    distance_rule = distance_condition.attrib.get('rule')
+                    distance_rule = distance_condition.attrib.get("rule")
                     distance_operator = OpenScenarioParser.operators[distance_rule]
 
-                    distance_freespace = strtobool(distance_condition.attrib.get('freespace', False))
+                    distance_freespace = strtobool(
+                        distance_condition.attrib.get("freespace", False)
+                    )
                     if distance_freespace:
                         raise NotImplementedError(
-                            "DistanceCondition: freespace attribute is currently not implemented")
-                    distance_along_route = strtobool(distance_condition.attrib.get('alongRoute', False))
+                            "DistanceCondition: freespace attribute is currently not implemented"
+                        )
+                    distance_along_route = strtobool(
+                        distance_condition.attrib.get("alongRoute", False)
+                    )
 
-                    if distance_condition.find('Position') is not None:
-                        position = distance_condition.find('Position')
+                    if distance_condition.find("Position") is not None:
+                        position = distance_condition.find("Position")
                         atomic = InTriggerDistanceToOSCPosition(
-                            trigger_actor, position, distance_value, distance_along_route,
-                            distance_operator, name=condition_name)
+                            trigger_actor,
+                            position,
+                            distance_value,
+                            distance_along_route,
+                            distance_operator,
+                            name=condition_name,
+                        )
 
-                elif entity_condition.find('RelativeDistanceCondition') is not None:
-                    distance_condition = entity_condition.find('RelativeDistanceCondition')
-                    distance_value = float(distance_condition.attrib.get('value'))
+                elif entity_condition.find("RelativeDistanceCondition") is not None:
+                    distance_condition = entity_condition.find(
+                        "RelativeDistanceCondition"
+                    )
+                    distance_value = float(distance_condition.attrib.get("value"))
 
-                    distance_freespace = strtobool(distance_condition.attrib.get('freespace', False))
+                    distance_freespace = strtobool(
+                        distance_condition.attrib.get("freespace", False)
+                    )
                     if distance_freespace:
                         raise NotImplementedError(
-                            "RelativeDistanceCondition: freespace attribute is currently not implemented")
-                    if distance_condition.attrib.get('relativeDistanceType') == "cartesianDistance":
+                            "RelativeDistanceCondition: freespace attribute is currently not implemented"
+                        )
+                    if (
+                        distance_condition.attrib.get("relativeDistanceType")
+                        == "cartesianDistance"
+                    ):
                         for actor in actor_list:
-                            if distance_condition.attrib.get('entityRef', None) == actor.attributes['role_name']:
+                            if (
+                                distance_condition.attrib.get("entityRef", None)
+                                == actor.attributes["role_name"]
+                            ):
                                 triggered_actor = actor
                                 break
 
                         if triggered_actor is None:
-                            raise AttributeError("Cannot find actor '{}' for condition".format(
-                                distance_condition.attrib.get('entityRef', None)))
+                            raise AttributeError(
+                                "Cannot find actor '{}' for condition".format(
+                                    distance_condition.attrib.get("entityRef", None)
+                                )
+                            )
 
-                        condition_rule = distance_condition.attrib.get('rule')
-                        condition_operator = OpenScenarioParser.operators[condition_rule]
+                        condition_rule = distance_condition.attrib.get("rule")
+                        condition_operator = OpenScenarioParser.operators[
+                            condition_rule
+                        ]
                         atomic = InTriggerDistanceToVehicle(
-                            triggered_actor, trigger_actor, distance_value, condition_operator, name=condition_name)
+                            triggered_actor,
+                            trigger_actor,
+                            distance_value,
+                            condition_operator,
+                            name=condition_name,
+                        )
                     else:
                         raise NotImplementedError(
-                            "RelativeDistance condition with the given specification is not yet supported")
-        elif condition.find('ByValueCondition') is not None:
-            value_condition = condition.find('ByValueCondition')
-            if value_condition.find('ParameterCondition') is not None:
-                parameter_condition = value_condition.find('ParameterCondition')
-                arg_name = parameter_condition.attrib.get('parameterRef')
-                value = parameter_condition.attrib.get('value')
-                if value != '':
+                            "RelativeDistance condition with the given specification is not yet supported"
+                        )
+        elif condition.find("ByValueCondition") is not None:
+            value_condition = condition.find("ByValueCondition")
+            if value_condition.find("ParameterCondition") is not None:
+                parameter_condition = value_condition.find("ParameterCondition")
+                arg_name = parameter_condition.attrib.get("parameterRef")
+                value = parameter_condition.attrib.get("value")
+                if value != "":
                     arg_value = float(value)
                 else:
                     arg_value = 0
-                parameter_condition.attrib.get('rule')
+                parameter_condition.attrib.get("rule")
 
                 if condition_name in globals():
                     criterion_instance = globals()[condition_name]
                 else:
                     raise AttributeError(
-                        "The condition {} cannot be mapped to a criterion atomic".format(condition_name))
+                        "The condition {} cannot be mapped to a criterion atomic".format(
+                            condition_name
+                        )
+                    )
 
-                atomic = py_trees.composites.Parallel("Evaluation Criteria for multiple ego vehicles")
+                atomic = py_trees.composites.Parallel(
+                    "Evaluation Criteria for multiple ego vehicles"
+                )
                 for triggered_actor in actor_list:
-                    if arg_name != '':
+                    if arg_name != "":
                         atomic.add_child(criterion_instance(triggered_actor, arg_value))
                     else:
                         atomic.add_child(criterion_instance(triggered_actor))
-            elif value_condition.find('SimulationTimeCondition') is not None:
-                simtime_condition = value_condition.find('SimulationTimeCondition')
-                value = float(simtime_condition.attrib.get('value'))
-                rule = simtime_condition.attrib.get('rule')
+            elif value_condition.find("SimulationTimeCondition") is not None:
+                simtime_condition = value_condition.find("SimulationTimeCondition")
+                value = float(simtime_condition.attrib.get("value"))
+                rule = simtime_condition.attrib.get("rule")
                 atomic = SimulationTimeCondition(value, success_rule=rule)
-            elif value_condition.find('TimeOfDayCondition') is not None:
-                tod_condition = value_condition.find('TimeOfDayCondition')
-                condition_date = tod_condition.attrib.get('dateTime')
-                condition_rule = tod_condition.attrib.get('rule')
+            elif value_condition.find("TimeOfDayCondition") is not None:
+                tod_condition = value_condition.find("TimeOfDayCondition")
+                condition_date = tod_condition.attrib.get("dateTime")
+                condition_rule = tod_condition.attrib.get("rule")
                 condition_operator = OpenScenarioParser.operators[condition_rule]
-                atomic = TimeOfDayComparison(condition_date, condition_operator, condition_name)
-            elif value_condition.find('StoryboardElementStateCondition') is not None:
-                state_condition = value_condition.find('StoryboardElementStateCondition')
-                element_name = state_condition.attrib.get('storyboardElementRef')
-                element_type = state_condition.attrib.get('storyboardElementType')
-                state = state_condition.attrib.get('state')
+                atomic = TimeOfDayComparison(
+                    condition_date, condition_operator, condition_name
+                )
+            elif value_condition.find("StoryboardElementStateCondition") is not None:
+                state_condition = value_condition.find(
+                    "StoryboardElementStateCondition"
+                )
+                element_name = state_condition.attrib.get("storyboardElementRef")
+                element_type = state_condition.attrib.get("storyboardElementType")
+                state = state_condition.attrib.get("state")
                 if state == "startTransition":
-                    atomic = OSCStartEndCondition(element_type, element_name, rule="START", name=state + "Condition")
-                elif state == "stopTransition" or state == "endTransition" or state == "completeState":
-                    atomic = OSCStartEndCondition(element_type, element_name, rule="END", name=state + "Condition")
+                    atomic = OSCStartEndCondition(
+                        element_type,
+                        element_name,
+                        rule="START",
+                        name=state + "Condition",
+                    )
+                elif (
+                    state == "stopTransition"
+                    or state == "endTransition"
+                    or state == "completeState"
+                ):
+                    atomic = OSCStartEndCondition(
+                        element_type, element_name, rule="END", name=state + "Condition"
+                    )
                 else:
                     raise NotImplementedError(
-                        "Only start, stop, endTransitions and completeState are currently supported")
-            elif value_condition.find('UserDefinedValueCondition') is not None:
-                raise NotImplementedError("ByValue UserDefinedValue conditions are not yet supported")
-            elif value_condition.find('TrafficSignalCondition') is not None:
-                tl_condition = value_condition.find('TrafficSignalCondition')
+                        "Only start, stop, endTransitions and completeState are currently supported"
+                    )
+            elif value_condition.find("UserDefinedValueCondition") is not None:
+                raise NotImplementedError(
+                    "ByValue UserDefinedValue conditions are not yet supported"
+                )
+            elif value_condition.find("TrafficSignalCondition") is not None:
+                tl_condition = value_condition.find("TrafficSignalCondition")
 
-                name_condition = tl_condition.attrib.get('name')
-                traffic_light = OpenScenarioParser.get_traffic_light_from_osc_name(name_condition)
+                name_condition = tl_condition.attrib.get("name")
+                traffic_light = OpenScenarioParser.get_traffic_light_from_osc_name(
+                    name_condition
+                )
 
-                tl_state = tl_condition.attrib.get('state').upper()
+                tl_state = tl_condition.attrib.get("state").upper()
                 if tl_state not in OpenScenarioParser.tl_states:
                     raise KeyError("CARLA only supports Green, Red, Yellow or Off")
                 state_condition = OpenScenarioParser.tl_states[tl_state]
 
                 atomic = WaitForTrafficLightState(
-                    traffic_light, state_condition, name=condition_name)
-            elif value_condition.find('TrafficSignalControllerCondition') is not None:
-                raise NotImplementedError("ByValue TrafficSignalController conditions are not yet supported")
+                    traffic_light, state_condition, name=condition_name
+                )
+            elif value_condition.find("TrafficSignalControllerCondition") is not None:
+                raise NotImplementedError(
+                    "ByValue TrafficSignalController conditions are not yet supported"
+                )
             else:
                 raise AttributeError("Unknown ByValue condition")
 
@@ -902,155 +1135,252 @@ class OpenScenarioParser(object):
 
         Note not all OpenSCENARIO actions are currently supported
         """
-        maneuver_name = action.attrib.get('name', 'unknown')
+        maneuver_name = action.attrib.get("name", "unknown")
 
-        if action.find('GlobalAction') is not None:
-            global_action = action.find('GlobalAction')
-            if global_action.find('InfrastructureAction') is not None:
-                infrastructure_action = global_action.find('InfrastructureAction').find('TrafficSignalAction')
-                if infrastructure_action.find('TrafficSignalStateAction') is not None:
-                    traffic_light_action = infrastructure_action.find('TrafficSignalStateAction')
+        if action.find("GlobalAction") is not None:
+            global_action = action.find("GlobalAction")
+            if global_action.find("InfrastructureAction") is not None:
+                infrastructure_action = global_action.find("InfrastructureAction").find(
+                    "TrafficSignalAction"
+                )
+                if infrastructure_action.find("TrafficSignalStateAction") is not None:
+                    traffic_light_action = infrastructure_action.find(
+                        "TrafficSignalStateAction"
+                    )
 
-                    name_condition = traffic_light_action.attrib.get('name')
-                    traffic_light = OpenScenarioParser.get_traffic_light_from_osc_name(name_condition)
+                    name_condition = traffic_light_action.attrib.get("name")
+                    traffic_light = OpenScenarioParser.get_traffic_light_from_osc_name(
+                        name_condition
+                    )
 
-                    tl_state = traffic_light_action.attrib.get('state').upper()
+                    tl_state = traffic_light_action.attrib.get("state").upper()
                     if tl_state not in OpenScenarioParser.tl_states:
                         raise KeyError("CARLA only supports Green, Red, Yellow or Off")
                     traffic_light_state = OpenScenarioParser.tl_states[tl_state]
 
                     atomic = TrafficLightStateSetter(
-                        traffic_light, traffic_light_state, name=maneuver_name + "_" + str(traffic_light.id))
+                        traffic_light,
+                        traffic_light_state,
+                        name=maneuver_name + "_" + str(traffic_light.id),
+                    )
                 else:
-                    raise NotImplementedError("TrafficLights can only be influenced via TrafficSignalStateAction")
-            elif global_action.find('EnvironmentAction') is not None:
+                    raise NotImplementedError(
+                        "TrafficLights can only be influenced via TrafficSignalStateAction"
+                    )
+            elif global_action.find("EnvironmentAction") is not None:
                 weather_behavior = ChangeWeather(
-                    OpenScenarioParser.get_weather_from_env_action(global_action, catalogs))
+                    OpenScenarioParser.get_weather_from_env_action(
+                        global_action, catalogs
+                    )
+                )
                 friction_behavior = ChangeRoadFriction(
-                    OpenScenarioParser.get_friction_from_env_action(global_action, catalogs))
+                    OpenScenarioParser.get_friction_from_env_action(
+                        global_action, catalogs
+                    )
+                )
 
                 env_behavior = py_trees.composites.Parallel(
-                    policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL, name=maneuver_name)
+                    policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL,
+                    name=maneuver_name,
+                )
 
                 env_behavior.add_child(
-                    oneshot_behavior(variable_name=maneuver_name + ">WeatherUpdate", behaviour=weather_behavior))
+                    oneshot_behavior(
+                        variable_name=maneuver_name + ">WeatherUpdate",
+                        behaviour=weather_behavior,
+                    )
+                )
                 env_behavior.add_child(
-                    oneshot_behavior(variable_name=maneuver_name + ">FrictionUpdate", behaviour=friction_behavior))
+                    oneshot_behavior(
+                        variable_name=maneuver_name + ">FrictionUpdate",
+                        behaviour=friction_behavior,
+                    )
+                )
 
                 return env_behavior
 
             else:
                 raise NotImplementedError("Global actions are not yet supported")
-        elif action.find('UserDefinedAction') is not None:
-            user_defined_action = action.find('UserDefinedAction')
-            if user_defined_action.find('CustomCommandAction') is not None:
-                command = user_defined_action.find('CustomCommandAction').attrib.get('type')
-                atomic = RunScript(command, base_path=OpenScenarioParser.osc_filepath, name=maneuver_name)
-        elif action.find('PrivateAction') is not None:
-            private_action = action.find('PrivateAction')
+        elif action.find("UserDefinedAction") is not None:
+            user_defined_action = action.find("UserDefinedAction")
+            if user_defined_action.find("CustomCommandAction") is not None:
+                command = user_defined_action.find("CustomCommandAction").attrib.get(
+                    "type"
+                )
+                atomic = RunScript(
+                    command,
+                    base_path=OpenScenarioParser.osc_filepath,
+                    name=maneuver_name,
+                )
+        elif action.find("PrivateAction") is not None:
+            private_action = action.find("PrivateAction")
 
-            if private_action.find('LongitudinalAction') is not None:
-                private_action = private_action.find('LongitudinalAction')
+            if private_action.find("LongitudinalAction") is not None:
+                private_action = private_action.find("LongitudinalAction")
 
-                if private_action.find('SpeedAction') is not None:
-                    long_maneuver = private_action.find('SpeedAction')
+                if private_action.find("SpeedAction") is not None:
+                    long_maneuver = private_action.find("SpeedAction")
 
                     # duration and distance
-                    distance = float('inf')
-                    duration = float('inf')
-                    dimension = long_maneuver.find("SpeedActionDynamics").attrib.get('dynamicsDimension')
-                    if dimension == "distance":
-                        distance = float(long_maneuver.find("SpeedActionDynamics").attrib.get('value', float("inf")))
-                    else:
-                        duration = float(long_maneuver.find("SpeedActionDynamics").attrib.get('value', float("inf")))
-
-                    # absolute velocity with given target speed
-                    if long_maneuver.find("SpeedActionTarget").find("AbsoluteTargetSpeed") is not None:
-                        target_speed = float(long_maneuver.find("SpeedActionTarget").find(
-                            "AbsoluteTargetSpeed").attrib.get('value', 0))
-                        atomic = ChangeActorTargetSpeed(
-                            actor, target_speed, distance=distance, duration=duration, name=maneuver_name)
-
-                    # relative velocity to given actor
-                    if long_maneuver.find("SpeedActionTarget").find("RelativeTargetSpeed") is not None:
-                        relative_speed = long_maneuver.find("SpeedActionTarget").find("RelativeTargetSpeed")
-                        obj = relative_speed.attrib.get('entityRef')
-                        value = float(relative_speed.attrib.get('value', 0))
-                        value_type = relative_speed.attrib.get('speedTargetValueType')
-                        continuous = relative_speed.attrib.get('continuous')
-
-                        for traffic_actor in CarlaDataProvider.get_world().get_actors():
-                            if 'role_name' in traffic_actor.attributes and traffic_actor.attributes['role_name'] == obj:
-                                obj_actor = traffic_actor
-
-                        atomic = ChangeActorTargetSpeed(actor,
-                                                        target_speed=0.0,
-                                                        relative_actor=obj_actor,
-                                                        value=value,
-                                                        value_type=value_type,
-                                                        continuous=continuous,
-                                                        distance=distance,
-                                                        duration=duration,
-                                                        name=maneuver_name)
-
-                elif private_action.find('LongitudinalDistanceAction') is not None:
-                    raise NotImplementedError("Longitudinal distance actions are not yet supported")
-                else:
-                    raise AttributeError("Unknown longitudinal action")
-            elif private_action.find('LateralAction') is not None:
-                private_action = private_action.find('LateralAction')
-                if private_action.find('LaneChangeAction') is not None:
-                    # Note: LaneChangeActions are currently only supported for RelativeTargetLane
-                    #       with +1 or -1 referring to the action actor
-                    lat_maneuver = private_action.find('LaneChangeAction')
-                    target_lane_rel = float(lat_maneuver.find("LaneChangeTarget").find(
-                        "RelativeTargetLane").attrib.get('value', 0))
-                    # duration and distance
-                    distance = float('inf')
-                    duration = float('inf')
-                    dimension = lat_maneuver.find("LaneChangeActionDynamics").attrib.get('dynamicsDimension')
+                    distance = float("inf")
+                    duration = float("inf")
+                    dimension = long_maneuver.find("SpeedActionDynamics").attrib.get(
+                        "dynamicsDimension"
+                    )
                     if dimension == "distance":
                         distance = float(
-                            lat_maneuver.find("LaneChangeActionDynamics").attrib.get('value', float("inf")))
+                            long_maneuver.find("SpeedActionDynamics").attrib.get(
+                                "value", float("inf")
+                            )
+                        )
                     else:
                         duration = float(
-                            lat_maneuver.find("LaneChangeActionDynamics").attrib.get('value', float("inf")))
-                    atomic = ChangeActorLateralMotion(actor,
-                                                      direction="left" if target_lane_rel < 0 else "right",
-                                                      distance_lane_change=distance,
-                                                      distance_other_lane=1000,
-                                                      name=maneuver_name)
+                            long_maneuver.find("SpeedActionDynamics").attrib.get(
+                                "value", float("inf")
+                            )
+                        )
+
+                    # absolute velocity with given target speed
+                    if (
+                        long_maneuver.find("SpeedActionTarget").find(
+                            "AbsoluteTargetSpeed"
+                        )
+                        is not None
+                    ):
+                        target_speed = float(
+                            long_maneuver.find("SpeedActionTarget")
+                            .find("AbsoluteTargetSpeed")
+                            .attrib.get("value", 0)
+                        )
+                        atomic = ChangeActorTargetSpeed(
+                            actor,
+                            target_speed,
+                            distance=distance,
+                            duration=duration,
+                            name=maneuver_name,
+                        )
+
+                    # relative velocity to given actor
+                    if (
+                        long_maneuver.find("SpeedActionTarget").find(
+                            "RelativeTargetSpeed"
+                        )
+                        is not None
+                    ):
+                        relative_speed = long_maneuver.find("SpeedActionTarget").find(
+                            "RelativeTargetSpeed"
+                        )
+                        obj = relative_speed.attrib.get("entityRef")
+                        value = float(relative_speed.attrib.get("value", 0))
+                        value_type = relative_speed.attrib.get("speedTargetValueType")
+                        continuous = relative_speed.attrib.get("continuous")
+
+                        for traffic_actor in CarlaDataProvider.get_world().get_actors():
+                            if (
+                                "role_name" in traffic_actor.attributes
+                                and traffic_actor.attributes["role_name"] == obj
+                            ):
+                                obj_actor = traffic_actor
+
+                        atomic = ChangeActorTargetSpeed(
+                            actor,
+                            target_speed=0.0,
+                            relative_actor=obj_actor,
+                            value=value,
+                            value_type=value_type,
+                            continuous=continuous,
+                            distance=distance,
+                            duration=duration,
+                            name=maneuver_name,
+                        )
+
+                elif private_action.find("LongitudinalDistanceAction") is not None:
+                    raise NotImplementedError(
+                        "Longitudinal distance actions are not yet supported"
+                    )
+                else:
+                    raise AttributeError("Unknown longitudinal action")
+            elif private_action.find("LateralAction") is not None:
+                private_action = private_action.find("LateralAction")
+                if private_action.find("LaneChangeAction") is not None:
+                    # Note: LaneChangeActions are currently only supported for RelativeTargetLane
+                    #       with +1 or -1 referring to the action actor
+                    lat_maneuver = private_action.find("LaneChangeAction")
+                    target_lane_rel = float(
+                        lat_maneuver.find("LaneChangeTarget")
+                        .find("RelativeTargetLane")
+                        .attrib.get("value", 0)
+                    )
+                    # duration and distance
+                    distance = float("inf")
+                    duration = float("inf")
+                    dimension = lat_maneuver.find(
+                        "LaneChangeActionDynamics"
+                    ).attrib.get("dynamicsDimension")
+                    if dimension == "distance":
+                        distance = float(
+                            lat_maneuver.find("LaneChangeActionDynamics").attrib.get(
+                                "value", float("inf")
+                            )
+                        )
+                    else:
+                        duration = float(
+                            lat_maneuver.find("LaneChangeActionDynamics").attrib.get(
+                                "value", float("inf")
+                            )
+                        )
+                    atomic = ChangeActorLateralMotion(
+                        actor,
+                        direction="left" if target_lane_rel < 0 else "right",
+                        distance_lane_change=distance,
+                        distance_other_lane=1000,
+                        name=maneuver_name,
+                    )
                 else:
                     raise AttributeError("Unknown lateral action")
-            elif private_action.find('VisibilityAction') is not None:
+            elif private_action.find("VisibilityAction") is not None:
                 raise NotImplementedError("Visibility actions are not yet supported")
-            elif private_action.find('SynchronizeAction') is not None:
-                raise NotImplementedError("Synchronization actions are not yet supported")
-            elif private_action.find('ActivateControllerAction') is not None:
-                private_action = private_action.find('ActivateControllerAction')
-                activate = strtobool(private_action.attrib.get('longitudinal'))
+            elif private_action.find("SynchronizeAction") is not None:
+                raise NotImplementedError(
+                    "Synchronization actions are not yet supported"
+                )
+            elif private_action.find("ActivateControllerAction") is not None:
+                private_action = private_action.find("ActivateControllerAction")
+                activate = strtobool(private_action.attrib.get("longitudinal"))
                 atomic = ChangeAutoPilot(actor, activate, name=maneuver_name)
-            elif private_action.find('ControllerAction') is not None:
-                controller_action = private_action.find('ControllerAction')
-                module, args = OpenScenarioParser.get_controller(controller_action, catalogs)
+            elif private_action.find("ControllerAction") is not None:
+                controller_action = private_action.find("ControllerAction")
+                module, args = OpenScenarioParser.get_controller(
+                    controller_action, catalogs
+                )
                 atomic = ChangeActorControl(actor, control_py_module=module, args=args)
-            elif private_action.find('TeleportAction') is not None:
-                position = private_action.find('TeleportAction')
-                atomic = ActorTransformSetterToOSCPosition(actor, position, name=maneuver_name)
-            elif private_action.find('RoutingAction') is not None:
-                private_action = private_action.find('RoutingAction')
-                if private_action.find('AssignRouteAction') is not None:
+            elif private_action.find("TeleportAction") is not None:
+                position = private_action.find("TeleportAction")
+                atomic = ActorTransformSetterToOSCPosition(
+                    actor, position, name=maneuver_name
+                )
+            elif private_action.find("RoutingAction") is not None:
+                private_action = private_action.find("RoutingAction")
+                if private_action.find("AssignRouteAction") is not None:
                     # @TODO: How to handle relative positions here? This might chance at runtime?!
-                    route_action = private_action.find('AssignRouteAction')
+                    route_action = private_action.find("AssignRouteAction")
                     waypoints = OpenScenarioParser.get_route(route_action, catalogs)
-                    atomic = ChangeActorWaypoints(actor, waypoints=waypoints, name=maneuver_name)
-                elif private_action.find('FollowTrajectoryAction') is not None:
-                    raise NotImplementedError("Private FollowTrajectory actions are not yet supported")
-                elif private_action.find('AcquirePositionAction') is not None:
-                    route_action = private_action.find('AcquirePositionAction')
-                    osc_position = route_action.find('Position')
-                    position = OpenScenarioParser.convert_position_to_transform(osc_position)
-                    atomic = ChangeActorWaypointsToReachPosition(actor, position=position, name=maneuver_name)
+                    atomic = ChangeActorWaypoints(
+                        actor, waypoints=waypoints, name=maneuver_name
+                    )
+                elif private_action.find("FollowTrajectoryAction") is not None:
+                    raise NotImplementedError(
+                        "Private FollowTrajectory actions are not yet supported"
+                    )
+                elif private_action.find("AcquirePositionAction") is not None:
+                    route_action = private_action.find("AcquirePositionAction")
+                    osc_position = route_action.find("Position")
+                    position = OpenScenarioParser.convert_position_to_transform(
+                        osc_position
+                    )
+                    atomic = ChangeActorWaypointsToReachPosition(
+                        actor, position=position, name=maneuver_name
+                    )
                 else:
                     raise AttributeError("Unknown private routing action")
             else:

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -677,7 +677,7 @@ class OpenScenarioParser(object):
                     condition_rule = headtime_condition.attrib.get('rule')
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
-                    condition_freespace = strtobool(headtime_condition.attrib.get('freespace'))
+                    condition_freespace = strtobool(headtime_condition.attrib.get('freespace', False))
                     condition_along_route = strtobool(headtime_condition.attrib.get('alongRoute', False))
 
                     for actor in actor_list:
@@ -703,7 +703,7 @@ class OpenScenarioParser(object):
                     condition_target = ttc_condition.find('TimeToCollisionConditionTarget')
                     entity_ref_ = condition_target.find('EntityRef')
 
-                    condition_freespace = strtobool(ttc_condition.attrib.get('freespace'))
+                    condition_freespace = strtobool(ttc_condition.attrib.get('freespace', False))
                     condition_along_route = strtobool(ttc_condition.attrib.get('alongRoute', False))
 
                     if condition_target.find('Position') is not None:

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -54,6 +54,7 @@ from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import (I
                                                                                InTriggerDistanceToOSCPosition,
                                                                                InTimeToArrivalToOSCPosition,
                                                                                InTimeToArrivalToVehicle,
+                                                                               InTimeToCollisionToVehicle,
                                                                                DriveDistance,
                                                                                StandStill,
                                                                                OSCStartEndCondition,
@@ -702,13 +703,11 @@ class OpenScenarioParser(object):
                     condition_rule = ttc_condition.attrib.get('rule')
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
-                    condition_value = ttc_condition.attrib.get('value')
+                    condition_value = float(ttc_condition.attrib.get('value'))
                     condition_target = ttc_condition.find('TimeToCollisionConditionTarget')
+                    entity_ref_ = condition_target.find('EntityRef')
 
-                    condition_freespace = strtobool(ttc_condition.attrib.get('freespace', False))
-                    if condition_freespace:
-                        raise NotImplementedError(
-                            "TimeToCollisionCondition: freespace attribute is currently not implemented")
+                    condition_freespace = strtobool(ttc_condition.attrib.get('freespace'))
                     condition_along_route = strtobool(ttc_condition.attrib.get('alongRoute', False))
 
                     if condition_target.find('Position') is not None:
@@ -717,15 +716,15 @@ class OpenScenarioParser(object):
                             trigger_actor, position, condition_value, condition_along_route, condition_operator)
                     else:
                         for actor in actor_list:
-                            if ttc_condition.attrib.get('EntityRef', None) == actor.attributes['role_name']:
+                            if entity_ref_.attrib.get('entityRef', None) == actor.attributes['role_name']:
                                 triggered_actor = actor
                                 break
                         if triggered_actor is None:
                             raise AttributeError("Cannot find actor '{}' for condition".format(
-                                ttc_condition.attrib.get('EntityRef', None)))
+                                entity_ref_.attrib.get('entityRef', None)))
 
-                        atomic = InTimeToArrivalToVehicle(
-                            trigger_actor, triggered_actor, condition_value,
+                        atomic = InTimeToCollisionToVehicle(
+                            trigger_actor, triggered_actor, condition_value, condition_freespace,
                             condition_along_route, condition_operator, condition_name)
                 elif entity_condition.find('AccelerationCondition') is not None:
                     accel_condition = entity_condition.find('AccelerationCondition')

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -36,7 +36,8 @@ from srunner.scenariomanager.scenarioatomics.atomic_behaviors import (
 )
 
 # pylint: disable=unused-import
-# For the following includes the pylint check is disabled, as these are accessed via globals()
+# For the following includes the pylint check is disabled, as these are
+# accessed via globals()
 from srunner.scenariomanager.scenarioatomics.atomic_criteria import (
     CollisionTest,
     MaxVelocityTest,
@@ -132,8 +133,10 @@ class OpenScenarioParser(object):
             ):
                 carla_tl_location = carla_tl.get_transform().location
                 distance = carla_tl_location.distance(
-                    carla.Location(float(pos[0]), float(pos[1]), carla_tl_location.z)
-                )
+                    carla.Location(
+                        float(
+                            pos[0]), float(
+                            pos[1]), carla_tl_location.z))
                 if distance < 2.0:
                     traffic_light = carla_tl
                     break
@@ -232,7 +235,8 @@ class OpenScenarioParser(object):
         ]
         entry_copy = copy.deepcopy(entry)
         catalog_copy = copy.deepcopy(catalog_reference)
-        entry = OpenScenarioParser.assign_catalog_parameters(entry_copy, catalog_copy)
+        entry = OpenScenarioParser.assign_catalog_parameters(
+            entry_copy, catalog_copy)
 
         return entry
 
@@ -261,7 +265,8 @@ class OpenScenarioParser(object):
                     value = parameter.attrib.get("value")
                     parameter_dict[name] = value
 
-        for parameter_assignments in catalog_reference.iter("ParameterAssignments"):
+        for parameter_assignments in catalog_reference.iter(
+                "ParameterAssignments"):
             for parameter_assignment in parameter_assignments.iter(
                 "ParameterAssignment"
             ):
@@ -353,9 +358,11 @@ class OpenScenarioParser(object):
         carla_weather.sun_altitude_angle = math.degrees(
             float(sun.attrib.get("elevation", 0))
         )
-        carla_weather.cloudiness = 100 - float(sun.attrib.get("intensity", 0)) * 100
+        carla_weather.cloudiness = 100 - \
+            float(sun.attrib.get("intensity", 0)) * 100
         fog = weather.find("Fog")
-        carla_weather.fog_distance = float(fog.attrib.get("visualRange", "inf"))
+        carla_weather.fog_distance = float(
+            fog.attrib.get("visualRange", "inf"))
         if carla_weather.fog_distance < 1000:
             carla_weather.fog_density = 100
         carla_weather.precipitation = 0
@@ -441,7 +448,8 @@ class OpenScenarioParser(object):
             route = xml_tree.find("Route")
         elif xml_tree.find("CatalogReference") is not None:
             catalog_reference = xml_tree.find("CatalogReference")
-            route = OpenScenarioParser.get_catalog_entry(catalogs, catalog_reference)
+            route = OpenScenarioParser.get_catalog_entry(
+                catalogs, catalog_reference)
         else:
             raise AttributeError("Unknown private FollowRoute action")
 
@@ -449,7 +457,8 @@ class OpenScenarioParser(object):
         if route is not None:
             for waypoint in route.iter("Waypoint"):
                 position = waypoint.find("Position")
-                transform = OpenScenarioParser.convert_position_to_transform(position)
+                transform = OpenScenarioParser.convert_position_to_transform(
+                    position)
                 waypoints.append(transform)
 
         return waypoints
@@ -516,10 +525,7 @@ class OpenScenarioParser(object):
 
             if obj_actor is None:
                 raise AttributeError(
-                    "Object '{}' provided as position reference is not known".format(
-                        obj
-                    )
-                )
+                    "Object '{}' provided as position reference is not known".format(obj))
 
             # calculate orientation h, p, r
             is_absolute = False
@@ -572,7 +578,8 @@ class OpenScenarioParser(object):
                 offset = float(rel_pos.attrib.get("offset", 0.0))
 
                 carla_map = CarlaDataProvider.get_map()
-                relative_waypoint = carla_map.get_waypoint(actor_transform.location)
+                relative_waypoint = carla_map.get_waypoint(
+                    actor_transform.location)
 
                 if dlane == 0:
                     wp = relative_waypoint
@@ -583,9 +590,7 @@ class OpenScenarioParser(object):
                 if wp is None:
                     raise AttributeError(
                         "Object '{}' position with dLane={} is not valid".format(
-                            obj, dlane
-                        )
-                    )
+                            obj, dlane))
 
                 if ds < 0:
                     ds = (-1.0) * ds
@@ -615,7 +620,8 @@ class OpenScenarioParser(object):
         elif position.find("RoadPosition") is not None:
             raise NotImplementedError("Road positions are not yet supported")
         elif position.find("RelativeRoadPosition") is not None:
-            raise NotImplementedError("RelativeRoad positions are not yet supported")
+            raise NotImplementedError(
+                "RelativeRoad positions are not yet supported")
         elif position.find("LanePosition") is not None:
             lane_pos = position.find("LanePosition")
             road_id = int(lane_pos.attrib.get("roadId", 0))
@@ -690,9 +696,8 @@ class OpenScenarioParser(object):
             )
             triggered_actor = None
 
-            for triggering_entities in condition.find("ByEntityCondition").iter(
-                "TriggeringEntities"
-            ):
+            for triggering_entities in condition.find(
+                    "ByEntityCondition").iter("TriggeringEntities"):
                 for entity in triggering_entities.iter("EntityRef"):
                     for actor in actor_list:
                         if (
@@ -706,7 +711,8 @@ class OpenScenarioParser(object):
                 "EntityCondition"
             ):
                 if entity_condition.find("EndOfRoadCondition") is not None:
-                    end_road_condition = entity_condition.find("EndOfRoadCondition")
+                    end_road_condition = entity_condition.find(
+                        "EndOfRoadCondition")
                     condition_duration = float(
                         end_road_condition.attrib.get("duration")
                     )
@@ -719,10 +725,12 @@ class OpenScenarioParser(object):
                     )
                 elif entity_condition.find("CollisionCondition") is not None:
 
-                    collision_condition = entity_condition.find("CollisionCondition")
+                    collision_condition = entity_condition.find(
+                        "CollisionCondition")
 
                     if collision_condition.find("EntityRef") is not None:
-                        collision_entity = collision_condition.find("EntityRef")
+                        collision_entity = collision_condition.find(
+                            "EntityRef")
 
                         for actor in actor_list:
                             if (
@@ -735,9 +743,8 @@ class OpenScenarioParser(object):
                         if triggered_actor is None:
                             raise AttributeError(
                                 "Cannot find actor '{}' for condition".format(
-                                    collision_condition.attrib.get("entityRef", None)
-                                )
-                            )
+                                    collision_condition.attrib.get(
+                                        "entityRef", None)))
 
                         atomic_cls = py_trees.meta.inverter(CollisionTest)
                         atomic = atomic_cls(
@@ -748,9 +755,8 @@ class OpenScenarioParser(object):
                         )
 
                     elif collision_condition.find("ByType") is not None:
-                        collision_type = collision_condition.find("ByType").attrib.get(
-                            "type", None
-                        )
+                        collision_type = collision_condition.find(
+                            "ByType").attrib.get("type", None)
 
                         triggered_type = OpenScenarioParser.actor_types[collision_type]
 
@@ -772,7 +778,8 @@ class OpenScenarioParser(object):
 
                 elif entity_condition.find("OffroadCondition") is not None:
                     off_condition = entity_condition.find("OffroadCondition")
-                    condition_duration = float(off_condition.attrib.get("duration"))
+                    condition_duration = float(
+                        off_condition.attrib.get("duration"))
                     atomic_cls = py_trees.meta.inverter(OffRoadTest)
                     atomic = atomic_cls(
                         trigger_actor,
@@ -781,9 +788,11 @@ class OpenScenarioParser(object):
                         name=condition_name,
                     )
                 elif entity_condition.find("TimeHeadwayCondition") is not None:
-                    headtime_condition = entity_condition.find("TimeHeadwayCondition")
+                    headtime_condition = entity_condition.find(
+                        "TimeHeadwayCondition")
 
-                    condition_value = float(headtime_condition.attrib.get("value"))
+                    condition_value = float(
+                        headtime_condition.attrib.get("value"))
 
                     condition_rule = headtime_condition.attrib.get("rule")
                     condition_operator = OpenScenarioParser.operators[condition_rule]
@@ -809,9 +818,8 @@ class OpenScenarioParser(object):
                     if triggered_actor is None:
                         raise AttributeError(
                             "Cannot find actor '{}' for condition".format(
-                                headtime_condition.attrib.get("entityRef", None)
-                            )
-                        )
+                                headtime_condition.attrib.get(
+                                    "entityRef", None)))
 
                     atomic = InTimeToArrivalToVehicle(
                         trigger_actor,
@@ -823,7 +831,8 @@ class OpenScenarioParser(object):
                     )
 
                 elif entity_condition.find("TimeToCollisionCondition") is not None:
-                    ttc_condition = entity_condition.find("TimeToCollisionCondition")
+                    ttc_condition = entity_condition.find(
+                        "TimeToCollisionCondition")
 
                     condition_rule = ttc_condition.attrib.get("rule")
                     condition_operator = OpenScenarioParser.operators[condition_rule]
@@ -875,8 +884,10 @@ class OpenScenarioParser(object):
                             condition_name,
                         )
                 elif entity_condition.find("AccelerationCondition") is not None:
-                    accel_condition = entity_condition.find("AccelerationCondition")
-                    condition_value = float(accel_condition.attrib.get("value"))
+                    accel_condition = entity_condition.find(
+                        "AccelerationCondition")
+                    condition_value = float(
+                        accel_condition.attrib.get("value"))
                     condition_rule = accel_condition.attrib.get("rule")
                     condition_operator = OpenScenarioParser.operators[condition_rule]
                     atomic = TriggerAcceleration(
@@ -888,7 +899,8 @@ class OpenScenarioParser(object):
                 elif entity_condition.find("StandStillCondition") is not None:
                     ss_condition = entity_condition.find("StandStillCondition")
                     duration = float(ss_condition.attrib.get("duration"))
-                    atomic = StandStill(trigger_actor, condition_name, duration)
+                    atomic = StandStill(
+                        trigger_actor, condition_name, duration)
                 elif entity_condition.find("SpeedCondition") is not None:
                     spd_condition = entity_condition.find("SpeedCondition")
                     condition_value = float(spd_condition.attrib.get("value"))
@@ -902,8 +914,10 @@ class OpenScenarioParser(object):
                         condition_name,
                     )
                 elif entity_condition.find("RelativeSpeedCondition") is not None:
-                    relspd_condition = entity_condition.find("RelativeSpeedCondition")
-                    condition_value = float(relspd_condition.attrib.get("value"))
+                    relspd_condition = entity_condition.find(
+                        "RelativeSpeedCondition")
+                    condition_value = float(
+                        relspd_condition.attrib.get("value"))
                     condition_rule = relspd_condition.attrib.get("rule")
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
@@ -933,21 +947,25 @@ class OpenScenarioParser(object):
                     distance_condition = entity_condition.find(
                         "TraveledDistanceCondition"
                     )
-                    distance_value = float(distance_condition.attrib.get("value"))
+                    distance_value = float(
+                        distance_condition.attrib.get("value"))
                     atomic = DriveDistance(
                         trigger_actor, distance_value, name=condition_name
                     )
                 elif entity_condition.find("ReachPositionCondition") is not None:
-                    rp_condition = entity_condition.find("ReachPositionCondition")
-                    distance_value = float(rp_condition.attrib.get("tolerance"))
+                    rp_condition = entity_condition.find(
+                        "ReachPositionCondition")
+                    distance_value = float(
+                        rp_condition.attrib.get("tolerance"))
                     position = rp_condition.find("Position")
                     atomic = InTriggerDistanceToOSCPosition(
-                        trigger_actor, position, distance_value, name=condition_name
-                    )
+                        trigger_actor, position, distance_value, name=condition_name)
                 elif entity_condition.find("DistanceCondition") is not None:
-                    distance_condition = entity_condition.find("DistanceCondition")
+                    distance_condition = entity_condition.find(
+                        "DistanceCondition")
 
-                    distance_value = float(distance_condition.attrib.get("value"))
+                    distance_value = float(
+                        distance_condition.attrib.get("value"))
 
                     distance_rule = distance_condition.attrib.get("rule")
                     distance_operator = OpenScenarioParser.operators[distance_rule]
@@ -978,7 +996,8 @@ class OpenScenarioParser(object):
                     distance_condition = entity_condition.find(
                         "RelativeDistanceCondition"
                     )
-                    distance_value = float(distance_condition.attrib.get("value"))
+                    distance_value = float(
+                        distance_condition.attrib.get("value"))
 
                     distance_freespace = strtobool(
                         distance_condition.attrib.get("freespace", False)
@@ -992,19 +1011,16 @@ class OpenScenarioParser(object):
                         == "cartesianDistance"
                     ):
                         for actor in actor_list:
-                            if (
-                                distance_condition.attrib.get("entityRef", None)
-                                == actor.attributes["role_name"]
-                            ):
+                            if (distance_condition.attrib.get("entityRef",
+                                                              None) == actor.attributes["role_name"]):
                                 triggered_actor = actor
                                 break
 
                         if triggered_actor is None:
                             raise AttributeError(
                                 "Cannot find actor '{}' for condition".format(
-                                    distance_condition.attrib.get("entityRef", None)
-                                )
-                            )
+                                    distance_condition.attrib.get(
+                                        "entityRef", None)))
 
                         condition_rule = distance_condition.attrib.get("rule")
                         condition_operator = OpenScenarioParser.operators[
@@ -1024,7 +1040,8 @@ class OpenScenarioParser(object):
         elif condition.find("ByValueCondition") is not None:
             value_condition = condition.find("ByValueCondition")
             if value_condition.find("ParameterCondition") is not None:
-                parameter_condition = value_condition.find("ParameterCondition")
+                parameter_condition = value_condition.find(
+                    "ParameterCondition")
                 arg_name = parameter_condition.attrib.get("parameterRef")
                 value = parameter_condition.attrib.get("value")
                 if value != "":
@@ -1047,11 +1064,14 @@ class OpenScenarioParser(object):
                 )
                 for triggered_actor in actor_list:
                     if arg_name != "":
-                        atomic.add_child(criterion_instance(triggered_actor, arg_value))
+                        atomic.add_child(
+                            criterion_instance(
+                                triggered_actor, arg_value))
                     else:
                         atomic.add_child(criterion_instance(triggered_actor))
             elif value_condition.find("SimulationTimeCondition") is not None:
-                simtime_condition = value_condition.find("SimulationTimeCondition")
+                simtime_condition = value_condition.find(
+                    "SimulationTimeCondition")
                 value = float(simtime_condition.attrib.get("value"))
                 rule = simtime_condition.attrib.get("rule")
                 atomic = SimulationTimeCondition(value, success_rule=rule)
@@ -1067,8 +1087,10 @@ class OpenScenarioParser(object):
                 state_condition = value_condition.find(
                     "StoryboardElementStateCondition"
                 )
-                element_name = state_condition.attrib.get("storyboardElementRef")
-                element_type = state_condition.attrib.get("storyboardElementType")
+                element_name = state_condition.attrib.get(
+                    "storyboardElementRef")
+                element_type = state_condition.attrib.get(
+                    "storyboardElementType")
                 state = state_condition.attrib.get("state")
                 if state == "startTransition":
                     atomic = OSCStartEndCondition(
@@ -1083,8 +1105,7 @@ class OpenScenarioParser(object):
                     or state == "completeState"
                 ):
                     atomic = OSCStartEndCondition(
-                        element_type, element_name, rule="END", name=state + "Condition"
-                    )
+                        element_type, element_name, rule="END", name=state + "Condition")
                 else:
                     raise NotImplementedError(
                         "Only start, stop, endTransitions and completeState are currently supported"
@@ -1098,12 +1119,12 @@ class OpenScenarioParser(object):
 
                 name_condition = tl_condition.attrib.get("name")
                 traffic_light = OpenScenarioParser.get_traffic_light_from_osc_name(
-                    name_condition
-                )
+                    name_condition)
 
                 tl_state = tl_condition.attrib.get("state").upper()
                 if tl_state not in OpenScenarioParser.tl_states:
-                    raise KeyError("CARLA only supports Green, Red, Yellow or Off")
+                    raise KeyError(
+                        "CARLA only supports Green, Red, Yellow or Off")
                 state_condition = OpenScenarioParser.tl_states[tl_state]
 
                 atomic = WaitForTrafficLightState(
@@ -1140,22 +1161,22 @@ class OpenScenarioParser(object):
         if action.find("GlobalAction") is not None:
             global_action = action.find("GlobalAction")
             if global_action.find("InfrastructureAction") is not None:
-                infrastructure_action = global_action.find("InfrastructureAction").find(
-                    "TrafficSignalAction"
-                )
-                if infrastructure_action.find("TrafficSignalStateAction") is not None:
+                infrastructure_action = global_action.find(
+                    "InfrastructureAction").find("TrafficSignalAction")
+                if infrastructure_action.find(
+                        "TrafficSignalStateAction") is not None:
                     traffic_light_action = infrastructure_action.find(
                         "TrafficSignalStateAction"
                     )
 
                     name_condition = traffic_light_action.attrib.get("name")
                     traffic_light = OpenScenarioParser.get_traffic_light_from_osc_name(
-                        name_condition
-                    )
+                        name_condition)
 
                     tl_state = traffic_light_action.attrib.get("state").upper()
                     if tl_state not in OpenScenarioParser.tl_states:
-                        raise KeyError("CARLA only supports Green, Red, Yellow or Off")
+                        raise KeyError(
+                            "CARLA only supports Green, Red, Yellow or Off")
                     traffic_light_state = OpenScenarioParser.tl_states[tl_state]
 
                     atomic = TrafficLightStateSetter(
@@ -1200,13 +1221,13 @@ class OpenScenarioParser(object):
                 return env_behavior
 
             else:
-                raise NotImplementedError("Global actions are not yet supported")
+                raise NotImplementedError(
+                    "Global actions are not yet supported")
         elif action.find("UserDefinedAction") is not None:
             user_defined_action = action.find("UserDefinedAction")
             if user_defined_action.find("CustomCommandAction") is not None:
-                command = user_defined_action.find("CustomCommandAction").attrib.get(
-                    "type"
-                )
+                command = user_defined_action.find(
+                    "CustomCommandAction").attrib.get("type")
                 atomic = RunScript(
                     command,
                     base_path=OpenScenarioParser.osc_filepath,
@@ -1224,21 +1245,16 @@ class OpenScenarioParser(object):
                     # duration and distance
                     distance = float("inf")
                     duration = float("inf")
-                    dimension = long_maneuver.find("SpeedActionDynamics").attrib.get(
-                        "dynamicsDimension"
-                    )
+                    dimension = long_maneuver.find(
+                        "SpeedActionDynamics").attrib.get("dynamicsDimension")
                     if dimension == "distance":
                         distance = float(
                             long_maneuver.find("SpeedActionDynamics").attrib.get(
-                                "value", float("inf")
-                            )
-                        )
+                                "value", float("inf")))
                     else:
                         duration = float(
                             long_maneuver.find("SpeedActionDynamics").attrib.get(
-                                "value", float("inf")
-                            )
-                        )
+                                "value", float("inf")))
 
                     # absolute velocity with given target speed
                     if (
@@ -1267,12 +1283,12 @@ class OpenScenarioParser(object):
                         )
                         is not None
                     ):
-                        relative_speed = long_maneuver.find("SpeedActionTarget").find(
-                            "RelativeTargetSpeed"
-                        )
+                        relative_speed = long_maneuver.find(
+                            "SpeedActionTarget").find("RelativeTargetSpeed")
                         obj = relative_speed.attrib.get("entityRef")
                         value = float(relative_speed.attrib.get("value", 0))
-                        value_type = relative_speed.attrib.get("speedTargetValueType")
+                        value_type = relative_speed.attrib.get(
+                            "speedTargetValueType")
                         continuous = relative_speed.attrib.get("continuous")
 
                         for traffic_actor in CarlaDataProvider.get_world().get_actors():
@@ -1320,15 +1336,11 @@ class OpenScenarioParser(object):
                     if dimension == "distance":
                         distance = float(
                             lat_maneuver.find("LaneChangeActionDynamics").attrib.get(
-                                "value", float("inf")
-                            )
-                        )
+                                "value", float("inf")))
                     else:
                         duration = float(
                             lat_maneuver.find("LaneChangeActionDynamics").attrib.get(
-                                "value", float("inf")
-                            )
-                        )
+                                "value", float("inf")))
                     atomic = ChangeActorLateralMotion(
                         actor,
                         direction="left" if target_lane_rel < 0 else "right",
@@ -1339,13 +1351,15 @@ class OpenScenarioParser(object):
                 else:
                     raise AttributeError("Unknown lateral action")
             elif private_action.find("VisibilityAction") is not None:
-                raise NotImplementedError("Visibility actions are not yet supported")
+                raise NotImplementedError(
+                    "Visibility actions are not yet supported")
             elif private_action.find("SynchronizeAction") is not None:
                 raise NotImplementedError(
                     "Synchronization actions are not yet supported"
                 )
             elif private_action.find("ActivateControllerAction") is not None:
-                private_action = private_action.find("ActivateControllerAction")
+                private_action = private_action.find(
+                    "ActivateControllerAction")
                 activate = strtobool(private_action.attrib.get("longitudinal"))
                 atomic = ChangeAutoPilot(actor, activate, name=maneuver_name)
             elif private_action.find("ControllerAction") is not None:
@@ -1353,7 +1367,8 @@ class OpenScenarioParser(object):
                 module, args = OpenScenarioParser.get_controller(
                     controller_action, catalogs
                 )
-                atomic = ChangeActorControl(actor, control_py_module=module, args=args)
+                atomic = ChangeActorControl(
+                    actor, control_py_module=module, args=args)
             elif private_action.find("TeleportAction") is not None:
                 position = private_action.find("TeleportAction")
                 atomic = ActorTransformSetterToOSCPosition(
@@ -1364,7 +1379,8 @@ class OpenScenarioParser(object):
                 if private_action.find("AssignRouteAction") is not None:
                     # @TODO: How to handle relative positions here? This might chance at runtime?!
                     route_action = private_action.find("AssignRouteAction")
-                    waypoints = OpenScenarioParser.get_route(route_action, catalogs)
+                    waypoints = OpenScenarioParser.get_route(
+                        route_action, catalogs)
                     atomic = ChangeActorWaypoints(
                         actor, waypoints=waypoints, name=maneuver_name
                     )
@@ -1376,8 +1392,7 @@ class OpenScenarioParser(object):
                     route_action = private_action.find("AcquirePositionAction")
                     osc_position = route_action.find("Position")
                     position = OpenScenarioParser.convert_position_to_transform(
-                        osc_position
-                    )
+                        osc_position)
                     atomic = ChangeActorWaypointsToReachPosition(
                         actor, position=position, name=maneuver_name
                     )
@@ -1388,7 +1403,8 @@ class OpenScenarioParser(object):
 
         else:
             if list(action):
-                raise AttributeError("Unknown action: {}".format(maneuver_name))
+                raise AttributeError(
+                    "Unknown action: {}".format(maneuver_name))
             else:
                 return Idle(duration=0, name=maneuver_name)
 

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -149,12 +149,15 @@ class OpenScenarioParser(object):
         """
         Parse the xml_tree, and replace all parameter references
         with the actual values.
+
         Note: Parameter names must not start with "$", however when referencing a parameter the
               reference has to start with "$".
               https://releases.asam.net/OpenSCENARIO/1.0.0/ASAM_OpenSCENARIO_BS-1-2_User-Guide_V1-0-0.html#_re_use_mechanisms
+
         Args:
             xml_tree: Containing all nodes that should be updated
             additional_parameter_dict (dictionary): Additional parameters as dict (key, value). Optional.
+
         returns:
             updated xml_tree, dictonary containing all parameters and their values
         """
@@ -187,6 +190,7 @@ class OpenScenarioParser(object):
     def set_global_parameters(parameter_dict):
         """
         Set global_osc_parameter dictionary
+
         Args:
             parameter_dict (Dictionary): Input for global_osc_parameter
         """
@@ -196,9 +200,11 @@ class OpenScenarioParser(object):
     def get_catalog_entry(catalogs, catalog_reference):
         """
         Get catalog entry referenced by catalog_reference included correct parameter settings
+
         Args:
             catalogs (Dictionary of dictionaries): List of all catalogs and their entries
             catalog_reference (XML ElementTree): Reference containing the exact catalog to be used
+
         returns:
             Catalog entry (XML ElementTree)
         """
@@ -215,10 +221,13 @@ class OpenScenarioParser(object):
         """
         Parse catalog_reference, and replace all parameter references
         in entry_instance by the values provided in catalog_reference.
+
         Not to be used from outside this class.
+
         Args:
             entry_instance (XML ElementTree): Entry to be updated
             catalog_reference (XML ElementTree): Reference containing the exact parameter values
+
         returns:
             updated entry_instance with updated parameter values
         """
@@ -252,10 +261,12 @@ class OpenScenarioParser(object):
     def get_friction_from_env_action(xml_tree, catalogs):
         """
         Extract the CARLA road friction coefficient from an OSC EnvironmentAction
+
         Args:
             xml_tree: Containing the EnvironmentAction,
                 or the reference to the catalog it is defined in.
             catalogs: XML Catalogs that could contain the EnvironmentAction
+
         returns:
            friction (float)
         """
@@ -282,10 +293,12 @@ class OpenScenarioParser(object):
     def get_weather_from_env_action(xml_tree, catalogs):
         """
         Extract the CARLA weather parameters from an OSC EnvironmentAction
+
         Args:
             xml_tree: Containing the EnvironmentAction,
                 or the reference to the catalog it is defined in.
             catalogs: XML Catalogs that could contain the EnvironmentAction
+
         returns:
            Weather (srunner.scenariomanager.weather_sim.Weather)
         """
@@ -334,10 +347,12 @@ class OpenScenarioParser(object):
     def get_controller(xml_tree, catalogs):
         """
         Extract the object controller from the OSC XML or a catalog
+
         Args:
             xml_tree: Containing the controller information,
                 or the reference to the catalog it is defined in.
             catalogs: XML Catalogs that could contain the EnvironmentAction
+
         returns:
            module: Python module containing the controller implementation
            args: Dictonary with (key, value) parameters for the controller
@@ -371,10 +386,12 @@ class OpenScenarioParser(object):
     def get_route(xml_tree, catalogs):
         """
         Extract the route from the OSC XML or a catalog
+
         Args:
             xml_tree: Containing the route information,
                 or the reference to the catalog it is defined in.
             catalogs: XML Catalogs that could contain the Route
+
         returns:
            waypoints: List of route waypoints
         """
@@ -401,6 +418,7 @@ class OpenScenarioParser(object):
     def convert_position_to_transform(position, actor_list=None):
         """
         Convert an OpenScenario position into a CARLA transform
+
         Not supported: Road, RelativeRoad, Lane, RelativeLane as the PythonAPI currently
                        does not provide sufficient access to OpenDrive information
                        Also not supported is Route. This can be added by checking additional
@@ -579,8 +597,10 @@ class OpenScenarioParser(object):
     def convert_condition_to_atomic(condition, actor_list):
         """
         Convert an OpenSCENARIO condition into a Behavior/Criterion atomic
+
         If there is a delay defined in the condition, then the condition is checked after the delay time
         passed by, e.g. <Condition name="" delay="5">.
+
         Note: Not all conditions are currently supported.
         """
 
@@ -880,6 +900,7 @@ class OpenScenarioParser(object):
     def convert_maneuver_to_atomic(action, actor, catalogs):
         """
         Convert an OpenSCENARIO maneuver action into a Behavior atomic
+
         Note not all OpenSCENARIO actions are currently supported
         """
         maneuver_name = action.attrib.get('name', 'unknown')

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -20,77 +20,68 @@ import carla
 
 from srunner.scenariomanager.carla_data_provider import CarlaDataProvider
 from srunner.scenariomanager.weather_sim import Weather
-from srunner.scenariomanager.scenarioatomics.atomic_behaviors import (
-    TrafficLightStateSetter,
-    ActorTransformSetterToOSCPosition,
-    RunScript,
-    ChangeWeather,
-    ChangeAutoPilot,
-    ChangeRoadFriction,
-    ChangeActorTargetSpeed,
-    ChangeActorControl,
-    ChangeActorWaypoints,
-    ChangeActorWaypointsToReachPosition,
-    ChangeActorLateralMotion,
-    Idle,
-)
-
+from srunner.scenariomanager.scenarioatomics.atomic_behaviors import (TrafficLightStateSetter,
+                                                                      ActorTransformSetterToOSCPosition,
+                                                                      RunScript,
+                                                                      ChangeWeather,
+                                                                      ChangeAutoPilot,
+                                                                      ChangeRoadFriction,
+                                                                      ChangeActorTargetSpeed,
+                                                                      ChangeActorControl,
+                                                                      ChangeActorWaypoints,
+                                                                      ChangeActorWaypointsToReachPosition,
+                                                                      ChangeActorLateralMotion,
+                                                                      Idle)
 # pylint: disable=unused-import
-# For the following includes the pylint check is disabled, as these are
-# accessed via globals()
-from srunner.scenariomanager.scenarioatomics.atomic_criteria import (
-    CollisionTest,
-    MaxVelocityTest,
-    DrivenDistanceTest,
-    AverageVelocityTest,
-    KeepLaneTest,
-    ReachedRegionTest,
-    OnSidewalkTest,
-    WrongLaneTest,
-    InRadiusRegionTest,
-    InRouteTest,
-    RouteCompletionTest,
-    RunningRedLightTest,
-    RunningStopTest,
-    OffRoadTest,
-    EndofRoadTest,
-)
-
+# For the following includes the pylint check is disabled, as these are accessed via globals()
+from srunner.scenariomanager.scenarioatomics.atomic_criteria import (CollisionTest,
+                                                                     MaxVelocityTest,
+                                                                     DrivenDistanceTest,
+                                                                     AverageVelocityTest,
+                                                                     KeepLaneTest,
+                                                                     ReachedRegionTest,
+                                                                     OnSidewalkTest,
+                                                                     WrongLaneTest,
+                                                                     InRadiusRegionTest,
+                                                                     InRouteTest,
+                                                                     RouteCompletionTest,
+                                                                     RunningRedLightTest,
+                                                                     RunningStopTest,
+                                                                     OffRoadTest,
+                                                                     EndofRoadTest)
 # pylint: enable=unused-import
-from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import (
-    InTriggerDistanceToVehicle,
-    InTriggerDistanceToOSCPosition,
-    InTimeToArrivalToOSCPosition,
-    InTimeToArrivalToVehicle,
-    InTimeToCollisionToVehicle,
-    DriveDistance,
-    StandStill,
-    OSCStartEndCondition,
-    TriggerAcceleration,
-    RelativeVelocityToOtherActor,
-    TimeOfDayComparison,
-    TriggerVelocity,
-    WaitForTrafficLightState,
-)
+from srunner.scenariomanager.scenarioatomics.atomic_trigger_conditions import (InTriggerDistanceToVehicle,
+                                                                               InTriggerDistanceToOSCPosition,
+                                                                               InTimeToArrivalToOSCPosition,
+                                                                               InTimeToArrivalToVehicle,
+                                                                               InTimeToCollisionToVehicle,
+                                                                               DriveDistance,
+                                                                               StandStill,
+                                                                               OSCStartEndCondition,
+                                                                               TriggerAcceleration,
+                                                                               RelativeVelocityToOtherActor,
+                                                                               TimeOfDayComparison,
+                                                                               TriggerVelocity,
+                                                                               WaitForTrafficLightState)
 from srunner.scenariomanager.timer import TimeOut, SimulationTimeCondition
 from srunner.tools.py_trees_port import oneshot_behavior
 
 
 class OpenScenarioParser(object):
+
     """
     Pure static class providing conversions from OpenSCENARIO elements to ScenarioRunner elements
     """
-
     operators = {
         "greaterThan": operator.gt,
         "lessThan": operator.lt,
-        "equalTo": operator.eq,
+        "equalTo": operator.eq
     }
 
     actor_types = {
         "pedestrian": "walker",
         "vehicle": "vehicle",
-        "miscellaneous": "miscellaneous",
+        "miscellaneous": "miscellaneous"
     }
 
     tl_states = {
@@ -114,11 +105,7 @@ class OpenScenarioParser(object):
         # Given by id
         if name.startswith("id="):
             tl_id = name[3:]
-            for carla_tl in (
-                CarlaDataProvider.get_world()
-                .get_actors()
-                .filter("traffic.traffic_light")
-            ):
+            for carla_tl in CarlaDataProvider.get_world().get_actors().filter('traffic.traffic_light'):
                 if carla_tl.id == tl_id:
                     traffic_light = carla_tl
                     break
@@ -126,17 +113,11 @@ class OpenScenarioParser(object):
         elif name.startswith("pos="):
             tl_pos = name[4:]
             pos = tl_pos.split(",")
-            for carla_tl in (
-                CarlaDataProvider.get_world()
-                .get_actors()
-                .filter("traffic.traffic_light")
-            ):
+            for carla_tl in CarlaDataProvider.get_world().get_actors().filter('traffic.traffic_light'):
                 carla_tl_location = carla_tl.get_transform().location
-                distance = carla_tl_location.distance(
-                    carla.Location(
-                        float(
-                            pos[0]), float(
-                            pos[1]), carla_tl_location.z))
+                distance = carla_tl_location.distance(carla.Location(float(pos[0]),
+                                                                     float(pos[1]),
+                                                                     carla_tl_location.z))
                 if distance < 2.0:
                     traffic_light = carla_tl
                     break
@@ -168,15 +149,12 @@ class OpenScenarioParser(object):
         """
         Parse the xml_tree, and replace all parameter references
         with the actual values.
-
         Note: Parameter names must not start with "$", however when referencing a parameter the
               reference has to start with "$".
               https://releases.asam.net/OpenSCENARIO/1.0.0/ASAM_OpenSCENARIO_BS-1-2_User-Guide_V1-0-0.html#_re_use_mechanisms
-
         Args:
             xml_tree: Containing all nodes that should be updated
             additional_parameter_dict (dictionary): Additional parameters as dict (key, value). Optional.
-
         returns:
             updated xml_tree, dictonary containing all parameters and their values
         """
@@ -184,7 +162,7 @@ class OpenScenarioParser(object):
         parameter_dict = dict()
         if additional_parameter_dict is not None:
             parameter_dict = additional_parameter_dict
-        parameters = xml_tree.find("ParameterDeclarations")
+        parameters = xml_tree.find('ParameterDeclarations')
 
         if parameters is None and not parameter_dict:
             return xml_tree, parameter_dict
@@ -193,17 +171,15 @@ class OpenScenarioParser(object):
             parameters = []
 
         for parameter in parameters:
-            name = parameter.attrib.get("name")
-            value = parameter.attrib.get("value")
+            name = parameter.attrib.get('name')
+            value = parameter.attrib.get('value')
             parameter_dict[name] = value
 
         for node in xml_tree.iter():
             for key in node.attrib:
                 for param in sorted(parameter_dict, key=len, reverse=True):
                     if "$" + param in node.attrib[key]:
-                        node.attrib[key] = node.attrib[key].replace(
-                            "$" + param, parameter_dict[param]
-                        )
+                        node.attrib[key] = node.attrib[key].replace("$" + param, parameter_dict[param])
 
         return xml_tree, parameter_dict
 
@@ -211,7 +187,6 @@ class OpenScenarioParser(object):
     def set_global_parameters(parameter_dict):
         """
         Set global_osc_parameter dictionary
-
         Args:
             parameter_dict (Dictionary): Input for global_osc_parameter
         """
@@ -221,22 +196,17 @@ class OpenScenarioParser(object):
     def get_catalog_entry(catalogs, catalog_reference):
         """
         Get catalog entry referenced by catalog_reference included correct parameter settings
-
         Args:
             catalogs (Dictionary of dictionaries): List of all catalogs and their entries
             catalog_reference (XML ElementTree): Reference containing the exact catalog to be used
-
         returns:
             Catalog entry (XML ElementTree)
         """
 
-        entry = catalogs[catalog_reference.attrib.get("catalogName")][
-            catalog_reference.attrib.get("entryName")
-        ]
+        entry = catalogs[catalog_reference.attrib.get("catalogName")][catalog_reference.attrib.get("entryName")]
         entry_copy = copy.deepcopy(entry)
         catalog_copy = copy.deepcopy(catalog_reference)
-        entry = OpenScenarioParser.assign_catalog_parameters(
-            entry_copy, catalog_copy)
+        entry = OpenScenarioParser.assign_catalog_parameters(entry_copy, catalog_copy)
 
         return entry
 
@@ -245,31 +215,25 @@ class OpenScenarioParser(object):
         """
         Parse catalog_reference, and replace all parameter references
         in entry_instance by the values provided in catalog_reference.
-
         Not to be used from outside this class.
-
         Args:
             entry_instance (XML ElementTree): Entry to be updated
             catalog_reference (XML ElementTree): Reference containing the exact parameter values
-
         returns:
             updated entry_instance with updated parameter values
         """
 
         parameter_dict = dict()
         for elem in entry_instance.iter():
-            if elem.find("ParameterDeclarations") is not None:
-                parameters = elem.find("ParameterDeclarations")
+            if elem.find('ParameterDeclarations') is not None:
+                parameters = elem.find('ParameterDeclarations')
                 for parameter in parameters:
-                    name = parameter.attrib.get("name")
-                    value = parameter.attrib.get("value")
+                    name = parameter.attrib.get('name')
+                    value = parameter.attrib.get('value')
                     parameter_dict[name] = value
 
-        for parameter_assignments in catalog_reference.iter(
-                "ParameterAssignments"):
-            for parameter_assignment in parameter_assignments.iter(
-                "ParameterAssignment"
-            ):
+        for parameter_assignments in catalog_reference.iter("ParameterAssignments"):
+            for parameter_assignment in parameter_assignments.iter("ParameterAssignment"):
                 parameter = parameter_assignment.attrib.get("parameterRef")
                 value = parameter_assignment.attrib.get("value")
                 parameter_dict[parameter] = value
@@ -278,13 +242,9 @@ class OpenScenarioParser(object):
             for key in node.attrib:
                 for param in sorted(parameter_dict, key=len, reverse=True):
                     if "$" + param in node.attrib[key]:
-                        node.attrib[key] = node.attrib[key].replace(
-                            "$" + param, parameter_dict[param]
-                        )
+                        node.attrib[key] = node.attrib[key].replace("$" + param, parameter_dict[param])
 
-        OpenScenarioParser.set_parameters(
-            entry_instance, OpenScenarioParser.global_osc_parameters
-        )
+        OpenScenarioParser.set_parameters(entry_instance, OpenScenarioParser.global_osc_parameters)
 
         return entry_instance
 
@@ -292,12 +252,10 @@ class OpenScenarioParser(object):
     def get_friction_from_env_action(xml_tree, catalogs):
         """
         Extract the CARLA road friction coefficient from an OSC EnvironmentAction
-
         Args:
             xml_tree: Containing the EnvironmentAction,
                 or the reference to the catalog it is defined in.
             catalogs: XML Catalogs that could contain the EnvironmentAction
-
         returns:
            friction (float)
         """
@@ -310,15 +268,13 @@ class OpenScenarioParser(object):
             environment = set_environment.find("Environment")
         elif set_environment.find("CatalogReference") is not None:
             catalog_reference = set_environment.find("CatalogReference")
-            environment = OpenScenarioParser.get_catalog_entry(
-                catalogs, catalog_reference
-            )
+            environment = OpenScenarioParser.get_catalog_entry(catalogs, catalog_reference)
 
         friction = 1.0
 
         road_condition = environment.iter("RoadCondition")
         for condition in road_condition:
-            friction = condition.attrib.get("frictionScaleFactor")
+            friction = condition.attrib.get('frictionScaleFactor')
 
         return friction
 
@@ -326,12 +282,10 @@ class OpenScenarioParser(object):
     def get_weather_from_env_action(xml_tree, catalogs):
         """
         Extract the CARLA weather parameters from an OSC EnvironmentAction
-
         Args:
             xml_tree: Containing the EnvironmentAction,
                 or the reference to the catalog it is defined in.
             catalogs: XML Catalogs that could contain the EnvironmentAction
-
         returns:
            Weather (srunner.scenariomanager.weather_sim.Weather)
         """
@@ -344,25 +298,17 @@ class OpenScenarioParser(object):
             environment = set_environment.find("Environment")
         elif set_environment.find("CatalogReference") is not None:
             catalog_reference = set_environment.find("CatalogReference")
-            environment = OpenScenarioParser.get_catalog_entry(
-                catalogs, catalog_reference
-            )
+            environment = OpenScenarioParser.get_catalog_entry(catalogs, catalog_reference)
 
         weather = environment.find("Weather")
         sun = weather.find("Sun")
 
         carla_weather = carla.WeatherParameters()
-        carla_weather.sun_azimuth_angle = math.degrees(
-            float(sun.attrib.get("azimuth", 0))
-        )
-        carla_weather.sun_altitude_angle = math.degrees(
-            float(sun.attrib.get("elevation", 0))
-        )
-        carla_weather.cloudiness = 100 - \
-            float(sun.attrib.get("intensity", 0)) * 100
+        carla_weather.sun_azimuth_angle = math.degrees(float(sun.attrib.get('azimuth', 0)))
+        carla_weather.sun_altitude_angle = math.degrees(float(sun.attrib.get('elevation', 0)))
+        carla_weather.cloudiness = 100 - float(sun.attrib.get('intensity', 0)) * 100
         fog = weather.find("Fog")
-        carla_weather.fog_distance = float(
-            fog.attrib.get("visualRange", "inf"))
+        carla_weather.fog_distance = float(fog.attrib.get('visualRange', 'inf'))
         if carla_weather.fog_distance < 1000:
             carla_weather.fog_density = 100
         carla_weather.precipitation = 0
@@ -370,13 +316,11 @@ class OpenScenarioParser(object):
         carla_weather.wetness = 0
         carla_weather.wind_intensity = 0
         precepitation = weather.find("Precipitation")
-        if precepitation.attrib.get("precipitationType") == "rain":
-            carla_weather.precipitation = (
-                float(precepitation.attrib.get("intensity")) * 100
-            )
+        if precepitation.attrib.get('precipitationType') == "rain":
+            carla_weather.precipitation = float(precepitation.attrib.get('intensity')) * 100
             carla_weather.precipitation_deposits = 100  # if it rains, make the road wet
             carla_weather.wetness = carla_weather.precipitation
-        elif precepitation.attrib.get("type") == "snow":
+        elif precepitation.attrib.get('type') == "snow":
             raise AttributeError("CARLA does not support snow precipitation")
 
         time_of_day = environment.find("TimeOfDay")
@@ -390,12 +334,10 @@ class OpenScenarioParser(object):
     def get_controller(xml_tree, catalogs):
         """
         Extract the object controller from the OSC XML or a catalog
-
         Args:
             xml_tree: Containing the controller information,
                 or the reference to the catalog it is defined in.
             catalogs: XML Catalogs that could contain the EnvironmentAction
-
         returns:
            module: Python module containing the controller implementation
            args: Dictonary with (key, value) parameters for the controller
@@ -404,28 +346,24 @@ class OpenScenarioParser(object):
         assign_action = next(xml_tree.iter("AssignControllerAction"))
 
         properties = None
-        if assign_action.find("Controller") is not None:
-            properties = assign_action.find("Controller").find("Properties")
+        if assign_action.find('Controller') is not None:
+            properties = assign_action.find('Controller').find('Properties')
         elif assign_action.find("CatalogReference") is not None:
             catalog_reference = assign_action.find("CatalogReference")
-            properties = OpenScenarioParser.get_catalog_entry(
-                catalogs, catalog_reference
-            ).find("Properties")
+            properties = OpenScenarioParser.get_catalog_entry(catalogs, catalog_reference).find('Properties')
 
         module = None
         args = {}
         for prop in properties:
-            if prop.attrib.get("name") == "module":
-                module = prop.attrib.get("value")
+            if prop.attrib.get('name') == "module":
+                module = prop.attrib.get('value')
             else:
-                args[prop.attrib.get("name")] = prop.attrib.get("value")
+                args[prop.attrib.get('name')] = prop.attrib.get('value')
 
-        override_action = xml_tree.find("OverrideControllerValueAction")
+        override_action = xml_tree.find('OverrideControllerValueAction')
         for child in override_action:
-            if strtobool(child.attrib.get("active")):
-                raise NotImplementedError(
-                    "Controller override actions are not yet supported"
-                )
+            if strtobool(child.attrib.get('active')):
+                raise NotImplementedError("Controller override actions are not yet supported")
 
         return module, args
 
@@ -433,32 +371,28 @@ class OpenScenarioParser(object):
     def get_route(xml_tree, catalogs):
         """
         Extract the route from the OSC XML or a catalog
-
         Args:
             xml_tree: Containing the route information,
                 or the reference to the catalog it is defined in.
             catalogs: XML Catalogs that could contain the Route
-
         returns:
            waypoints: List of route waypoints
         """
         route = None
 
-        if xml_tree.find("Route") is not None:
-            route = xml_tree.find("Route")
-        elif xml_tree.find("CatalogReference") is not None:
+        if xml_tree.find('Route') is not None:
+            route = xml_tree.find('Route')
+        elif xml_tree.find('CatalogReference') is not None:
             catalog_reference = xml_tree.find("CatalogReference")
-            route = OpenScenarioParser.get_catalog_entry(
-                catalogs, catalog_reference)
+            route = OpenScenarioParser.get_catalog_entry(catalogs, catalog_reference)
         else:
             raise AttributeError("Unknown private FollowRoute action")
 
         waypoints = []
         if route is not None:
-            for waypoint in route.iter("Waypoint"):
-                position = waypoint.find("Position")
-                transform = OpenScenarioParser.convert_position_to_transform(
-                    position)
+            for waypoint in route.iter('Waypoint'):
+                position = waypoint.find('Position')
+                transform = OpenScenarioParser.convert_position_to_transform(position)
                 waypoints.append(transform)
 
         return waypoints
@@ -467,44 +401,38 @@ class OpenScenarioParser(object):
     def convert_position_to_transform(position, actor_list=None):
         """
         Convert an OpenScenario position into a CARLA transform
-
         Not supported: Road, RelativeRoad, Lane, RelativeLane as the PythonAPI currently
                        does not provide sufficient access to OpenDrive information
                        Also not supported is Route. This can be added by checking additional
                        route information
         """
 
-        if position.find("WorldPosition") is not None:
-            world_pos = position.find("WorldPosition")
-            x = float(world_pos.attrib.get("x", 0))
-            y = float(world_pos.attrib.get("y", 0))
-            z = float(world_pos.attrib.get("z", 0))
-            yaw = math.degrees(float(world_pos.attrib.get("h", 0)))
-            pitch = math.degrees(float(world_pos.attrib.get("p", 0)))
-            roll = math.degrees(float(world_pos.attrib.get("r", 0)))
+        if position.find('WorldPosition') is not None:
+            world_pos = position.find('WorldPosition')
+            x = float(world_pos.attrib.get('x', 0))
+            y = float(world_pos.attrib.get('y', 0))
+            z = float(world_pos.attrib.get('z', 0))
+            yaw = math.degrees(float(world_pos.attrib.get('h', 0)))
+            pitch = math.degrees(float(world_pos.attrib.get('p', 0)))
+            roll = math.degrees(float(world_pos.attrib.get('r', 0)))
             if not OpenScenarioParser.use_carla_coordinate_system:
                 y = y * (-1.0)
                 yaw = yaw * (-1.0)
-            return carla.Transform(
-                carla.Location(x=x, y=y, z=z),
-                carla.Rotation(yaw=yaw, pitch=pitch, roll=roll),
-            )
+            return carla.Transform(carla.Location(x=x, y=y, z=z), carla.Rotation(yaw=yaw, pitch=pitch, roll=roll))
 
-        elif (
-            (position.find("RelativeWorldPosition") is not None)
-            or (position.find("RelativeObjectPosition") is not None)
-            or (position.find("RelativeLanePosition") is not None)
-        ):
+        elif ((position.find('RelativeWorldPosition') is not None) or
+              (position.find('RelativeObjectPosition') is not None) or
+              (position.find('RelativeLanePosition') is not None)):
 
-            if position.find("RelativeWorldPosition") is not None:
-                rel_pos = position.find("RelativeWorldPosition")
-            if position.find("RelativeObjectPosition") is not None:
-                rel_pos = position.find("RelativeObjectPosition")
-            if position.find("RelativeLanePosition") is not None:
-                rel_pos = position.find("RelativeLanePosition")
+            if position.find('RelativeWorldPosition') is not None:
+                rel_pos = position.find('RelativeWorldPosition')
+            if position.find('RelativeObjectPosition') is not None:
+                rel_pos = position.find('RelativeObjectPosition')
+            if position.find('RelativeLanePosition') is not None:
+                rel_pos = position.find('RelativeLanePosition')
 
             # get relative object and relative position
-            obj = rel_pos.attrib.get("entityRef")
+            obj = rel_pos.attrib.get('entityRef')
             obj_actor = None
             actor_transform = None
 
@@ -515,29 +443,25 @@ class OpenScenarioParser(object):
                         actor_transform = actor.transform
             else:
                 for actor in CarlaDataProvider.get_world().get_actors():
-                    if (
-                        "role_name" in actor.attributes
-                        and actor.attributes["role_name"] == obj
-                    ):
+                    if 'role_name' in actor.attributes and actor.attributes['role_name'] == obj:
                         obj_actor = actor
                         actor_transform = obj_actor.get_transform()
                         break
 
             if obj_actor is None:
-                raise AttributeError(
-                    "Object '{}' provided as position reference is not known".format(obj))
+                raise AttributeError("Object '{}' provided as position reference is not known".format(obj))
 
             # calculate orientation h, p, r
             is_absolute = False
             dyaw = 0
             dpitch = 0
             droll = 0
-            if rel_pos.find("Orientation") is not None:
-                orientation = rel_pos.find("Orientation")
-                is_absolute = orientation.attrib.get("type") == "absolute"
-                dyaw = math.degrees(float(orientation.attrib.get("h", 0)))
-                dpitch = math.degrees(float(orientation.attrib.get("p", 0)))
-                droll = math.degrees(float(orientation.attrib.get("r", 0)))
+            if rel_pos.find('Orientation') is not None:
+                orientation = rel_pos.find('Orientation')
+                is_absolute = (orientation.attrib.get('type') == "absolute")
+                dyaw = math.degrees(float(orientation.attrib.get('h', 0)))
+                dpitch = math.degrees(float(orientation.attrib.get('p', 0)))
+                droll = math.degrees(float(orientation.attrib.get('r', 0)))
 
             if not OpenScenarioParser.use_carla_coordinate_system:
                 dyaw = dyaw * (-1.0)
@@ -557,12 +481,11 @@ class OpenScenarioParser(object):
 
             # calculate location x, y, z
             # dx, dy, dz
-            if (position.find("RelativeWorldPosition") is not None) or (
-                position.find("RelativeObjectPosition") is not None
-            ):
-                dx = float(rel_pos.attrib.get("dx", 0))
-                dy = float(rel_pos.attrib.get("dy", 0))
-                dz = float(rel_pos.attrib.get("dz", 0))
+            if ((position.find('RelativeWorldPosition') is not None) or
+                    (position.find('RelativeObjectPosition') is not None)):
+                dx = float(rel_pos.attrib.get('dx', 0))
+                dy = float(rel_pos.attrib.get('dy', 0))
+                dz = float(rel_pos.attrib.get('dz', 0))
 
                 if not OpenScenarioParser.use_carla_coordinate_system:
                     dy = dy * (-1.0)
@@ -572,14 +495,13 @@ class OpenScenarioParser(object):
                 z = actor_transform.location.z + dz
 
             # dLane, ds, offset
-            elif position.find("RelativeLanePosition") is not None:
-                dlane = float(rel_pos.attrib.get("dLane"))
-                ds = float(rel_pos.attrib.get("ds"))
-                offset = float(rel_pos.attrib.get("offset", 0.0))
+            elif position.find('RelativeLanePosition') is not None:
+                dlane = float(rel_pos.attrib.get('dLane'))
+                ds = float(rel_pos.attrib.get('ds'))
+                offset = float(rel_pos.attrib.get('offset', 0.0))
 
                 carla_map = CarlaDataProvider.get_map()
-                relative_waypoint = carla_map.get_waypoint(
-                    actor_transform.location)
+                relative_waypoint = carla_map.get_waypoint(actor_transform.location)
 
                 if dlane == 0:
                     wp = relative_waypoint
@@ -588,9 +510,7 @@ class OpenScenarioParser(object):
                 elif dlane == 1:
                     wp = relative_waypoint.get_right_lane()
                 if wp is None:
-                    raise AttributeError(
-                        "Object '{}' position with dLane={} is not valid".format(
-                            obj, dlane))
+                    raise AttributeError("Object '{}' position with dLane={} is not valid".format(obj, dlane))
 
                 if ds < 0:
                     ds = (-1.0) * ds
@@ -611,36 +531,30 @@ class OpenScenarioParser(object):
                 y = wp.transform.location.y + y_offset
                 z = wp.transform.location.z
 
-            return carla.Transform(
-                carla.Location(x=x, y=y, z=z),
-                carla.Rotation(yaw=yaw, pitch=pitch, roll=roll),
-            )
+            return carla.Transform(carla.Location(x=x, y=y, z=z), carla.Rotation(yaw=yaw, pitch=pitch, roll=roll))
 
         # Not implemented
-        elif position.find("RoadPosition") is not None:
+        elif position.find('RoadPosition') is not None:
             raise NotImplementedError("Road positions are not yet supported")
-        elif position.find("RelativeRoadPosition") is not None:
-            raise NotImplementedError(
-                "RelativeRoad positions are not yet supported")
-        elif position.find("LanePosition") is not None:
-            lane_pos = position.find("LanePosition")
-            road_id = int(lane_pos.attrib.get("roadId", 0))
-            lane_id = int(lane_pos.attrib.get("laneId", 0))
-            offset = float(lane_pos.attrib.get("offset", 0))
-            s = float(lane_pos.attrib.get("s", 0))
+        elif position.find('RelativeRoadPosition') is not None:
+            raise NotImplementedError("RelativeRoad positions are not yet supported")
+        elif position.find('LanePosition') is not None:
+            lane_pos = position.find('LanePosition')
+            road_id = int(lane_pos.attrib.get('roadId', 0))
+            lane_id = int(lane_pos.attrib.get('laneId', 0))
+            offset = float(lane_pos.attrib.get('offset', 0))
+            s = float(lane_pos.attrib.get('s', 0))
             is_absolute = True
-            waypoint = CarlaDataProvider.get_map().get_waypoint_xodr(
-                road_id, lane_id, s
-            )
+            waypoint = CarlaDataProvider.get_map().get_waypoint_xodr(road_id, lane_id, s)
             if waypoint is None:
                 raise AttributeError("Lane position cannot be found")
 
             transform = waypoint.transform
-            if lane_pos.find("Orientation") is not None:
-                orientation = lane_pos.find("Orientation")
-                dyaw = math.degrees(float(orientation.attrib.get("h", 0)))
-                dpitch = math.degrees(float(orientation.attrib.get("p", 0)))
-                droll = math.degrees(float(orientation.attrib.get("r", 0)))
+            if lane_pos.find('Orientation') is not None:
+                orientation = lane_pos.find('Orientation')
+                dyaw = math.degrees(float(orientation.attrib.get('h', 0)))
+                dpitch = math.degrees(float(orientation.attrib.get('p', 0)))
+                droll = math.degrees(float(orientation.attrib.get('r', 0)))
 
                 if not OpenScenarioParser.use_carla_coordinate_system:
                     dyaw = dyaw * (-1.0)
@@ -651,18 +565,12 @@ class OpenScenarioParser(object):
 
             if offset != 0:
                 forward_vector = transform.rotation.get_forward_vector()
-                orthogonal_vector = carla.Vector3D(
-                    x=-forward_vector.y, y=forward_vector.x, z=forward_vector.z
-                )
-                transform.location.x = (
-                    transform.location.x + offset * orthogonal_vector.x
-                )
-                transform.location.y = (
-                    transform.location.y + offset * orthogonal_vector.y
-                )
+                orthogonal_vector = carla.Vector3D(x=-forward_vector.y, y=forward_vector.x, z=forward_vector.z)
+                transform.location.x = transform.location.x + offset * orthogonal_vector.x
+                transform.location.y = transform.location.y + offset * orthogonal_vector.y
 
             return transform
-        elif position.find("RoutePosition") is not None:
+        elif position.find('RoutePosition') is not None:
             raise NotImplementedError("Route positions are not yet supported")
         else:
             raise AttributeError("Unknown position")
@@ -671,469 +579,288 @@ class OpenScenarioParser(object):
     def convert_condition_to_atomic(condition, actor_list):
         """
         Convert an OpenSCENARIO condition into a Behavior/Criterion atomic
-
         If there is a delay defined in the condition, then the condition is checked after the delay time
         passed by, e.g. <Condition name="" delay="5">.
-
         Note: Not all conditions are currently supported.
         """
 
         atomic = None
         delay_atomic = None
-        condition_name = condition.attrib.get("name")
+        condition_name = condition.attrib.get('name')
 
-        if (
-            condition.attrib.get("delay") is not None
-            and str(condition.attrib.get("delay")) != "0"
-        ):
-            delay = float(condition.attrib.get("delay"))
+        if condition.attrib.get('delay') is not None and str(condition.attrib.get('delay')) != '0':
+            delay = float(condition.attrib.get('delay'))
             delay_atomic = TimeOut(delay)
 
-        if condition.find("ByEntityCondition") is not None:
+        if condition.find('ByEntityCondition') is not None:
 
-            trigger_actor = (
-                None  # A-priori validation ensures that this will be not None
-            )
+            trigger_actor = None    # A-priori validation ensures that this will be not None
             triggered_actor = None
 
-            for triggering_entities in condition.find(
-                    "ByEntityCondition").iter("TriggeringEntities"):
-                for entity in triggering_entities.iter("EntityRef"):
+            for triggering_entities in condition.find('ByEntityCondition').iter('TriggeringEntities'):
+                for entity in triggering_entities.iter('EntityRef'):
                     for actor in actor_list:
-                        if (
-                            entity.attrib.get("entityRef", None)
-                            == actor.attributes["role_name"]
-                        ):
+                        if entity.attrib.get('entityRef', None) == actor.attributes['role_name']:
                             trigger_actor = actor
                             break
 
-            for entity_condition in condition.find("ByEntityCondition").iter(
-                "EntityCondition"
-            ):
-                if entity_condition.find("EndOfRoadCondition") is not None:
-                    end_road_condition = entity_condition.find(
-                        "EndOfRoadCondition")
-                    condition_duration = float(
-                        end_road_condition.attrib.get("duration")
-                    )
+            for entity_condition in condition.find('ByEntityCondition').iter('EntityCondition'):
+                if entity_condition.find('EndOfRoadCondition') is not None:
+                    end_road_condition = entity_condition.find('EndOfRoadCondition')
+                    condition_duration = float(end_road_condition.attrib.get('duration'))
                     atomic_cls = py_trees.meta.inverter(EndofRoadTest)
                     atomic = atomic_cls(
-                        trigger_actor,
-                        condition_duration,
-                        terminate_on_failure=True,
-                        name=condition_name,
-                    )
-                elif entity_condition.find("CollisionCondition") is not None:
+                        trigger_actor, condition_duration, terminate_on_failure=True, name=condition_name)
+                elif entity_condition.find('CollisionCondition') is not None:
 
-                    collision_condition = entity_condition.find(
-                        "CollisionCondition")
+                    collision_condition = entity_condition.find('CollisionCondition')
 
-                    if collision_condition.find("EntityRef") is not None:
-                        collision_entity = collision_condition.find(
-                            "EntityRef")
+                    if collision_condition.find('EntityRef') is not None:
+                        collision_entity = collision_condition.find('EntityRef')
 
                         for actor in actor_list:
-                            if (
-                                collision_entity.attrib.get("entityRef", None)
-                                == actor.attributes["role_name"]
-                            ):
+                            if collision_entity.attrib.get('entityRef', None) == actor.attributes['role_name']:
                                 triggered_actor = actor
                                 break
 
                         if triggered_actor is None:
-                            raise AttributeError(
-                                "Cannot find actor '{}' for condition".format(
-                                    collision_condition.attrib.get(
-                                        "entityRef", None)))
+                            raise AttributeError("Cannot find actor '{}' for condition".format(
+                                collision_condition.attrib.get('entityRef', None)))
 
                         atomic_cls = py_trees.meta.inverter(CollisionTest)
-                        atomic = atomic_cls(
-                            trigger_actor,
-                            other_actor=triggered_actor,
-                            terminate_on_failure=True,
-                            name=condition_name,
-                        )
+                        atomic = atomic_cls(trigger_actor, other_actor=triggered_actor,
+                                            terminate_on_failure=True, name=condition_name)
 
-                    elif collision_condition.find("ByType") is not None:
-                        collision_type = collision_condition.find(
-                            "ByType").attrib.get("type", None)
+                    elif collision_condition.find('ByType') is not None:
+                        collision_type = collision_condition.find('ByType').attrib.get('type', None)
 
                         triggered_type = OpenScenarioParser.actor_types[collision_type]
 
                         atomic_cls = py_trees.meta.inverter(CollisionTest)
-                        atomic = atomic_cls(
-                            trigger_actor,
-                            other_actor_type=triggered_type,
-                            terminate_on_failure=True,
-                            name=condition_name,
-                        )
+                        atomic = atomic_cls(trigger_actor, other_actor_type=triggered_type,
+                                            terminate_on_failure=True, name=condition_name)
 
                     else:
                         atomic_cls = py_trees.meta.inverter(CollisionTest)
-                        atomic = atomic_cls(
-                            trigger_actor,
-                            terminate_on_failure=True,
-                            name=condition_name,
-                        )
+                        atomic = atomic_cls(trigger_actor, terminate_on_failure=True, name=condition_name)
 
-                elif entity_condition.find("OffroadCondition") is not None:
-                    off_condition = entity_condition.find("OffroadCondition")
-                    condition_duration = float(
-                        off_condition.attrib.get("duration"))
+                elif entity_condition.find('OffroadCondition') is not None:
+                    off_condition = entity_condition.find('OffroadCondition')
+                    condition_duration = float(off_condition.attrib.get('duration'))
                     atomic_cls = py_trees.meta.inverter(OffRoadTest)
                     atomic = atomic_cls(
-                        trigger_actor,
-                        condition_duration,
-                        terminate_on_failure=True,
-                        name=condition_name,
-                    )
-                elif entity_condition.find("TimeHeadwayCondition") is not None:
-                    headtime_condition = entity_condition.find(
-                        "TimeHeadwayCondition")
+                        trigger_actor, condition_duration, terminate_on_failure=True, name=condition_name)
+                elif entity_condition.find('TimeHeadwayCondition') is not None:
+                    headtime_condition = entity_condition.find('TimeHeadwayCondition')
 
-                    condition_value = float(
-                        headtime_condition.attrib.get("value"))
+                    condition_value = float(headtime_condition.attrib.get('value'))
 
-                    condition_rule = headtime_condition.attrib.get("rule")
+                    condition_rule = headtime_condition.attrib.get('rule')
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
-                    condition_freespace = strtobool(
-                        headtime_condition.attrib.get("freespace", False)
-                    )
+                    condition_freespace = strtobool(headtime_condition.attrib.get('freespace', False))
                     if condition_freespace:
                         raise NotImplementedError(
-                            "TimeHeadwayCondition: freespace attribute is currently not implemented"
-                        )
-                    condition_along_route = strtobool(
-                        headtime_condition.attrib.get("alongRoute", False)
-                    )
+                            "TimeHeadwayCondition: freespace attribute is currently not implemented")
+                    condition_along_route = strtobool(headtime_condition.attrib.get('alongRoute', False))
 
                     for actor in actor_list:
-                        if (
-                            headtime_condition.attrib.get("entityRef", None)
-                            == actor.attributes["role_name"]
-                        ):
+                        if headtime_condition.attrib.get('entityRef', None) == actor.attributes['role_name']:
                             triggered_actor = actor
                             break
                     if triggered_actor is None:
-                        raise AttributeError(
-                            "Cannot find actor '{}' for condition".format(
-                                headtime_condition.attrib.get(
-                                    "entityRef", None)))
+                        raise AttributeError("Cannot find actor '{}' for condition".format(
+                            headtime_condition.attrib.get('entityRef', None)))
 
                     atomic = InTimeToArrivalToVehicle(
-                        trigger_actor,
-                        triggered_actor,
-                        condition_value,
-                        condition_along_route,
-                        condition_operator,
-                        condition_name,
+                        trigger_actor, triggered_actor, condition_value,
+                        condition_along_route, condition_operator, condition_name
                     )
 
-                elif entity_condition.find("TimeToCollisionCondition") is not None:
-                    ttc_condition = entity_condition.find(
-                        "TimeToCollisionCondition")
+                elif entity_condition.find('TimeToCollisionCondition') is not None:
+                    ttc_condition = entity_condition.find('TimeToCollisionCondition')
 
-                    condition_rule = ttc_condition.attrib.get("rule")
+                    condition_rule = ttc_condition.attrib.get('rule')
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
-                    condition_value = float(ttc_condition.attrib.get("value"))
-                    condition_target = ttc_condition.find(
-                        "TimeToCollisionConditionTarget"
-                    )
-                    entity_ref_ = condition_target.find("EntityRef")
+                    condition_value = float(ttc_condition.attrib.get('value'))
+                    condition_target = ttc_condition.find('TimeToCollisionConditionTarget')
+                    entity_ref_ = condition_target.find('EntityRef')
 
-                    condition_freespace = strtobool(
-                        ttc_condition.attrib.get("freespace")
-                    )
-                    condition_along_route = strtobool(
-                        ttc_condition.attrib.get("alongRoute", False)
-                    )
+                    condition_freespace = strtobool(ttc_condition.attrib.get('freespace'))
+                    condition_along_route = strtobool(ttc_condition.attrib.get('alongRoute', False))
 
-                    if condition_target.find("Position") is not None:
-                        position = condition_target.find("Position")
+                    if condition_target.find('Position') is not None:
+                        position = condition_target.find('Position')
                         atomic = InTimeToArrivalToOSCPosition(
-                            trigger_actor,
-                            position,
-                            condition_value,
-                            condition_along_route,
-                            condition_operator,
-                        )
+                            trigger_actor, position, condition_value, condition_along_route, condition_operator)
                     else:
                         for actor in actor_list:
-                            if (
-                                entity_ref_.attrib.get("entityRef", None)
-                                == actor.attributes["role_name"]
-                            ):
+                            if entity_ref_.attrib.get('entityRef', None) == actor.attributes['role_name']:
                                 triggered_actor = actor
                                 break
                         if triggered_actor is None:
-                            raise AttributeError(
-                                "Cannot find actor '{}' for condition".format(
-                                    entity_ref_.attrib.get("entityRef", None)
-                                )
-                            )
+                            raise AttributeError("Cannot find actor '{}' for condition".format(
+                                entity_ref_.attrib.get('entityRef', None)))
 
                         atomic = InTimeToCollisionToVehicle(
-                            trigger_actor,
-                            triggered_actor,
-                            condition_value,
-                            condition_freespace,
-                            condition_along_route,
-                            condition_operator,
-                            condition_name,
-                        )
-                elif entity_condition.find("AccelerationCondition") is not None:
-                    accel_condition = entity_condition.find(
-                        "AccelerationCondition")
-                    condition_value = float(
-                        accel_condition.attrib.get("value"))
-                    condition_rule = accel_condition.attrib.get("rule")
+                            trigger_actor, triggered_actor, condition_value, condition_freespace,
+                            condition_along_route, condition_operator, condition_name)
+                elif entity_condition.find('AccelerationCondition') is not None:
+                    accel_condition = entity_condition.find('AccelerationCondition')
+                    condition_value = float(accel_condition.attrib.get('value'))
+                    condition_rule = accel_condition.attrib.get('rule')
                     condition_operator = OpenScenarioParser.operators[condition_rule]
                     atomic = TriggerAcceleration(
-                        trigger_actor,
-                        condition_value,
-                        condition_operator,
-                        condition_name,
-                    )
-                elif entity_condition.find("StandStillCondition") is not None:
-                    ss_condition = entity_condition.find("StandStillCondition")
-                    duration = float(ss_condition.attrib.get("duration"))
-                    atomic = StandStill(
-                        trigger_actor, condition_name, duration)
-                elif entity_condition.find("SpeedCondition") is not None:
-                    spd_condition = entity_condition.find("SpeedCondition")
-                    condition_value = float(spd_condition.attrib.get("value"))
-                    condition_rule = spd_condition.attrib.get("rule")
+                        trigger_actor, condition_value, condition_operator, condition_name)
+                elif entity_condition.find('StandStillCondition') is not None:
+                    ss_condition = entity_condition.find('StandStillCondition')
+                    duration = float(ss_condition.attrib.get('duration'))
+                    atomic = StandStill(trigger_actor, condition_name, duration)
+                elif entity_condition.find('SpeedCondition') is not None:
+                    spd_condition = entity_condition.find('SpeedCondition')
+                    condition_value = float(spd_condition.attrib.get('value'))
+                    condition_rule = spd_condition.attrib.get('rule')
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
                     atomic = TriggerVelocity(
-                        trigger_actor,
-                        condition_value,
-                        condition_operator,
-                        condition_name,
-                    )
-                elif entity_condition.find("RelativeSpeedCondition") is not None:
-                    relspd_condition = entity_condition.find(
-                        "RelativeSpeedCondition")
-                    condition_value = float(
-                        relspd_condition.attrib.get("value"))
-                    condition_rule = relspd_condition.attrib.get("rule")
+                        trigger_actor, condition_value, condition_operator, condition_name)
+                elif entity_condition.find('RelativeSpeedCondition') is not None:
+                    relspd_condition = entity_condition.find('RelativeSpeedCondition')
+                    condition_value = float(relspd_condition.attrib.get('value'))
+                    condition_rule = relspd_condition.attrib.get('rule')
                     condition_operator = OpenScenarioParser.operators[condition_rule]
 
                     for actor in actor_list:
-                        if (
-                            relspd_condition.attrib.get("entityRef", None)
-                            == actor.attributes["role_name"]
-                        ):
+                        if relspd_condition.attrib.get('entityRef', None) == actor.attributes['role_name']:
                             triggered_actor = actor
                             break
 
                     if triggered_actor is None:
-                        raise AttributeError(
-                            "Cannot find actor '{}' for condition".format(
-                                relspd_condition.attrib.get("entityRef", None)
-                            )
-                        )
+                        raise AttributeError("Cannot find actor '{}' for condition".format(
+                            relspd_condition.attrib.get('entityRef', None)))
 
                     atomic = RelativeVelocityToOtherActor(
-                        trigger_actor,
-                        triggered_actor,
-                        condition_value,
-                        condition_operator,
-                        condition_name,
-                    )
-                elif entity_condition.find("TraveledDistanceCondition") is not None:
-                    distance_condition = entity_condition.find(
-                        "TraveledDistanceCondition"
-                    )
-                    distance_value = float(
-                        distance_condition.attrib.get("value"))
-                    atomic = DriveDistance(
-                        trigger_actor, distance_value, name=condition_name
-                    )
-                elif entity_condition.find("ReachPositionCondition") is not None:
-                    rp_condition = entity_condition.find(
-                        "ReachPositionCondition")
-                    distance_value = float(
-                        rp_condition.attrib.get("tolerance"))
-                    position = rp_condition.find("Position")
+                        trigger_actor, triggered_actor, condition_value, condition_operator, condition_name)
+                elif entity_condition.find('TraveledDistanceCondition') is not None:
+                    distance_condition = entity_condition.find('TraveledDistanceCondition')
+                    distance_value = float(distance_condition.attrib.get('value'))
+                    atomic = DriveDistance(trigger_actor, distance_value, name=condition_name)
+                elif entity_condition.find('ReachPositionCondition') is not None:
+                    rp_condition = entity_condition.find('ReachPositionCondition')
+                    distance_value = float(rp_condition.attrib.get('tolerance'))
+                    position = rp_condition.find('Position')
                     atomic = InTriggerDistanceToOSCPosition(
                         trigger_actor, position, distance_value, name=condition_name)
-                elif entity_condition.find("DistanceCondition") is not None:
-                    distance_condition = entity_condition.find(
-                        "DistanceCondition")
+                elif entity_condition.find('DistanceCondition') is not None:
+                    distance_condition = entity_condition.find('DistanceCondition')
 
-                    distance_value = float(
-                        distance_condition.attrib.get("value"))
+                    distance_value = float(distance_condition.attrib.get('value'))
 
-                    distance_rule = distance_condition.attrib.get("rule")
+                    distance_rule = distance_condition.attrib.get('rule')
                     distance_operator = OpenScenarioParser.operators[distance_rule]
 
-                    distance_freespace = strtobool(
-                        distance_condition.attrib.get("freespace", False)
-                    )
+                    distance_freespace = strtobool(distance_condition.attrib.get('freespace', False))
                     if distance_freespace:
                         raise NotImplementedError(
-                            "DistanceCondition: freespace attribute is currently not implemented"
-                        )
-                    distance_along_route = strtobool(
-                        distance_condition.attrib.get("alongRoute", False)
-                    )
+                            "DistanceCondition: freespace attribute is currently not implemented")
+                    distance_along_route = strtobool(distance_condition.attrib.get('alongRoute', False))
 
-                    if distance_condition.find("Position") is not None:
-                        position = distance_condition.find("Position")
+                    if distance_condition.find('Position') is not None:
+                        position = distance_condition.find('Position')
                         atomic = InTriggerDistanceToOSCPosition(
-                            trigger_actor,
-                            position,
-                            distance_value,
-                            distance_along_route,
-                            distance_operator,
-                            name=condition_name,
-                        )
+                            trigger_actor, position, distance_value, distance_along_route,
+                            distance_operator, name=condition_name)
 
-                elif entity_condition.find("RelativeDistanceCondition") is not None:
-                    distance_condition = entity_condition.find(
-                        "RelativeDistanceCondition"
-                    )
-                    distance_value = float(
-                        distance_condition.attrib.get("value"))
+                elif entity_condition.find('RelativeDistanceCondition') is not None:
+                    distance_condition = entity_condition.find('RelativeDistanceCondition')
+                    distance_value = float(distance_condition.attrib.get('value'))
 
-                    distance_freespace = strtobool(
-                        distance_condition.attrib.get("freespace", False)
-                    )
+                    distance_freespace = strtobool(distance_condition.attrib.get('freespace', False))
                     if distance_freespace:
                         raise NotImplementedError(
-                            "RelativeDistanceCondition: freespace attribute is currently not implemented"
-                        )
-                    if (
-                        distance_condition.attrib.get("relativeDistanceType")
-                        == "cartesianDistance"
-                    ):
+                            "RelativeDistanceCondition: freespace attribute is currently not implemented")
+                    if distance_condition.attrib.get('relativeDistanceType') == "cartesianDistance":
                         for actor in actor_list:
-                            if (distance_condition.attrib.get("entityRef",
-                                                              None) == actor.attributes["role_name"]):
+                            if distance_condition.attrib.get('entityRef', None) == actor.attributes['role_name']:
                                 triggered_actor = actor
                                 break
 
                         if triggered_actor is None:
-                            raise AttributeError(
-                                "Cannot find actor '{}' for condition".format(
-                                    distance_condition.attrib.get(
-                                        "entityRef", None)))
+                            raise AttributeError("Cannot find actor '{}' for condition".format(
+                                distance_condition.attrib.get('entityRef', None)))
 
-                        condition_rule = distance_condition.attrib.get("rule")
-                        condition_operator = OpenScenarioParser.operators[
-                            condition_rule
-                        ]
+                        condition_rule = distance_condition.attrib.get('rule')
+                        condition_operator = OpenScenarioParser.operators[condition_rule]
                         atomic = InTriggerDistanceToVehicle(
-                            triggered_actor,
-                            trigger_actor,
-                            distance_value,
-                            condition_operator,
-                            name=condition_name,
-                        )
+                            triggered_actor, trigger_actor, distance_value, condition_operator, name=condition_name)
                     else:
                         raise NotImplementedError(
-                            "RelativeDistance condition with the given specification is not yet supported"
-                        )
-        elif condition.find("ByValueCondition") is not None:
-            value_condition = condition.find("ByValueCondition")
-            if value_condition.find("ParameterCondition") is not None:
-                parameter_condition = value_condition.find(
-                    "ParameterCondition")
-                arg_name = parameter_condition.attrib.get("parameterRef")
-                value = parameter_condition.attrib.get("value")
-                if value != "":
+                            "RelativeDistance condition with the given specification is not yet supported")
+        elif condition.find('ByValueCondition') is not None:
+            value_condition = condition.find('ByValueCondition')
+            if value_condition.find('ParameterCondition') is not None:
+                parameter_condition = value_condition.find('ParameterCondition')
+                arg_name = parameter_condition.attrib.get('parameterRef')
+                value = parameter_condition.attrib.get('value')
+                if value != '':
                     arg_value = float(value)
                 else:
                     arg_value = 0
-                parameter_condition.attrib.get("rule")
+                parameter_condition.attrib.get('rule')
 
                 if condition_name in globals():
                     criterion_instance = globals()[condition_name]
                 else:
                     raise AttributeError(
-                        "The condition {} cannot be mapped to a criterion atomic".format(
-                            condition_name
-                        )
-                    )
+                        "The condition {} cannot be mapped to a criterion atomic".format(condition_name))
 
-                atomic = py_trees.composites.Parallel(
-                    "Evaluation Criteria for multiple ego vehicles"
-                )
+                atomic = py_trees.composites.Parallel("Evaluation Criteria for multiple ego vehicles")
                 for triggered_actor in actor_list:
-                    if arg_name != "":
-                        atomic.add_child(
-                            criterion_instance(
-                                triggered_actor, arg_value))
+                    if arg_name != '':
+                        atomic.add_child(criterion_instance(triggered_actor, arg_value))
                     else:
                         atomic.add_child(criterion_instance(triggered_actor))
-            elif value_condition.find("SimulationTimeCondition") is not None:
-                simtime_condition = value_condition.find(
-                    "SimulationTimeCondition")
-                value = float(simtime_condition.attrib.get("value"))
-                rule = simtime_condition.attrib.get("rule")
+            elif value_condition.find('SimulationTimeCondition') is not None:
+                simtime_condition = value_condition.find('SimulationTimeCondition')
+                value = float(simtime_condition.attrib.get('value'))
+                rule = simtime_condition.attrib.get('rule')
                 atomic = SimulationTimeCondition(value, success_rule=rule)
-            elif value_condition.find("TimeOfDayCondition") is not None:
-                tod_condition = value_condition.find("TimeOfDayCondition")
-                condition_date = tod_condition.attrib.get("dateTime")
-                condition_rule = tod_condition.attrib.get("rule")
+            elif value_condition.find('TimeOfDayCondition') is not None:
+                tod_condition = value_condition.find('TimeOfDayCondition')
+                condition_date = tod_condition.attrib.get('dateTime')
+                condition_rule = tod_condition.attrib.get('rule')
                 condition_operator = OpenScenarioParser.operators[condition_rule]
-                atomic = TimeOfDayComparison(
-                    condition_date, condition_operator, condition_name
-                )
-            elif value_condition.find("StoryboardElementStateCondition") is not None:
-                state_condition = value_condition.find(
-                    "StoryboardElementStateCondition"
-                )
-                element_name = state_condition.attrib.get(
-                    "storyboardElementRef")
-                element_type = state_condition.attrib.get(
-                    "storyboardElementType")
-                state = state_condition.attrib.get("state")
+                atomic = TimeOfDayComparison(condition_date, condition_operator, condition_name)
+            elif value_condition.find('StoryboardElementStateCondition') is not None:
+                state_condition = value_condition.find('StoryboardElementStateCondition')
+                element_name = state_condition.attrib.get('storyboardElementRef')
+                element_type = state_condition.attrib.get('storyboardElementType')
+                state = state_condition.attrib.get('state')
                 if state == "startTransition":
-                    atomic = OSCStartEndCondition(
-                        element_type,
-                        element_name,
-                        rule="START",
-                        name=state + "Condition",
-                    )
-                elif (
-                    state == "stopTransition"
-                    or state == "endTransition"
-                    or state == "completeState"
-                ):
-                    atomic = OSCStartEndCondition(
-                        element_type, element_name, rule="END", name=state + "Condition")
+                    atomic = OSCStartEndCondition(element_type, element_name, rule="START", name=state + "Condition")
+                elif state == "stopTransition" or state == "endTransition" or state == "completeState":
+                    atomic = OSCStartEndCondition(element_type, element_name, rule="END", name=state + "Condition")
                 else:
                     raise NotImplementedError(
-                        "Only start, stop, endTransitions and completeState are currently supported"
-                    )
-            elif value_condition.find("UserDefinedValueCondition") is not None:
-                raise NotImplementedError(
-                    "ByValue UserDefinedValue conditions are not yet supported"
-                )
-            elif value_condition.find("TrafficSignalCondition") is not None:
-                tl_condition = value_condition.find("TrafficSignalCondition")
+                        "Only start, stop, endTransitions and completeState are currently supported")
+            elif value_condition.find('UserDefinedValueCondition') is not None:
+                raise NotImplementedError("ByValue UserDefinedValue conditions are not yet supported")
+            elif value_condition.find('TrafficSignalCondition') is not None:
+                tl_condition = value_condition.find('TrafficSignalCondition')
 
-                name_condition = tl_condition.attrib.get("name")
-                traffic_light = OpenScenarioParser.get_traffic_light_from_osc_name(
-                    name_condition)
+                name_condition = tl_condition.attrib.get('name')
+                traffic_light = OpenScenarioParser.get_traffic_light_from_osc_name(name_condition)
 
-                tl_state = tl_condition.attrib.get("state").upper()
+                tl_state = tl_condition.attrib.get('state').upper()
                 if tl_state not in OpenScenarioParser.tl_states:
-                    raise KeyError(
-                        "CARLA only supports Green, Red, Yellow or Off")
+                    raise KeyError("CARLA only supports Green, Red, Yellow or Off")
                 state_condition = OpenScenarioParser.tl_states[tl_state]
 
                 atomic = WaitForTrafficLightState(
-                    traffic_light, state_condition, name=condition_name
-                )
-            elif value_condition.find("TrafficSignalControllerCondition") is not None:
-                raise NotImplementedError(
-                    "ByValue TrafficSignalController conditions are not yet supported"
-                )
+                    traffic_light, state_condition, name=condition_name)
+            elif value_condition.find('TrafficSignalControllerCondition') is not None:
+                raise NotImplementedError("ByValue TrafficSignalController conditions are not yet supported")
             else:
                 raise AttributeError("Unknown ByValue condition")
 
@@ -1153,249 +880,157 @@ class OpenScenarioParser(object):
     def convert_maneuver_to_atomic(action, actor, catalogs):
         """
         Convert an OpenSCENARIO maneuver action into a Behavior atomic
-
         Note not all OpenSCENARIO actions are currently supported
         """
-        maneuver_name = action.attrib.get("name", "unknown")
+        maneuver_name = action.attrib.get('name', 'unknown')
 
-        if action.find("GlobalAction") is not None:
-            global_action = action.find("GlobalAction")
-            if global_action.find("InfrastructureAction") is not None:
-                infrastructure_action = global_action.find(
-                    "InfrastructureAction").find("TrafficSignalAction")
-                if infrastructure_action.find(
-                        "TrafficSignalStateAction") is not None:
-                    traffic_light_action = infrastructure_action.find(
-                        "TrafficSignalStateAction"
-                    )
+        if action.find('GlobalAction') is not None:
+            global_action = action.find('GlobalAction')
+            if global_action.find('InfrastructureAction') is not None:
+                infrastructure_action = global_action.find('InfrastructureAction').find('TrafficSignalAction')
+                if infrastructure_action.find('TrafficSignalStateAction') is not None:
+                    traffic_light_action = infrastructure_action.find('TrafficSignalStateAction')
 
-                    name_condition = traffic_light_action.attrib.get("name")
-                    traffic_light = OpenScenarioParser.get_traffic_light_from_osc_name(
-                        name_condition)
+                    name_condition = traffic_light_action.attrib.get('name')
+                    traffic_light = OpenScenarioParser.get_traffic_light_from_osc_name(name_condition)
 
-                    tl_state = traffic_light_action.attrib.get("state").upper()
+                    tl_state = traffic_light_action.attrib.get('state').upper()
                     if tl_state not in OpenScenarioParser.tl_states:
-                        raise KeyError(
-                            "CARLA only supports Green, Red, Yellow or Off")
+                        raise KeyError("CARLA only supports Green, Red, Yellow or Off")
                     traffic_light_state = OpenScenarioParser.tl_states[tl_state]
 
                     atomic = TrafficLightStateSetter(
-                        traffic_light,
-                        traffic_light_state,
-                        name=maneuver_name + "_" + str(traffic_light.id),
-                    )
+                        traffic_light, traffic_light_state, name=maneuver_name + "_" + str(traffic_light.id))
                 else:
-                    raise NotImplementedError(
-                        "TrafficLights can only be influenced via TrafficSignalStateAction"
-                    )
-            elif global_action.find("EnvironmentAction") is not None:
+                    raise NotImplementedError("TrafficLights can only be influenced via TrafficSignalStateAction")
+            elif global_action.find('EnvironmentAction') is not None:
                 weather_behavior = ChangeWeather(
-                    OpenScenarioParser.get_weather_from_env_action(
-                        global_action, catalogs
-                    )
-                )
+                    OpenScenarioParser.get_weather_from_env_action(global_action, catalogs))
                 friction_behavior = ChangeRoadFriction(
-                    OpenScenarioParser.get_friction_from_env_action(
-                        global_action, catalogs
-                    )
-                )
+                    OpenScenarioParser.get_friction_from_env_action(global_action, catalogs))
 
                 env_behavior = py_trees.composites.Parallel(
-                    policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL,
-                    name=maneuver_name,
-                )
+                    policy=py_trees.common.ParallelPolicy.SUCCESS_ON_ALL, name=maneuver_name)
 
                 env_behavior.add_child(
-                    oneshot_behavior(
-                        variable_name=maneuver_name + ">WeatherUpdate",
-                        behaviour=weather_behavior,
-                    )
-                )
+                    oneshot_behavior(variable_name=maneuver_name + ">WeatherUpdate", behaviour=weather_behavior))
                 env_behavior.add_child(
-                    oneshot_behavior(
-                        variable_name=maneuver_name + ">FrictionUpdate",
-                        behaviour=friction_behavior,
-                    )
-                )
+                    oneshot_behavior(variable_name=maneuver_name + ">FrictionUpdate", behaviour=friction_behavior))
 
                 return env_behavior
 
             else:
-                raise NotImplementedError(
-                    "Global actions are not yet supported")
-        elif action.find("UserDefinedAction") is not None:
-            user_defined_action = action.find("UserDefinedAction")
-            if user_defined_action.find("CustomCommandAction") is not None:
-                command = user_defined_action.find(
-                    "CustomCommandAction").attrib.get("type")
-                atomic = RunScript(
-                    command,
-                    base_path=OpenScenarioParser.osc_filepath,
-                    name=maneuver_name,
-                )
-        elif action.find("PrivateAction") is not None:
-            private_action = action.find("PrivateAction")
+                raise NotImplementedError("Global actions are not yet supported")
+        elif action.find('UserDefinedAction') is not None:
+            user_defined_action = action.find('UserDefinedAction')
+            if user_defined_action.find('CustomCommandAction') is not None:
+                command = user_defined_action.find('CustomCommandAction').attrib.get('type')
+                atomic = RunScript(command, base_path=OpenScenarioParser.osc_filepath, name=maneuver_name)
+        elif action.find('PrivateAction') is not None:
+            private_action = action.find('PrivateAction')
 
-            if private_action.find("LongitudinalAction") is not None:
-                private_action = private_action.find("LongitudinalAction")
+            if private_action.find('LongitudinalAction') is not None:
+                private_action = private_action.find('LongitudinalAction')
 
-                if private_action.find("SpeedAction") is not None:
-                    long_maneuver = private_action.find("SpeedAction")
+                if private_action.find('SpeedAction') is not None:
+                    long_maneuver = private_action.find('SpeedAction')
 
                     # duration and distance
-                    distance = float("inf")
-                    duration = float("inf")
-                    dimension = long_maneuver.find(
-                        "SpeedActionDynamics").attrib.get("dynamicsDimension")
+                    distance = float('inf')
+                    duration = float('inf')
+                    dimension = long_maneuver.find("SpeedActionDynamics").attrib.get('dynamicsDimension')
                     if dimension == "distance":
-                        distance = float(
-                            long_maneuver.find("SpeedActionDynamics").attrib.get(
-                                "value", float("inf")))
+                        distance = float(long_maneuver.find("SpeedActionDynamics").attrib.get('value', float("inf")))
                     else:
-                        duration = float(
-                            long_maneuver.find("SpeedActionDynamics").attrib.get(
-                                "value", float("inf")))
+                        duration = float(long_maneuver.find("SpeedActionDynamics").attrib.get('value', float("inf")))
 
                     # absolute velocity with given target speed
-                    if (
-                        long_maneuver.find("SpeedActionTarget").find(
-                            "AbsoluteTargetSpeed"
-                        )
-                        is not None
-                    ):
-                        target_speed = float(
-                            long_maneuver.find("SpeedActionTarget")
-                            .find("AbsoluteTargetSpeed")
-                            .attrib.get("value", 0)
-                        )
+                    if long_maneuver.find("SpeedActionTarget").find("AbsoluteTargetSpeed") is not None:
+                        target_speed = float(long_maneuver.find("SpeedActionTarget").find(
+                            "AbsoluteTargetSpeed").attrib.get('value', 0))
                         atomic = ChangeActorTargetSpeed(
-                            actor,
-                            target_speed,
-                            distance=distance,
-                            duration=duration,
-                            name=maneuver_name,
-                        )
+                            actor, target_speed, distance=distance, duration=duration, name=maneuver_name)
 
                     # relative velocity to given actor
-                    if (
-                        long_maneuver.find("SpeedActionTarget").find(
-                            "RelativeTargetSpeed"
-                        )
-                        is not None
-                    ):
-                        relative_speed = long_maneuver.find(
-                            "SpeedActionTarget").find("RelativeTargetSpeed")
-                        obj = relative_speed.attrib.get("entityRef")
-                        value = float(relative_speed.attrib.get("value", 0))
-                        value_type = relative_speed.attrib.get(
-                            "speedTargetValueType")
-                        continuous = relative_speed.attrib.get("continuous")
+                    if long_maneuver.find("SpeedActionTarget").find("RelativeTargetSpeed") is not None:
+                        relative_speed = long_maneuver.find("SpeedActionTarget").find("RelativeTargetSpeed")
+                        obj = relative_speed.attrib.get('entityRef')
+                        value = float(relative_speed.attrib.get('value', 0))
+                        value_type = relative_speed.attrib.get('speedTargetValueType')
+                        continuous = relative_speed.attrib.get('continuous')
 
                         for traffic_actor in CarlaDataProvider.get_world().get_actors():
-                            if (
-                                "role_name" in traffic_actor.attributes
-                                and traffic_actor.attributes["role_name"] == obj
-                            ):
+                            if 'role_name' in traffic_actor.attributes and traffic_actor.attributes['role_name'] == obj:
                                 obj_actor = traffic_actor
 
-                        atomic = ChangeActorTargetSpeed(
-                            actor,
-                            target_speed=0.0,
-                            relative_actor=obj_actor,
-                            value=value,
-                            value_type=value_type,
-                            continuous=continuous,
-                            distance=distance,
-                            duration=duration,
-                            name=maneuver_name,
-                        )
+                        atomic = ChangeActorTargetSpeed(actor,
+                                                        target_speed=0.0,
+                                                        relative_actor=obj_actor,
+                                                        value=value,
+                                                        value_type=value_type,
+                                                        continuous=continuous,
+                                                        distance=distance,
+                                                        duration=duration,
+                                                        name=maneuver_name)
 
-                elif private_action.find("LongitudinalDistanceAction") is not None:
-                    raise NotImplementedError(
-                        "Longitudinal distance actions are not yet supported"
-                    )
+                elif private_action.find('LongitudinalDistanceAction') is not None:
+                    raise NotImplementedError("Longitudinal distance actions are not yet supported")
                 else:
                     raise AttributeError("Unknown longitudinal action")
-            elif private_action.find("LateralAction") is not None:
-                private_action = private_action.find("LateralAction")
-                if private_action.find("LaneChangeAction") is not None:
+            elif private_action.find('LateralAction') is not None:
+                private_action = private_action.find('LateralAction')
+                if private_action.find('LaneChangeAction') is not None:
                     # Note: LaneChangeActions are currently only supported for RelativeTargetLane
                     #       with +1 or -1 referring to the action actor
-                    lat_maneuver = private_action.find("LaneChangeAction")
-                    target_lane_rel = float(
-                        lat_maneuver.find("LaneChangeTarget")
-                        .find("RelativeTargetLane")
-                        .attrib.get("value", 0)
-                    )
+                    lat_maneuver = private_action.find('LaneChangeAction')
+                    target_lane_rel = float(lat_maneuver.find("LaneChangeTarget").find(
+                        "RelativeTargetLane").attrib.get('value', 0))
                     # duration and distance
-                    distance = float("inf")
-                    duration = float("inf")
-                    dimension = lat_maneuver.find(
-                        "LaneChangeActionDynamics"
-                    ).attrib.get("dynamicsDimension")
+                    distance = float('inf')
+                    duration = float('inf')
+                    dimension = lat_maneuver.find("LaneChangeActionDynamics").attrib.get('dynamicsDimension')
                     if dimension == "distance":
                         distance = float(
-                            lat_maneuver.find("LaneChangeActionDynamics").attrib.get(
-                                "value", float("inf")))
+                            lat_maneuver.find("LaneChangeActionDynamics").attrib.get('value', float("inf")))
                     else:
                         duration = float(
-                            lat_maneuver.find("LaneChangeActionDynamics").attrib.get(
-                                "value", float("inf")))
-                    atomic = ChangeActorLateralMotion(
-                        actor,
-                        direction="left" if target_lane_rel < 0 else "right",
-                        distance_lane_change=distance,
-                        distance_other_lane=1000,
-                        name=maneuver_name,
-                    )
+                            lat_maneuver.find("LaneChangeActionDynamics").attrib.get('value', float("inf")))
+                    atomic = ChangeActorLateralMotion(actor,
+                                                      direction="left" if target_lane_rel < 0 else "right",
+                                                      distance_lane_change=distance,
+                                                      distance_other_lane=1000,
+                                                      name=maneuver_name)
                 else:
                     raise AttributeError("Unknown lateral action")
-            elif private_action.find("VisibilityAction") is not None:
-                raise NotImplementedError(
-                    "Visibility actions are not yet supported")
-            elif private_action.find("SynchronizeAction") is not None:
-                raise NotImplementedError(
-                    "Synchronization actions are not yet supported"
-                )
-            elif private_action.find("ActivateControllerAction") is not None:
-                private_action = private_action.find(
-                    "ActivateControllerAction")
-                activate = strtobool(private_action.attrib.get("longitudinal"))
+            elif private_action.find('VisibilityAction') is not None:
+                raise NotImplementedError("Visibility actions are not yet supported")
+            elif private_action.find('SynchronizeAction') is not None:
+                raise NotImplementedError("Synchronization actions are not yet supported")
+            elif private_action.find('ActivateControllerAction') is not None:
+                private_action = private_action.find('ActivateControllerAction')
+                activate = strtobool(private_action.attrib.get('longitudinal'))
                 atomic = ChangeAutoPilot(actor, activate, name=maneuver_name)
-            elif private_action.find("ControllerAction") is not None:
-                controller_action = private_action.find("ControllerAction")
-                module, args = OpenScenarioParser.get_controller(
-                    controller_action, catalogs
-                )
-                atomic = ChangeActorControl(
-                    actor, control_py_module=module, args=args)
-            elif private_action.find("TeleportAction") is not None:
-                position = private_action.find("TeleportAction")
-                atomic = ActorTransformSetterToOSCPosition(
-                    actor, position, name=maneuver_name
-                )
-            elif private_action.find("RoutingAction") is not None:
-                private_action = private_action.find("RoutingAction")
-                if private_action.find("AssignRouteAction") is not None:
+            elif private_action.find('ControllerAction') is not None:
+                controller_action = private_action.find('ControllerAction')
+                module, args = OpenScenarioParser.get_controller(controller_action, catalogs)
+                atomic = ChangeActorControl(actor, control_py_module=module, args=args)
+            elif private_action.find('TeleportAction') is not None:
+                position = private_action.find('TeleportAction')
+                atomic = ActorTransformSetterToOSCPosition(actor, position, name=maneuver_name)
+            elif private_action.find('RoutingAction') is not None:
+                private_action = private_action.find('RoutingAction')
+                if private_action.find('AssignRouteAction') is not None:
                     # @TODO: How to handle relative positions here? This might chance at runtime?!
-                    route_action = private_action.find("AssignRouteAction")
-                    waypoints = OpenScenarioParser.get_route(
-                        route_action, catalogs)
-                    atomic = ChangeActorWaypoints(
-                        actor, waypoints=waypoints, name=maneuver_name
-                    )
-                elif private_action.find("FollowTrajectoryAction") is not None:
-                    raise NotImplementedError(
-                        "Private FollowTrajectory actions are not yet supported"
-                    )
-                elif private_action.find("AcquirePositionAction") is not None:
-                    route_action = private_action.find("AcquirePositionAction")
-                    osc_position = route_action.find("Position")
-                    position = OpenScenarioParser.convert_position_to_transform(
-                        osc_position)
-                    atomic = ChangeActorWaypointsToReachPosition(
-                        actor, position=position, name=maneuver_name
-                    )
+                    route_action = private_action.find('AssignRouteAction')
+                    waypoints = OpenScenarioParser.get_route(route_action, catalogs)
+                    atomic = ChangeActorWaypoints(actor, waypoints=waypoints, name=maneuver_name)
+                elif private_action.find('FollowTrajectoryAction') is not None:
+                    raise NotImplementedError("Private FollowTrajectory actions are not yet supported")
+                elif private_action.find('AcquirePositionAction') is not None:
+                    route_action = private_action.find('AcquirePositionAction')
+                    osc_position = route_action.find('Position')
+                    position = OpenScenarioParser.convert_position_to_transform(osc_position)
+                    atomic = ChangeActorWaypointsToReachPosition(actor, position=position, name=maneuver_name)
                 else:
                     raise AttributeError("Unknown private routing action")
             else:
@@ -1403,8 +1038,7 @@ class OpenScenarioParser(object):
 
         else:
             if list(action):
-                raise AttributeError(
-                    "Unknown action: {}".format(maneuver_name))
+                raise AttributeError("Unknown action: {}".format(maneuver_name))
             else:
                 return Idle(duration=0, name=maneuver_name)
 


### PR DESCRIPTION
Description

A new class ```InTimeToCollisionToVehicle``` is added to support ```TimeToCollisionCondition``` tag for dynamic actors.

The formula used for TimeToCollision calculation in previous Implementation is :
```
  Relative Distance = Distance between centre location of two actors.
  TimeToCollision = (2 * Relative Distance ) /  relative velocity of two actors
```
The formula used for TimeToCollision calculation in current implementation is :

```
Relative Distance = Distance between centre location of two actors.

When "freespace" is true:
TimeToCollision = (Relative Distance - half of length of actor1 -  half of length of actor2 ) / relative velocity of two actors.

When "freespace" is false:
TimeToCollision = Relative Distance  / relative velocity of two actors.
```
The modified calculation is done as in the below image :

   ```When "freespace" is true:```
   ![ttc](https://user-images.githubusercontent.com/68461250/96423351-d4944780-1216-11eb-9754-b68265e78d6b.png)

  ```When "freespace" is false:```
   ![ttc1](https://user-images.githubusercontent.com/68461250/96423679-4c627200-1217-11eb-9196-8f0c3551b603.png)



Where has this been tested?
Platform(s): Ubuntu 18.04
Python version(s): Python 3.6
Unreal Engine version(s):
CARLA version: CARLA_0.9.10

Possible Drawbacks : None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/666)
<!-- Reviewable:end -->
