### PR TITLE
Added support for OSC routing options

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Added a sensor barrier for the agents to ensure that the simulation waits for them to render their data.
 * Added an option to produce a machine-readable JSON version of the scenario report.
 * Added a static obstacle evasion OpenSCENARIO scenario
+* Added support for OSC Routing options
 ### :bug: Bug Fixes
 * Fixed exception when using OSC scenarios without EnvironmentAction inside Storyboard-Init
 * Fixed bug causing the TrafficManager to not be correctly updated at asynchronous simualtions

--- a/Docs/openscenario_support.md
+++ b/Docs/openscenario_support.md
@@ -252,7 +252,7 @@ contains of submodules, which are not listed, the support status applies to all 
 <td><small><code>RoutingAction</code></small><br><code>AssignRouteAction</code></td>
 <td>&#10060;</td>
 <td>&#9989;</td>
-<td></td>
+<td>Route Options (shortest/fastest/etc) are supported. Shortests means direct path between A and B, all other will use the shortest path along the road network between A and B</td>
 <tr>
 <td><small><code>RoutingAction</code></small><br><code>FollowTrajectoryAction</code></td>
 <td>&#10060;</td>

--- a/srunner/scenariomanager/actorcontrols/npc_vehicle_control.py
+++ b/srunner/scenariomanager/actorcontrols/npc_vehicle_control.py
@@ -47,6 +47,7 @@ class NpcVehicleControl(BasicControl):
         """
         Update the plan (waypoint list) of the LocalPlanner
         """
+        self._local_planner._waypoint_buffer.clear()    # pylint: disable=protected-access
         plan = []
         for transform in self._waypoints:
             waypoint = CarlaDataProvider.get_map().get_waypoint(

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -411,7 +411,9 @@ class OpenScenarioParser(object):
             catalogs: XML Catalogs that could contain the Route
 
         returns:
-           waypoints: List of route waypoints
+           waypoints: List of route waypoints = (waypoint, routing strategy)
+                      where the strategy is a string indicating if the fastest/shortest/etc.
+                      route should be used.
         """
         route = None
 
@@ -427,7 +429,8 @@ class OpenScenarioParser(object):
         if route is not None:
             for waypoint in route.iter('Waypoint'):
                 position = waypoint.find('Position')
-                waypoints.append(position)
+                routing_option = str(waypoint.attrib.get('routeStrategy'))
+                waypoints.append((position, routing_option))
         else:
             raise AttributeError("No waypoints has been set")
 


### PR DESCRIPTION
When using routing options (routeStrategy) for route waypoints in OSC,
shortest and fastest will be treated differently.

Shortest = direct connection between A and B
Others = shortest path along the road network from A to B

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/677)
<!-- Reviewable:end -->
