### PR TITLE
Minor changes to OutsideRouteLanes event

### DIFF
--- a/srunner/scenariomanager/traffic_events.py
+++ b/srunner/scenariomanager/traffic_events.py
@@ -63,6 +63,10 @@ class TrafficEvent(object):
         """return the frame"""
         return self._frame
 
+    def set_frame(self, frame):
+        """return the frame"""
+        self._frame = frame
+
     def set_message(self, message):
         """Set message"""
         self._message = message


### PR DESCRIPTION
### Description

With the addition of live results at the LB, the OutsideRouteLanesTest has been modified to have its traffic event track its value on realtime, instead of being created at the end. The behavior remains unchanged

### Where has this been tested?

  * **Platform(s):** Ubutnu18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** CARLA's 
  * **CARLA version:** dev

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/920)
<!-- Reviewable:end -->
