### PR TITLE
Updated watchdog

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -26,6 +26,8 @@
 * Extended SimpleVehicleController (OSC) to handle traffic lights
 * Generalized visualizer attached to OSC controllers
 * Fixed bug at the Getting Started docs which caused an import error
+* Improved the watchdog. It can now be paused, resumed and uses the same thread, instead of opening and closing new ones each frame.
+* Added `simple-watchdog-timer` library to the requirements, as it is used by the new watchdog.
 
 ## CARLA ScenarioRunner 0.9.11
 ### :rocket: New Features

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ opencv-python==4.2.0.32
 numpy
 matplotlib
 six
+simple-watchdog-timer

--- a/srunner/scenariomanager/scenario_manager.py
+++ b/srunner/scenariomanager/scenario_manager.py
@@ -195,6 +195,8 @@ class ScenarioManager(object):
         """
         This function is used by the overall signal handler to terminate the scenario execution
         """
+        if self._watchdog and not self._watchdog.get_status():
+            self._watchdog.stop()
         self._running = False
 
     def analyze_scenario(self, stdout, filename, junit, json):

--- a/srunner/scenariomanager/watchdog.py
+++ b/srunner/scenariomanager/watchdog.py
@@ -11,7 +11,7 @@ It is for example used in the ScenarioManager
 """
 from __future__ import print_function
 
-from threading import Timer
+import simple_watchdog_timer as swt
 try:
     import thread
 except ImportError:
@@ -19,61 +19,63 @@ except ImportError:
 
 
 class Watchdog(object):
-
     """
     Simple watchdog timer to detect timeouts
 
     Args:
-        timeout (float): Timeout value of the watchdog [seconds].
-            If it is not reset before exceeding this value, a KayboardInterrupt is raised.
+        timeout (float): Timeout value of the watchdog [seconds]. If triggered, raises a KeyboardInterrupt.
+        interval (float): Time between timeout checks [seconds]. Defaults to 1% of the timeout.
 
     Attributes:
         _timeout (float): Timeout value of the watchdog [seconds].
-        _failed (bool):   True if watchdog exception occured, false otherwise
+        _interval (float): Time between timeout checks [seconds].
+        _failed (bool): True if watchdog exception occured, false otherwise
     """
 
-    def __init__(self, timeout=1.0):
-        """
-        Class constructor
-        """
-        self._timeout = timeout + 1.0  # Let's add one second here to avoid overlap with other CARLA timeouts
+    def __init__(self, timeout=1.0, interval=None):
+        """Class constructor"""
+        self._watchdog = None
+        self._timeout = timeout + 1.0
+        self._interval = interval if interval is not None else self._timeout / 100
         self._failed = False
-        self._timer = None
 
     def start(self):
-        """
-        Start the watchdog
-        """
-        self._timer = Timer(self._timeout, self._event)
-        self._timer.daemon = True
-        self._timer.start()
-
-    def update(self):
-        """
-        Reset watchdog.
-        """
-        self.stop()
-        self.start()
-
-    def _event(self):
-        """
-        This method is called when the timer triggers. A KayboardInterrupt
-        is generated on the main thread and the watchdog is stopped.
-        """
-        print('Watchdog exception - Timeout of {} seconds occured'.format(self._timeout))
-        self._failed = True
-        self.stop()
-        thread.interrupt_main()
+        """Start the watchdog"""
+        self._watchdog = swt.WDT(
+            check_interval_sec=self._interval,
+            trigger_delta_sec=self._timeout,
+            callback=self._callback
+        )
 
     def stop(self):
-        """
-        Stops the watchdog.
-        """
-        self._timer.cancel()
+        """Stop the watchdog"""
+        if self._watchdog is not None:
+            self.resume()  # If not resumed, the stop will block. Does nothing if already resumed
+            self._watchdog.stop()
+
+    def pause(self):
+        """Pause the watchdog"""
+        if self._watchdog is not None:
+            self._watchdog.pause()
+
+    def resume(self):
+        """Resume the watchdog."""
+        if self._watchdog is not None:
+            self._watchdog.resume()
+
+    def update(self):
+        """Reset the watchdog."""
+        if self._watchdog is not None:
+            self._watchdog.update()
+
+    def _callback(self, watchdog):
+        """Method called when the timer triggers. Raises a KeyboardInterrupt on
+        the main thread and stops the watchdog."""
+        self.pause()  # Good practice to stop it after the event occurs
+        print('Watchdog exception - Timeout of {} seconds occured'.format(self._timeout))
+        self._failed = True
+        thread.interrupt_main()
 
     def get_status(self):
-        """
-        returns:
-           bool:  False if watchdog exception occured, True otherwise
-        """
+        """returns False if watchdog exception occured, True otherwise"""
         return not self._failed


### PR DESCRIPTION
### Description

The watchdog has been improved:
- It can now be paused and resumed
- The old watchdog's *update* method closed the current thread and started another one. That behavior has been updated so that everything is done at the same thread.
- Added checks to see if the watchdog has started before trying to manipulate it. This was causing errors when trying to stop a non-started watchdog. 

Other changes:
- Added [`simple-watchdog-timer`](https://github.com/hjortlund/simple_watchdog_timer) to the requirements, as it is the library used to implement the new watchdog
- Removed unused function `get_running_status()` at *scenario_manager.py*.
- `stop_scenario()` at *scenario_manager.py* now, if needed, additionally stops the watchdog (needed due to the new watchdog behavior).

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA's 4.26
  * **CARLA version:** 0.9.11 (current dev)

### Possible Drawbacks

Possible unseen behavior changes between watchdogs might arise. The new watchdog library hasn't been tried with Python 2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/754)
<!-- Reviewable:end -->
