### PR TITLE
Fixed InTimeToArrivalToVehicle bug with static objects

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fixed bug causing the TrafficManager to not be correctly updated at asynchronous simualtions
 * Fixed shutdown issue in ScenarioRunner causing to not switch to asynchronous mode
 * Fixed OSC TeleportAction within Story
+* Fixed bug causing the InTimeToArrivalToVehicle atomic to crash if one of the actors was a a static object
 ### :ghost: Maintenance
 * Added check to ensure OSC names (for story/act/maneuver) are unique
 

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -865,13 +865,13 @@ class InTimeToArrivalToVehicle(AtomicCondition):
 
         # Get the bounding boxes
         if self._condition_freespace:
-            if type(self._actor) in [carla.Vehicle, carla.Walker]:
+            if isinstance(self._actor, (carla.Vehicle, carla.Walker)):
                 actor_extent = self._actor.bounding_box.extent.x
             else:
                 # Patch, as currently static objects have no bounding boxes
                 actor_extent = 0
 
-            if type(self._other_actor) in [carla.Vehicle, carla.Walker]:
+            if isinstance(self._other_actor, (carla.Vehicle, carla.Walker)):
                 other_extent = self._other_actor.bounding_box.extent.x
             else:
                 # Patch, as currently static objects have no bounding boxes

--- a/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_trigger_conditions.py
@@ -863,6 +863,20 @@ class InTimeToArrivalToVehicle(AtomicCondition):
         current_location = CarlaDataProvider.get_location(self._actor)
         other_location = CarlaDataProvider.get_location(self._other_actor)
 
+        # Get the bounding boxes
+        if self._condition_freespace:
+            if type(self._actor) in [carla.Vehicle, carla.Walker]:
+                actor_extent = self._actor.bounding_box.extent.x
+            else:
+                # Patch, as currently static objects have no bounding boxes
+                actor_extent = 0
+
+            if type(self._other_actor) in [carla.Vehicle, carla.Walker]:
+                other_extent = self._other_actor.bounding_box.extent.x
+            else:
+                # Patch, as currently static objects have no bounding boxes
+                other_extent = 0
+
         if current_location is None or other_location is None:
             return new_status
 
@@ -881,8 +895,7 @@ class InTimeToArrivalToVehicle(AtomicCondition):
 
         if current_velocity > other_velocity:
             if self._condition_freespace:
-                time_to_arrival = (distance - self._actor.bounding_box.extent.x -
-                                   self._other_actor.bounding_box.extent.x) / (current_velocity - other_velocity)
+                time_to_arrival = (distance - actor_extent - other_extent) / (current_velocity - other_velocity)
             else:
                 time_to_arrival = distance / (current_velocity - other_velocity)
 


### PR DESCRIPTION
### Description

Currently, while vehicles and walkers have bounding boxes, all other objects such as static props or traffic signs don't. This was causing an exception when InTimeToArrivalToVehicle was being used to check for such objects. An additional condition has been placed, to avoid such exception.

Fixes #678

### Where has this been tested?

  * **Platform(s):** Ubutnu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.10.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/679)
<!-- Reviewable:end -->
