### PR TITLE
Removed illegal escape on [] around CDATA in junit xml.

### DIFF
--- a/srunner/scenariomanager/result_writer.py
+++ b/srunner/scenariomanager/result_writer.py
@@ -250,14 +250,14 @@ class ResultOutputProvider(object):
                              "time=\"0\" classname=\"Scenarios.{}\">\n".format(
                                  testcase_name, self._data.scenario_tree.name))
             if criterion.test_status != "SUCCESS":
-                result_string += "      <failure message=\"{}\"  type=\"\"><!\[CDATA\[\n".format(
+                result_string += "      <failure message=\"{}\"  type=\"\"><![CDATA[\n".format(
                     criterion.name)
                 result_string += "  Actual:   {}\n".format(
                     criterion.actual_value)
                 result_string += "  Expected: {}\n".format(
                     criterion.expected_value_success)
                 result_string += "\n"
-                result_string += "  Exact Value: {} = {}\]\]></failure>\n".format(
+                result_string += "  Exact Value: {} = {}]]></failure>\n".format(
                     criterion.name, criterion.actual_value)
             else:
                 result_string += "  Exact Value: {} = {}\n".format(
@@ -271,14 +271,14 @@ class ResultOutputProvider(object):
                              self._data.scenario_duration_system,
                              self._data.scenario_tree.name))
         if self._data.scenario_duration_game >= self._data.scenario.timeout:
-            result_string += "      <failure message=\"{}\"  type=\"\"><!\[CDATA\[\n".format(
+            result_string += "      <failure message=\"{}\"  type=\"\"><![CDATA[\n".format(
                 "Duration")
             result_string += "  Actual:   {}\n".format(
                 self._data.scenario_duration_game)
             result_string += "  Expected: {}\n".format(
                 self._data.scenario.timeout)
             result_string += "\n"
-            result_string += "  Exact Value: {} = {}\]\]></failure>\n".format(
+            result_string += "  Exact Value: {} = {}]]></failure>\n".format(
                 "Duration", self._data.scenario_duration_game)
         else:
             result_string += "  Exact Value: {} = {}\n".format(


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [/] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [/] Extended the README / documentation, if necessary
  - [/] Code compiles correctly and runs
  - [/] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [/] Changelog is updated

-->

#### Description

The generated XML result file is ill formatted. 
I have discovered the problem when I tried to generate HTML version of results from XML generated by scenario runner. 
Input: 
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites tests="2" failures="1" disabled="0" errors="0" timestamp="2021-06-14 07:45:16" time="44.30" name="Simulation" package="Scenarios">
  <testsuite name="AsWaypointFollower_2" tests="2" failures="1" disabled="0" errors="0" time="44.30">
    <testcase name="CollisionTest_asystems.vez10_171" status="run" time="0" classname="Scenarios.AsWaypointFollower_2">
      <failure message="CollisionTest"  type=""><!\[CDATA\[
  Actual:   1
  Expected: 0

  Exact Value: CollisionTest = 1\]\]></failure>
    </testcase>
    <testcase name="Duration" status="run" time="44.29674530029297" classname="Scenarios.AsWaypointFollower_2">
  Exact Value: Duration = 74.50000111013651
    </testcase>
  </testsuite>
</testsuites>
```
Conversion code:
```python
import vjunit.vjunit
converter = vjunit.vjunit.VJunit()
converter.convert("junit-results.xml", "out.html")
```
Which resulted in:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kpawelczyk/anaconda3/envs/simulator/lib/python3.8/site-packages/vjunit/vjunit.py", line 80, in convert
    testsuites = self.parse(path)
  File "/home/kpawelczyk/anaconda3/envs/simulator/lib/python3.8/site-packages/vjunit/vjunit.py", line 22, in parse
    return self.parse_content(self._load_file(path))
  File "/home/kpawelczyk/anaconda3/envs/simulator/lib/python3.8/site-packages/vjunit/vjunit.py", line 26, in parse_content
    tree = ET.fromstring(content)
  File "/home/kpawelczyk/anaconda3/envs/simulator/lib/python3.8/xml/etree/ElementTree.py", line 1320, in XML
    parser.feed(text)
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 5, column 50
```
According to XML standard CDATA section should not have escaped square braces https://www.w3.org/TR/xml/#sec-cdata-sect.

In this MR I propose to remove escape sequence around CDATA sections. I tested such file and it was converted correctly. 

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8.5
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.11

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None that I can think of.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/765)
<!-- Reviewable:end -->
