### PR TITLE
Overwrite ParameterDeclarations from CLI arguments.

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -11,7 +11,10 @@
 * [CARLA ScenarioRunner 0.9.2](#carla-scenariorunner-092)
 
 ## Latest Changes
-
+### :rocket: New Features
+* OpenSCENARIO support:
+    - Added `--openscenarioparams` argument to overwrite global `ParameterDeclaration`
+### :bug: Bug Fixes
 * Fixed bug at the Getting Started docs which caused an import error
 
 ## CARLA ScenarioRunner 0.9.11

--- a/Docs/getting_started.md
+++ b/Docs/getting_started.md
@@ -90,6 +90,11 @@ python scenario_runner.py --openscenario <path/to/xosc-file>
 Please note that the OpenSCENARIO support and the OpenSCENARIO format itself are still work in progress.
 More information you can find in [OpenSCENARIO support](openscenario_support.md)
 
+### Running scenarios using the OpenSCENARIO format with Global ParameterDeclaration overwrite
+```
+python scenario_runner.py --openscenario <path/to/xosc-file> --openscenarioparams 'param1: value1, param2: value2'
+```
+
 ## Running route-based scenario (similar to the CARLA AD Challenge)
 To run a route-based scenario, please run the ScenarioRunner as follows:
 ```

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -582,6 +582,9 @@ def main():
         print("Agents are currently only compatible with route scenarios'\n\n")
         parser.print_help(sys.stdout)
         return 1
+    
+    if arguments.openscenarioparams and not arguments.openscenario:
+        print("WARN: Ignoring --openscenarioparams when --openscenario is not specified")
 
     if arguments.route:
         arguments.reloadWorld = True

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -479,7 +479,12 @@ class ScenarioRunner(object):
             self._cleanup()
             return False
 
-        config = OpenScenarioConfiguration(self._args.openscenario, self.client, self._args.openscenarioparams)
+        openscenario_params = dict()
+        if self._args.openscenarioparams is not None:
+            for entry in self._args.openscenarioparams.split(','):
+                [key, val] = [m.strip() for m in entry.split(':')]
+                openscenario_params[key] = val
+        config = OpenScenarioConfiguration(self._args.openscenario, self.client, openscenario_params)
 
         result = self._load_and_run_scenario(config)
         self._cleanup()

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -582,7 +582,7 @@ def main():
         print("Agents are currently only compatible with route scenarios'\n\n")
         parser.print_help(sys.stdout)
         return 1
-    
+
     if arguments.openscenarioparams and not arguments.openscenario:
         print("WARN: Ignoring --openscenarioparams when --openscenario is not specified")
 

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -479,7 +479,7 @@ class ScenarioRunner(object):
             self._cleanup()
             return False
 
-        config = OpenScenarioConfiguration(self._args.openscenario, self.client)
+        config = OpenScenarioConfiguration(self._args.openscenario, self.client, self._args.openscenarioparams)
 
         result = self._load_and_run_scenario(config)
         self._cleanup()
@@ -529,6 +529,7 @@ def main():
     parser.add_argument(
         '--scenario', help='Name of the scenario to be executed. Use the preposition \'group:\' to run all scenarios of one class, e.g. ControlLoss or FollowLeadingVehicle')
     parser.add_argument('--openscenario', help='Provide an OpenSCENARIO definition')
+    parser.add_argument('--openscenarioparams', help='Overwrited for OpenSCENARIO ParameterDeclaration')
     parser.add_argument(
         '--route', help='Run a route as a scenario (input: (route_file,scenario_file,[route id]))', nargs='+', type=str)
 

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -191,7 +191,7 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
         """
         _global_params_overwrite = dict()
         if self._global_params_overwrite is not None:
-            _global_params_overwrite = dict([tuple(mn.split(':')) for mn in self._global_params_overwrite.split(',')])
+            _global_params_overwrite = dict([tuple(m.strip() for m in  mn.split(':')) for mn in self._global_params_overwrite.split(',')])
         self.xml_tree, self._global_parameters = OpenScenarioParser.set_parameters(self.xml_tree, _global_params_overwrite)
 
         for elem in self.xml_tree.iter():

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -31,11 +31,11 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
     - Only one Story + Init is supported per Storyboard
     """
 
-    def __init__(self, filename, client, params):
+    def __init__(self, filename, client, custom_params):
 
         self.xml_tree = ET.parse(filename)
         self.filename = filename
-        self._global_params_overwrite = params
+        self._custom_params = custom_params if custom_params is not None else dict()
 
         self._validate_openscenario_configuration()
         self.client = client
@@ -189,10 +189,7 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
 
         Set _global_parameters.
         """
-        _global_params_overwrite = dict()
-        if self._global_params_overwrite is not None:
-            _global_params_overwrite = dict([tuple(m.strip() for m in  mn.split(':')) for mn in self._global_params_overwrite.split(',')])
-        self.xml_tree, self._global_parameters = OpenScenarioParser.set_parameters(self.xml_tree, _global_params_overwrite)
+        self.xml_tree, self._global_parameters = OpenScenarioParser.set_parameters(self.xml_tree, self._custom_params)
 
         for elem in self.xml_tree.iter():
             if elem.find('ParameterDeclarations') is not None:

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -31,10 +31,11 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
     - Only one Story + Init is supported per Storyboard
     """
 
-    def __init__(self, filename, client):
+    def __init__(self, filename, client, params):
 
         self.xml_tree = ET.parse(filename)
         self.filename = filename
+        self._global_params_overwrite = params
 
         self._validate_openscenario_configuration()
         self.client = client
@@ -188,8 +189,10 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
 
         Set _global_parameters.
         """
-
-        self.xml_tree, self._global_parameters = OpenScenarioParser.set_parameters(self.xml_tree)
+        _global_params_overwrite = dict()
+        if self._global_params_overwrite is not None:
+            _global_params_overwrite = dict([tuple(mn.split(':')) for mn in self._global_params_overwrite.split(',')])
+        self.xml_tree, self._global_parameters = OpenScenarioParser.set_parameters(self.xml_tree, _global_params_overwrite)
 
         for elem in self.xml_tree.iter():
             if elem.find('ParameterDeclarations') is not None:

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -178,8 +178,6 @@ class OpenScenarioParser(object):
         """
 
         parameter_dict = dict()
-        if additional_parameter_dict is not None:
-            parameter_dict = additional_parameter_dict
         parameters = xml_tree.find('ParameterDeclarations')
 
         if parameters is None and not parameter_dict:
@@ -192,6 +190,10 @@ class OpenScenarioParser(object):
             name = parameter.attrib.get('name')
             value = parameter.attrib.get('value')
             parameter_dict[name] = value
+
+        # overwrite parameters in parameters_dict by additional_parameters_dict
+        if additional_parameter_dict is not None:
+            parameter_dict = dict(list(parameter_dict.items()) + list(additional_parameter_dict.items()))
 
         for node in xml_tree.iter():
             for key in node.attrib:


### PR DESCRIPTION
Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated - ***not needed, since not a new release***

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->
New:
Added `--openscenarioparams` parameter to scene_runner, which overwrites the global ParameterDeclaration.
Syntax: 
```bash
python scenario_runner.py --openscenario <path/to/xosc-file> --openscenarioparams 'param1: value1, param2: value2'
```
Change: 
openscenario_parser.py: `additional_parameter_dict` argument of set_parameters overwrites those found in XML, in case of conflict.
#### Where has this been tested?

  * **Platform(s):*Ubuntu 18.04*
  * **Python version(s):*2, 3*

#### Possible Drawbacks
openscenario_parser.py: `additional_parameter_dict` argument of set_parameters overwrites those found in XML, in case of conflict.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/736)
<!-- Reviewable:end -->
