### PR TITLE
Fixed AcquirePositionAction

### DIFF
--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -607,8 +607,12 @@ class ChangeActorWaypoints(AtomicBehavior):
                 if i == 0:
                     mmap = CarlaDataProvider.get_map()
                     ego_location = CarlaDataProvider.get_location(self._actor)
-                    ego_waypoint = mmap.get_waypoint(ego_location).transform.location
-                    waypoint = ego_waypoint
+                    ego_waypoint = mmap.get_waypoint(ego_location)
+                    try:
+                        ego_next_wp = ego_waypoint.next(1)[0]
+                    except IndexError:
+                        ego_next_wp = ego_waypoint
+                    waypoint = ego_next_wp.transform.location
                 else:
                     waypoint = carla_route_elements[i - 1][0].location
                 waypoint_next = carla_route_elements[i][0].location
@@ -627,7 +631,7 @@ class ChangeActorWaypoints(AtomicBehavior):
                         if len(route) > 1:
                             last_heading_vec = route[-1].location - route[-2].location
                         else:
-                            last_heading_vec = route[-1].location - ego_waypoint
+                            last_heading_vec = route[-1].location - ego_next_wp.transform.location
                         last_heading = np.arctan2(last_heading_vec.y, last_heading_vec.x)
 
                         heading_delta = math.fabs(new_heading - last_heading)

--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -537,7 +537,6 @@ class ChangeActorWaypoints(AtomicBehavior):
     The behavior is in RUNNING state until the last waypoint is reached, or if a
     second waypoint related atomic for the same actor is triggered. These are:
     - ChangeActorWaypoints
-    - ChangeActorWaypointsToReachPosition
     - ChangeActorLateralMotion
 
     Args:
@@ -606,7 +605,10 @@ class ChangeActorWaypoints(AtomicBehavior):
                 route.append(carla_route_elements[i][0])
             else:
                 if i == 0:
-                    waypoint = CarlaDataProvider.get_location(self._actor)
+                    mmap = CarlaDataProvider.get_map()
+                    ego_location = CarlaDataProvider.get_location(self._actor)
+                    ego_waypoint = mmap.get_waypoint(ego_location).transform.location
+                    waypoint = ego_waypoint
                 else:
                     waypoint = carla_route_elements[i - 1][0].location
                 waypoint_next = carla_route_elements[i][0].location
@@ -625,7 +627,7 @@ class ChangeActorWaypoints(AtomicBehavior):
                         if len(route) > 1:
                             last_heading_vec = route[-1].location - route[-2].location
                         else:
-                            last_heading_vec = route[-1].location - CarlaDataProvider.get_location(self._actor)
+                            last_heading_vec = route[-1].location - ego_waypoint
                         last_heading = np.arctan2(last_heading_vec.y, last_heading_vec.x)
 
                         heading_delta = math.fabs(new_heading - last_heading)
@@ -668,67 +670,6 @@ class ChangeActorWaypoints(AtomicBehavior):
         return new_status
 
 
-class ChangeActorWaypointsToReachPosition(ChangeActorWaypoints):
-
-    """
-    Atomic to change the waypoints for an actor controller in order to reach
-    a given position.
-
-    The behavior is in RUNNING state until the last waypoint is reached, or if a
-    second waypoint related atomic for the same actor is triggered. These are:
-    - ChangeActorWaypoints
-    - ChangeActorWaypointsToReachPosition
-    - ChangeActorLateralMotion
-
-    Args:
-        actor (carla.Actor): Controlled actor.
-        position (carla.Transform): CARLA transform to be reached by the actor.
-        name (string): Name of the behavior.
-            Defaults to 'ChangeActorWaypointsToReachPosition'.
-
-    Attributes:
-        _end_transform (carla.Transform): Final position (CARLA transform).
-        _start_time (float): Start time of the atomic [s].
-            Defaults to None.
-        _grp (GlobalPlanner): global planner instance of the town
-    """
-
-    def __init__(self, actor, position, name="ChangeActorWaypointsToReachPosition"):
-        """
-        Setup parameters
-        """
-        super(ChangeActorWaypointsToReachPosition, self).__init__(actor, [])
-
-        self._end_transform = position
-
-        town_map = CarlaDataProvider.get_map()
-        dao = GlobalRoutePlannerDAO(town_map, 2)
-        self._grp = GlobalRoutePlanner(dao)
-        self._grp.setup()
-
-    def initialise(self):
-        """
-        Set _start_time and get (actor, controller) pair from Blackboard.
-
-        Generate a waypoint list (route) which representes the route. Set
-        this waypoint list for the actor controller.
-
-        May throw if actor is not available as key for the ActorsWithController
-        dictionary from Blackboard.
-        """
-
-        # get start position
-        position_actor = CarlaDataProvider.get_location(self._actor)
-
-        # calculate plan with global_route_planner function
-        plan = self._grp.trace_route(position_actor, self._end_transform.location)
-
-        for elem in plan:
-            self._waypoints.append(elem[0].transform)
-
-        super(ChangeActorWaypointsToReachPosition, self).initialise()
-
-
 class ChangeActorLateralMotion(AtomicBehavior):
 
     """
@@ -737,7 +678,6 @@ class ChangeActorLateralMotion(AtomicBehavior):
     The behavior is in RUNNING state until the last waypoint is reached, or if a
     second waypoint related atomic for the same actor is triggered. These are:
     - ChangeActorWaypoints
-    - ChangeActorWaypointsToReachPosition
     - ChangeActorLateralMotion
 
     If an impossible lane change is asked for (due to the lack of lateral lanes,

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -31,7 +31,6 @@ from srunner.scenariomanager.scenarioatomics.atomic_behaviors import (TrafficLig
                                                                       ChangeActorTargetSpeed,
                                                                       ChangeActorControl,
                                                                       ChangeActorWaypoints,
-                                                                      ChangeActorWaypointsToReachPosition,
                                                                       ChangeActorLateralMotion,
                                                                       Idle)
 # pylint: disable=unused-import
@@ -1071,8 +1070,8 @@ class OpenScenarioParser(object):
                 elif private_action.find('AcquirePositionAction') is not None:
                     route_action = private_action.find('AcquirePositionAction')
                     osc_position = route_action.find('Position')
-                    position = OpenScenarioParser.convert_position_to_transform(osc_position)
-                    atomic = ChangeActorWaypointsToReachPosition(actor, position=position, name=maneuver_name)
+                    waypoints = [(osc_position, 'fastest')]
+                    atomic = ChangeActorWaypoints(actor, waypoints=waypoints, name=maneuver_name)
                 else:
                     raise AttributeError("Unknown private routing action")
             else:


### PR DESCRIPTION
### Description

Fixed a bug at the last commit causing *AcquirePositionAction* of OSC to crash. The new *ChangeActorWaypoints* already has a global route planner, therefore the *ChangeActorWaypointsToReachPosition* behavior can be completely removed.

Changed some parts of the code from location to waypoint location at the *ChangeActorWaypoints*. This fixes the behaviour when the actor was initially far away from the center of the lane

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.10.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/687)
<!-- Reviewable:end -->
