### PR TITLE
add int() around id to make eq work in traffic_light identifier when reading from openscenario

### DIFF
--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -124,7 +124,7 @@ class OpenScenarioParser(object):
 
         # Given by id
         if name.startswith("id="):
-            tl_id = name[3:]
+            tl_id = int(name[3:])
             for carla_tl in CarlaDataProvider.get_world().get_actors().filter('traffic.traffic_light'):
                 if carla_tl.id == tl_id:
                     traffic_light = carla_tl


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

-->

#### Description
Simple fix to make sure that traffic_lights can be read using the id as well as positions. The code was checking equality between int (returned by the actor.id) and string and therefore not working correctly. Added the conversion of the id form the osc to int rather than string. 

<!-- Please explain the changes you made here as detailed as possible. -->
I just added int() around the traffic_light_id (tf_id) from the osc file.

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s): ubuntu 18.04**
  * **Python version(s): 3.7.5**
  * **Unreal Engine version(s):4.24**
  * **CARLA version:0.9.11**

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/774)
<!-- Reviewable:end -->
