### PR TITLE
Fixed repetition crash

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ## Latest changes
 
+### :bug: Bug Fixes
+* Fixed a bug with repetitions / scenario groups causing the simulation to crash after the second one.
+
 ## CARLA ScenarioRunner 0.9.12
 ### :rocket: New Features
 * OpenSCENARIO support:

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -447,6 +447,7 @@ class ScenarioRunner(object):
         # Execute each configuration
         for config in scenario_configurations:
             for _ in range(self._args.repetitions):
+                self.finished = False
                 result = self._load_and_run_scenario(config)
 
             self._cleanup()


### PR DESCRIPTION
### Description

The *finished* attribute was added to avoid multiple cleanups of the simulation. However, this parameter wasn't being reset on repetitions, causing them to crash if 3 or more were run

Fixes #798

#### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.26
  * **CARLA version:** 0.9.12

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/812)
<!-- Reviewable:end -->
