### PR TITLE
Runscript fix

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### :bug: Bug Fixes
 * Fixed bug at OtherLeadingVehicle scenario causing the vehicles to move faster than intended
 * Fixed bug causing some debris at ControlLoss scenario to be floating, instead of at ground level
+* Fixed bug causing OpenScenario UserDefinedCommand subprocess runner to exit before executing script  
 
 ## CARLA ScenarioRunner 0.9.13
 ### :rocket: New Features

--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -181,7 +181,13 @@ class RunScript(AtomicBehavior):
             new_status = py_trees.common.Status.FAILURE
             print("Script file does not exists {}".format(path))
         else:
-            subprocess.Popen(self._script, shell=True, cwd=self._base_path)  # pylint: disable=consider-using-with
+            process = subprocess.Popen(self._script, shell=True, cwd=self._base_path)  # pylint: disable=consider-using-with
+            
+            while process.poll() is None:
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    print("Waiting for user defined command to complete...")
             new_status = py_trees.common.Status.SUCCESS
 
         self.logger.debug("%s.update()[%s->%s]" % (self.__class__.__name__, self.status, new_status))


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ X] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ X] Extended the README / documentation, if necessary
  - [ X] Code compiles correctly and runs
  - [X ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [X] Changelog is updated

-->

#### Description

OpenScenario UserDefinedCommand is executed by atomic_behaviors.py RunScript. The script given by the user is executed as a python subprocess using Popen. The behavior this far has been that RunScript.update() returns a py_trees.common.Status.SUCCESS directly after Popen() is called. This causes scripts not running as daemon to exit before completion.

This fix makes RunScript to wait for the user provided script to finish before returning a SUCCESS status. If needed, the earlier behavior can be replicated by setting the user defined script to run as daemon. This fix enables making scenario execution conditional on user defined scripts.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** 4.26
  * **CARLA version:** 0.9.12

#### Possible Drawbacks

User defined scripts have to be explicitly specified to run as daemon if that is desired behavior, unlike before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/850)
<!-- Reviewable:end -->
