### PR TITLE
Fixed rotation when using relative road position

### DIFF
--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -603,7 +603,7 @@ class OpenScenarioParser(object):
                 transform.rotation.yaw = yaw
                 transform.rotation.pitch = pitch
                 transform.rotation.roll = roll
-                transform = get_offset_transform(waypoint.transform, target_t)
+                transform = get_offset_transform(transform, target_t)
 
             return transform
 


### PR DESCRIPTION
#### Description

Fixed bug that ignores orientation provided by OpenScenario file for RelativeRoadPosition.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 2.7.17
  * **CARLA version:** 0.9.11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/806)
<!-- Reviewable:end -->
