### PR TITLE
Add support to place OSC controller implemenations next to OSC scenar…

### DIFF
--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -1084,7 +1084,7 @@ class OpenScenarioParser(object):
             elif private_action.find('ControllerAction') is not None:
                 controller_action = private_action.find('ControllerAction')
                 module, args = OpenScenarioParser.get_controller(controller_action, catalogs)
-                atomic = ChangeActorControl(actor, control_py_module=module, args=args, 
+                atomic = ChangeActorControl(actor, control_py_module=module, args=args,
                                             scenario_file_path=OpenScenarioParser.osc_filepath)
             elif private_action.find('TeleportAction') is not None:
                 teleport_action = private_action.find('TeleportAction')

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -1084,7 +1084,8 @@ class OpenScenarioParser(object):
             elif private_action.find('ControllerAction') is not None:
                 controller_action = private_action.find('ControllerAction')
                 module, args = OpenScenarioParser.get_controller(controller_action, catalogs)
-                atomic = ChangeActorControl(actor, control_py_module=module, args=args)
+                atomic = ChangeActorControl(actor, control_py_module=module, args=args, 
+                                            scenario_file_path=OpenScenarioParser.osc_filepath)
             elif private_action.find('TeleportAction') is not None:
                 teleport_action = private_action.find('TeleportAction')
                 position = teleport_action.find('Position')


### PR DESCRIPTION
…ios for the case of ControllerActions in the Storyboard

Addition to PR #704 in which the Storyboard ControllerActions are not covered yet.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated

-->

#### Description

Added the scenario path (already available in the `OpenScenarioParser`) as argument (in the `openscenario_parser.py`) to the `ChangeActorControl` atomic behavior instantiation. 
So, the controller files are recognized when assigned in the OpenScenario Storyboard.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** Python 3.7
  * **CARLA version:** 0.9.10.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/705)
<!-- Reviewable:end -->
