### PR TITLE
Fixed OSC LaneOffset sign handling

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Additional Scenarios:
     - Added Construction setup scenario.
 ### :bug: Bug Fixes
+* Fixed LaneOffset (+ vs. -) for OpenSCENARIO
 * Fixed bug at the Getting Started docs which caused an import error
 * Fixed neverending lane change maneuver in OpenSCENARIO
 * Fixed bug causing the spawning of an actor with `request_new_actor` to never activate the autopilot.
@@ -31,7 +32,7 @@
 * Generalized visualizer attached to OSC controllers
 * Fixed bug at the Getting Started docs which caused an import error
 * Improved the watchdog. It can now be paused, resumed and uses the same thread, instead of opening and closing new ones each frame.
-* Added `simple-watchdog-timer` library to the requirements, as it is used by the new watchdog.
+* Added `simple-watchdog-timer` library to the requirements, as it is used by the new watchdog. This requires Python 3.x from now on!
 * Extended CarlaDataProvider's spawning functions to allow filtering the safer blueprint, and optionally tick the server
 
 ## CARLA ScenarioRunner 0.9.11

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -623,7 +623,8 @@ class OpenScenarioParser(object):
                 transform.rotation.yaw = transform.rotation.yaw + dyaw
                 transform.rotation.pitch = transform.rotation.pitch + dpitch
                 transform.rotation.roll = transform.rotation.roll + droll
-            if t < 0:
+
+            if not OpenScenarioParser.use_carla_coordinate_system:
                 # multiply -1 because unlike offset t road is -ve for right side
                 t = -1*t
             transform = get_offset_transform(transform, t)
@@ -1071,7 +1072,7 @@ class OpenScenarioParser(object):
                     lat_maneuver = private_action.find('LaneChangeAction')
                     target_lane_rel = float(lat_maneuver.find("LaneChangeTarget").find(
                         "RelativeTargetLane").attrib.get('value', 0))
-                    direction = "left" if target_lane_rel < 0 else "right"
+                    direction = "left" if target_lane_rel > 0 else "right"
                     lane_changes = abs(target_lane_rel)
                     # duration and distance
                     distance = float('inf')


### PR DESCRIPTION
#Fixes #767

@sagar-g-v : I think changing the sign only for t < 0 is not correct, and has to be inverted always when using an common XODR coordinate system. Do you agree?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/771)
<!-- Reviewable:end -->
