### PR TITLE
fixed the problem of rolename argument not in use in manual_control.py

### DIFF
--- a/manual_control.py
+++ b/manual_control.py
@@ -127,6 +127,7 @@ class World(object):
             sys.exit(1)
         self.hud = hud
         self.player = None
+        self.rolename = args.rolename
         self.collision_sensor = None
         self.lane_invasion_sensor = None
         self.gnss_sensor = None
@@ -157,7 +158,7 @@ class World(object):
             time.sleep(1)
             possible_vehicles = self.world.get_actors().filter('vehicle.*')
             for vehicle in possible_vehicles:
-                if vehicle.attributes['role_name'] == 'hero':
+                if vehicle.attributes['role_name'] == self.rolename:
                     print("Ego vehicle found")
                     self.player = vehicle
                     break


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixed the problem of not using the `rolename` argument passed by command line when finding Ego vehicle. This is useful when a scenario has more than one ego vehicle and you want to manually control one of them.

#  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Windows 11 22H2
  * **Python version(s):** 3.8.15
  * **Unreal Engine version(s):** 4.24
  * **CARLA version:** 0.9.13

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/960)
<!-- Reviewable:end -->
