### PR TITLE
Fixed shutdown issue in ScenarioManager causing problems in sync mode

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### :bug: Bug Fixes
 * Fixed exception when using OSC scenarios without EnvironmentAction inside Storyboard-Init
 * Fixed bug causing the TrafficManager to not be correctly updated at asynchronous simualtions
+* Fixed shutdown issue in ScenarioRunner causing to not switch to asynchronous mode
 ### :ghost: Maintenance
 * Added check to ensure OSC names (for story/act/maneuver) are unique
 

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -170,13 +170,15 @@ class ScenarioRunner(object):
         Remove and destroy all actors
         """
         # Simulation still running and in synchronous mode?
-        if self.manager is not None and self.manager.get_running_status() \
-                and self.world is not None and self._args.sync:
-            # Reset to asynchronous mode
-            settings = self.world.get_settings()
-            settings.synchronous_mode = False
-            settings.fixed_delta_seconds = None
-            self.world.apply_settings(settings)
+        if self.world is not None and self._args.sync:
+            try:
+                # Reset to asynchronous mode
+                settings = self.world.get_settings()
+                settings.synchronous_mode = False
+                settings.fixed_delta_seconds = None
+                self.world.apply_settings(settings)
+            except RuntimeError:
+                sys.exit(-1)
 
         self.manager.cleanup()
 


### PR DESCRIPTION
On shutdown it could happen that sync mode remained active, causing issues on next startup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/669)
<!-- Reviewable:end -->
