### PR TITLE
Fixed never ending lane change maneuver in OSC

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -18,6 +18,7 @@
     - Added support for storyboards with multiple stories
 ### :bug: Bug Fixes
 * Fixed bug at the Getting Started docs which caused an import error
+* Fixed neverending lane change maneuver in OpenSCENARIO
 ### :ghost: Maintenance
 * Extended SimpleVehicleController (OSC) to handle traffic lights
 * Generalized visualizer attached to OSC controllers

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -260,6 +260,8 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
                                     if ref_actor.transform is not None:
                                         raise e
                                     break
+                        else:
+                            raise e
                     if actor.transform is None:
                         all_actor_transforms_set = False
 

--- a/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
+++ b/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
@@ -232,7 +232,7 @@ class SimpleVehicleControl(BasicControl):
         else:
             right_vector = transform.get_right_vector()
             offset_location = transform.location + carla.Location(x=self._offset*right_vector.x,
-                                                                y=self._offset*right_vector.y)
+                                                                  y=self._offset*right_vector.y)
 
         return offset_location
 
@@ -279,7 +279,7 @@ class SimpleVehicleControl(BasicControl):
 
         if self._consider_traffic_lights:
             if (self._actor.is_at_traffic_light() and
-                self._actor.get_traffic_light_state() == carla.TrafficLightState.Red):
+                    self._actor.get_traffic_light_state() == carla.TrafficLightState.Red):
                 target_speed = 0
 
         if target_speed < current_speed:

--- a/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
+++ b/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
@@ -290,8 +290,11 @@ class SimpleVehicleControl(BasicControl):
         else:
             self._actor.set_light_state(carla.VehicleLightState.NONE)
             if self._max_acceleration is not None:
-                target_speed = min(target_speed, current_speed + (current_time -
-                                                                  self._last_update) * self._max_acceleration)
+                tmp_speed = min(target_speed, current_speed + (current_time -
+                                                               self._last_update) * self._max_acceleration)
+                # If the tmp_speed is < 0.5 the vehicle may not properly accelerate.
+                # Therefore, we bump the speed to 0.5 m/s if target_speed allows.
+                target_speed = max(tmp_speed, min(0.5, target_speed))
 
         # set new linear velocity
         velocity = carla.Vector3D(0, 0, 0)

--- a/srunner/scenariomanager/actorcontrols/visualizer.py
+++ b/srunner/scenariomanager/actorcontrols/visualizer.py
@@ -115,6 +115,11 @@ class Visualizer(object):
             im_v = cv2.vconcat([self._cv_image_actor, self._cv_image_bird])
             cv2.circle(im_v, (900, 300), 80, (170, 170, 170), -1)
             text = str(int(round((self._actor.get_velocity().x * 3.6))))+" kph"
+
+            speed = np.sqrt(self._actor.get_velocity().x**2 + self._actor.get_velocity().y**2)
+
+
+            text = str(int(round((speed * 3.6))))+" kph"
             text = ' '*(7-len(text)) + text
             im_v = cv2.putText(im_v, text, (830, 310), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 0), 2, cv2.LINE_AA)
             cv2.imshow("", im_v)

--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -974,6 +974,19 @@ class ChangeActorLateralMotion(AtomicBehavior):
             if distance > self._distance_other_lane:
                 # long enough distance on new lane --> SUCCESS
                 new_status = py_trees.common.Status.SUCCESS
+
+                new_waypoints = []
+                map_wp = current_position_actor
+                while len(new_waypoints) < 200:
+                    map_wps = map_wp.next(2.0)
+                    if map_wps:
+                        new_waypoints.append(map_wps[0].transform)
+                        map_wp = map_wps[0]
+                    else:
+                        break
+
+                actor_dict[self._actor.id].update_waypoints(new_waypoints, start_time=self._start_time)
+
         else:
             self._pos_before_lane_change = current_position_actor.transform.location
 

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -1041,7 +1041,7 @@ class OpenScenarioParser(object):
                             lat_maneuver.find("LaneChangeActionDynamics").attrib.get('value', float("inf")))
                     atomic = ChangeActorLateralMotion(actor, direction=direction,
                                                       distance_lane_change=distance,
-                                                      distance_other_lane=1000,
+                                                      distance_other_lane=10,
                                                       lane_changes=lane_changes,
                                                       name=maneuver_name)
                 elif private_action.find('LaneOffsetAction') is not None:

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -491,7 +491,7 @@ class OpenScenarioParser(object):
                         actor_transform = obj_actor.get_transform()
                         break
 
-            if obj_actor is None:
+            if obj_actor is None or actor_transform is None:
                 raise AttributeError("Object '{}' provided as position reference is not known".format(obj))
 
             # calculate orientation h, p, r
@@ -590,7 +590,8 @@ class OpenScenarioParser(object):
             is_absolute = True
             waypoint = CarlaDataProvider.get_map().get_waypoint_xodr(road_id, lane_id, s)
             if waypoint is None:
-                raise AttributeError("Lane position cannot be found")
+                raise AttributeError("Lane position 'roadId={}, laneId={}, s={}, offset={}' does not exist".format(
+                    road_id, lane_id, s, offset))
 
             transform = waypoint.transform
             if lane_pos.find('Orientation') is not None:


### PR DESCRIPTION
Fixes #727 

Past behavior:
A lane change in OSC was always set to cover 1000m, if there was no proper end condition set.

New behavior:
A lane change in OSC covers now only 10m on the new lane. To avoid that a vehicle stops immediately after, the behavior returns with success but provides waypoints for another 200 meters to allow the vehicle to continue moving.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **CARLA version:** 0.9.11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/741)
<!-- Reviewable:end -->
