### PR TITLE
Fixed writing result files with OSC under Windows

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fixed shutdown issue in ScenarioRunner causing to not switch to asynchronous mode
 * Fixed OSC TeleportAction within Story
 * Fixed bug causing the InTimeToArrivalToVehicle atomic to crash if one of the actors was a a static object
+* Fixed writing result files when using OpenSCENARIO under Windows
 ### :ghost: Maintenance
 * Added check to ensure OSC names (for story/act/maneuver) are unique
 

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -41,7 +41,7 @@ from srunner.tools.scenario_parser import ScenarioConfigurationParser
 from srunner.tools.route_parser import RouteParser
 
 # Version of scenario_runner
-VERSION = '0.9.9'
+VERSION = '0.9.10'
 
 
 class ScenarioRunner(object):
@@ -91,8 +91,8 @@ class ScenarioRunner(object):
         self.traffic_manager = self.client.get_trafficmanager(int(self._args.trafficManagerPort))
 
         dist = pkg_resources.get_distribution("carla")
-        if LooseVersion(dist.version) < LooseVersion('0.9.8'):
-            raise ImportError("CARLA version 0.9.8 or newer required. CARLA version found: {}".format(dist))
+        if LooseVersion(dist.version) < LooseVersion('0.9.10'):
+            raise ImportError("CARLA version 0.9.10 or newer required. CARLA version found: {}".format(dist))
 
         # Load agent if requested via command line args
         # If something goes wrong an exception will be thrown by importlib (ok here)

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -146,6 +146,7 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
         self.name = header.attrib.get('description', 'Unknown')
 
         if self.name.startswith("CARLA:"):
+            self.name = self.name[6:]
             OpenScenarioParser.set_use_carla_coordinate_system()
 
     def _set_carla_town(self):


### PR DESCRIPTION
Using the "CARLA:" prefix in the OSC description caused broken result files
under Windows. Therefore, the internal handling of the scenario name was modified
to enable writing the output files under Windows and Linux.

Fixes #682

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/691)
<!-- Reviewable:end -->
