### PR TITLE
Added scenario timeouts

### DIFF
--- a/srunner/scenariomanager/timer.py
+++ b/srunner/scenariomanager/timer.py
@@ -165,7 +165,7 @@ class RouteTimeoutBehavior(py_trees.behaviour.Behaviour):
     it increases every time the agent advanced through the route, and is dependent on the road's speed.
     """
     MIN_TIMEOUT = 180
-    TIMEOUT_ROUTE_PERC = 25
+    TIMEOUT_ROUTE_PERC = 15
 
     def __init__(self, ego_vehicle, route, debug=False, name="RouteTimeoutBehavior"):
         """

--- a/srunner/scenariomanager/traffic_events.py
+++ b/srunner/scenariomanager/traffic_events.py
@@ -32,6 +32,7 @@ class TrafficEventType(Enum):
     VEHICLE_BLOCKED = 13
     MIN_SPEED_INFRACTION = 14
     YIELD_TO_EMERGENCY_VEHICLE = 15
+    SCENARIO_TIMEOUT = 16
 
 
 class TrafficEvent(object):


### PR DESCRIPTION
### Description

Some of the new scenario could block the ego forever. A timeout has been added to their behavior tree that, after a set amount of time, will stop the scenario, allowing the ego to continue, but penalising the stack, reducing its score (at the Leaderboard).

These scenarios are:
- The `ParkingExit`
- Obstacle scenario that require a lane change (i.e `Accident`, `Construction`, ...)
- Junction scenarios with actor flows (`CrossingBicycleFlow`, `SignalizedJucntionLeftTurn`, ...)
- Highway entry / exits (`EnterActorFlow`, `HighwayExit`, ...)

### Where has this been tested?

  * **Platform(s):** Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA's
  * **CARLA version:** dev

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/917)
<!-- Reviewable:end -->
