### PR TITLE
Improved reloading of OpenDRIVE maps in OSC

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -16,6 +16,7 @@
     - Added `--openscenarioparams` argument to overwrite global `ParameterDeclaration`
     - Added controller using CARLA's autopilot (in replacement for ActivateControllerAction)
     - Added support for storyboards with multiple stories
+    - Eliminated unnecessary reloads of OpenDRIVE maps
 * Additional Scenarios:
     - Added Construction setup scenario.
 ### :bug: Bug Fixes

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -87,12 +87,11 @@ class ScenarioRunner(object):
         # requests in the localhost at port 2000.
         self.client = carla.Client(args.host, int(args.port))
         self.client.set_timeout(self.client_timeout)
-
-        self.traffic_manager = self.client.get_trafficmanager(int(self._args.trafficManagerPort))
+        CarlaDataProvider.set_client(self.client)
 
         dist = pkg_resources.get_distribution("carla")
-        if LooseVersion(dist.version) < LooseVersion('0.9.10'):
-            raise ImportError("CARLA version 0.9.10 or newer required. CARLA version found: {}".format(dist))
+        if LooseVersion(dist.version) < LooseVersion('0.9.11'):
+            raise ImportError("CARLA version 0.9.11 or newer required. CARLA version found: {}".format(dist))
 
         # Load agent if requested via command line args
         # If something goes wrong an exception will be thrown by importlib (ok here)
@@ -177,6 +176,7 @@ class ScenarioRunner(object):
                 settings.synchronous_mode = False
                 settings.fixed_delta_seconds = None
                 self.world.apply_settings(settings)
+                self.client.get_trafficmanager(int(self._args.trafficManagerPort)).set_synchronous_mode(False)
             except RuntimeError:
                 sys.exit(-1)
 
@@ -326,19 +326,14 @@ class ScenarioRunner(object):
             settings.synchronous_mode = True
             settings.fixed_delta_seconds = 1.0 / self.frame_rate
             self.world.apply_settings(settings)
-
-            self.traffic_manager.set_synchronous_mode(True)
-            self.traffic_manager.set_random_device_seed(int(self._args.trafficManagerSeed))
-
-        CarlaDataProvider.set_client(self.client)
         CarlaDataProvider.set_world(self.world)
-        CarlaDataProvider.set_traffic_manager_port(int(self._args.trafficManagerPort))
 
         # Wait for the world to be ready
         if CarlaDataProvider.is_sync_mode():
             self.world.tick()
         else:
             self.world.wait_for_tick()
+
         if CarlaDataProvider.get_map().name != town and CarlaDataProvider.get_map().name != "OpenDriveMap":
             print("The CARLA server uses the wrong map: {}".format(CarlaDataProvider.get_map().name))
             print("This scenario requires to use map: {}".format(town))
@@ -365,6 +360,12 @@ class ScenarioRunner(object):
                 print("Could not setup required agent due to {}".format(e))
                 self._cleanup()
                 return False
+
+        CarlaDataProvider.set_traffic_manager_port(int(self._args.trafficManagerPort))
+        tm = self.client.get_trafficmanager(int(self._args.trafficManagerPort))
+        tm.set_random_device_seed(int(self._args.trafficManagerSeed))
+        if self._args.sync:
+            tm.set_synchronous_mode(True)
 
         # Prepare scenario
         print("Preparing scenario: " + config.name)
@@ -597,6 +598,8 @@ def main():
     try:
         scenario_runner = ScenarioRunner(arguments)
         result = scenario_runner.run()
+    except Exception:   # pylint: disable=broad-except
+        traceback.print_exc()
 
     finally:
         if scenario_runner is not None:

--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -170,25 +170,45 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
         world = self.client.get_world()
         wmap = None
         if world:
+            world.get_settings()
             wmap = world.get_map()
 
         if world is None or (wmap is not None and wmap.name != self.town):
             if ".xodr" in self.town:
                 with open(self.town) as od_file:
                     data = od_file.read()
+                index = data.find('<OpenDRIVE>')
+                data = data[index:]
+
                 old_map = ""
                 if wmap is not None:
                     old_map = wmap.to_opendrive()
+                    index = old_map.find('<OpenDRIVE>')
+                    old_map = old_map[index:]
+
                 if data != old_map:
                     self.logger.warning(" Wrong OpenDRIVE map in use. Forcing reload of CARLA world")
-                    self.client.generate_opendrive_world(str(data))
-                    world = self.client.get_world()
+
+                    vertex_distance = 2.0  # in meters
+                    wall_height = 1.0      # in meters
+                    extra_width = 0.6      # in meters
+                    world = self.client.generate_opendrive_world(str(data),
+                                                                 carla.OpendriveGenerationParameters(
+                                                                 vertex_distance=vertex_distance,
+                                                                 wall_height=wall_height,
+                                                                 additional_width=extra_width,
+                                                                 smooth_junctions=True,
+                                                                 enable_mesh_visibility=True))
             else:
                 self.logger.warning(" Wrong map in use. Forcing reload of CARLA world")
                 self.client.load_world(self.town)
                 world = self.client.get_world()
+
             CarlaDataProvider.set_world(world)
-            world.wait_for_tick()
+            if CarlaDataProvider.is_sync_mode():
+                world.tick()
+            else:
+                world.wait_for_tick()
         else:
             CarlaDataProvider.set_world(world)
 


### PR DESCRIPTION
Before enforcing a reload of the CARLA map when using OpenSCENARIO
the currently loaded map is compared with the new map. This comparison
was reworked to enforce that both maps start with the '<OpenDRIVE>' start tag:
- Perform map string comparison only for content after <OpenDRIVE> tag
- Load OpenDRIVE map using vertex_distance etc. parameters

Reworked handling of TrafficManager inside ScenarioRunner to improve
startup time:
- Moved TrafficManager code from constructor to _load_and_run_scenario after updating the world

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/752)
<!-- Reviewable:end -->
