### PR TITLE
Add more parameters

### DIFF
--- a/manual_control.py
+++ b/manual_control.py
@@ -163,6 +163,9 @@ def game_loop(args):
             client.stop_recorder()
 
         if world is not None:
+            # prevent destruction of ego vehicle
+            if args.keep_ego_vehicle:
+                world.player = None
             world.destroy()
 
         pygame.quit()
@@ -206,6 +209,10 @@ def main():
         metavar='NAME',
         default='hero',
         help='role name of ego vehicle to control (default: "hero")')
+    argparser.add_argument(
+        '--keep_ego_vehicle',
+        action='store_true',
+        help='do not destroy ego vehicle on exit')
     args = argparser.parse_args()
 
     args.filter = "vehicle.*"   # Needed for CARLA version

--- a/manual_control.py
+++ b/manual_control.py
@@ -101,7 +101,7 @@ class WorldSR(World):
             time.sleep(1)
             possible_vehicles = self.world.get_actors().filter('vehicle.*')
             for vehicle in possible_vehicles:
-                if vehicle.attributes['role_name'] == "hero":
+                if vehicle.attributes['role_name'] == self.actor_role_name:
                     print("Ego vehicle found")
                     self.player = vehicle
                     break
@@ -201,9 +201,13 @@ def main():
         metavar='WIDTHxHEIGHT',
         default='1280x720',
         help='window resolution (default: 1280x720)')
+    argparser.add_argument(
+        '--rolename',
+        metavar='NAME',
+        default='hero',
+        help='role name of ego vehicle to control (default: "hero")')
     args = argparser.parse_args()
 
-    args.rolename = 'hero'      # Needed for CARLA version
     args.filter = "vehicle.*"   # Needed for CARLA version
     args.gamma = 2.2   # Needed for CARLA version
     args.width, args.height = [int(x) for x in args.res.split('x')]


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated

-->

#### Description

I added two more arguments to `manual_control.py`:
- `--rolename`
- `--keep_ego_vehicle`

The `rolename` argument can be used to search for ego vehicles with role names other than `hero`. This is especially required when running the scenario runner with the arguments `--waitForEgo` and `--openscenario`: this specific setting only works if the already existing vehicle has the role name `ego_vehicle` (instead of `hero`) and if the corresponding entity in the XOSC file is called `ego_vehicle` (`<ScenarioObject name="ego_vehicle">...</ScenarioObject>`).

 
The `keep_ego_vehicle` argument can be set in order to prevent the destruction of the ego vehicle after the termination of the `manual_control.py` script.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.11

#### Possible Drawbacks
None

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/786)
<!-- Reviewable:end -->
