### PR TITLE
Updated README to link Challenge to Leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ documentation.
 Challenge Evaluation
 ---------------------
 
-You can evaluate your own agents using a reproduction
-of the CARLA Challenge by following [this tutorial](Docs/challenge_evaluation.md)
+The CARLA Challenge has moved to the [CARLA Autonomous Driving Leaderboard](https://leaderboard.carla.org/). Please see the [leaderboard repository](https://github.com/carla-simulator/leaderboard) and the [getting started guide](https://leaderboard.carla.org/get_started/) for more information.
 
 Contributing
 ------------


### PR DESCRIPTION
#### Description
This change updates the `CARLA Challenge` references in the readme to correctly point to the Leaderboard website and repository.

#### Where has this been tested?

Platform(s): Ubuntu 18.04
Python version(s): 3.7
Unreal Engine version(s): 4.26
CARLA version: 0.9.11 (current dev)

#### Possible Drawbacks
None. This is a documentation correction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/763)
<!-- Reviewable:end -->
