### PR TITLE
Feature/add waypoint reached threshold

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Minor improvements to some example scenarios. These include FollowLeadingVehicle, VehicleTurning, DynamicObjectCrossing and SignalizedJunctionRightTurn and RunningRedLight. Their behaviors are now more smooth, robust and some outdated mechanics have been removed
 * SignalizedJunctionLeftTurn has been remade. It now has an actor flow on which the ego has to merge into, instead of a single vehicle.
 * The BackgroundActivity has been readded to the routes, which the objective of creating the sensation of traffic around the ego
+* Add waypoint reached threshold so that the precision of the actor reaching to waypoints can be adjusted based on object types.
 
 ### :bug: Bug Fixes
 * Fixed bug at OtherLeadingVehicle scenario causing the vehicles to move faster than intended

--- a/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
+++ b/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
@@ -51,8 +51,8 @@ class SimpleVehicleControl(BasicControl):
                            May include: (consider_obstacles, true/false)     - Enable consideration of obstacles
                                         (proximity_threshold, distance)      - Distance in front of actor in which
                                                                                obstacles are considered
-                                        (waypoint_reached_threshold, distance) - Distance between actor and waypoint 
-                                                                               determining reached or not                               
+                                        (waypoint_reached_threshold, distance) - Distance between actor and waypoint
+                                                                               determining reached or not
                                         (consider_trafficlights, true/false) - Enable consideration of traffic lights
                                         (max_deceleration, float)            - Use a reasonable deceleration value for
                                                                                this vehicle
@@ -72,7 +72,7 @@ class SimpleVehicleControl(BasicControl):
             Defaults to False.
         _proximity_threshold (float): Distance in front of actor in which obstacles are considered
             Defaults to infinity.
-        _waypoint_reached_threshold(float): Distance between actor and waypoint determining reached or not 
+        _waypoint_reached_threshold(float): Distance between actor and waypoint determining reached or not
             Defaults to 4.0 meters.
         _cv_image (CV Image): Contains the OpenCV image, in case a debug camera is attached to the actor
             Defaults to None.

--- a/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
+++ b/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
@@ -93,6 +93,7 @@ class SimpleVehicleControl(BasicControl):
         self._consider_traffic_lights = False
         self._consider_obstacles = False
         self._proximity_threshold = float('inf')
+        self._waypoint_reached_threshold = 4.0
         self._max_deceleration = None
         self._max_acceleration = None
 
@@ -119,6 +120,9 @@ class SimpleVehicleControl(BasicControl):
 
         if args and 'consider_trafficlights' in args and strtobool(args['consider_trafficlights']):
             self._consider_traffic_lights = strtobool(args['consider_trafficlights'])
+
+        if args and 'waypoint_reached_threshold' in args:
+            self._waypoint_reached_threshold = float(args['waypoint_reached_threshold'])
 
         if args and 'max_deceleration' in args:
             self._max_deceleration = float(args['max_deceleration'])
@@ -217,7 +221,7 @@ class SimpleVehicleControl(BasicControl):
                 self._reached_goal = True
             else:
                 direction_norm = self._set_new_velocity(self._offset_waypoint(self._waypoints[0]))
-                if direction_norm < 4.0:
+                if direction_norm < self._waypoint_reached_threshold:
                     self._waypoints = self._waypoints[1:]
                     if not self._waypoints:
                         self._reached_goal = True

--- a/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
+++ b/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
@@ -51,6 +51,8 @@ class SimpleVehicleControl(BasicControl):
                            May include: (consider_obstacles, true/false)     - Enable consideration of obstacles
                                         (proximity_threshold, distance)      - Distance in front of actor in which
                                                                                obstacles are considered
+                                        (waypoint_reached_threshold, distance) - Distance between actor and waypoint 
+                                                                               determining reached or not                               
                                         (consider_trafficlights, true/false) - Enable consideration of traffic lights
                                         (max_deceleration, float)            - Use a reasonable deceleration value for
                                                                                this vehicle
@@ -70,6 +72,8 @@ class SimpleVehicleControl(BasicControl):
             Defaults to False.
         _proximity_threshold (float): Distance in front of actor in which obstacles are considered
             Defaults to infinity.
+        _waypoint_reached_threshold(float): Distance between actor and waypoint determining reached or not 
+            Defaults to 4.0 meters.
         _cv_image (CV Image): Contains the OpenCV image, in case a debug camera is attached to the actor
             Defaults to None.
         _camera (sensor.camera.rgb): Debug camera attached to actor


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Previously, when the waypoints are predefined, there is a unified waypoint reached threshold for all kinds of road users, which is 4 meters. In this case, some actors (eg. bicycle) will perform drifting when following the predefined waypoints.
In order to fulfill the requirements of different objects and scenarios (eg. driving slow and precisely following the waypoints when in small and crowd road), an argument waypoint_reached_threshold is added for simple_vehicle_control.py with 4.0 meters as default and able to be adjusted manually in OpenSCENARIO files. 


Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Python version(s):** 3.8.10
  * **Unreal Engine version(s):** 4.24.3
  * **CARLA version:** 0.9.13

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/940)
<!-- Reviewable:end -->
