### PR TITLE
Fix for OpenDrive maps with schema argument

### DIFF
--- a/srunner/scenarioconfigs/openscenario_configuration.py
+++ b/srunner/scenarioconfigs/openscenario_configuration.py
@@ -177,13 +177,13 @@ class OpenScenarioConfiguration(ScenarioConfiguration):
             if ".xodr" in self.town:
                 with open(self.town, 'r', encoding='utf-8') as od_file:
                     data = od_file.read()
-                index = data.find('<OpenDRIVE>')
+                index = data.find('<OpenDRIVE')
                 data = data[index:]
 
                 old_map = ""
                 if wmap is not None:
                     old_map = wmap.to_opendrive()
-                    index = old_map.find('<OpenDRIVE>')
+                    index = old_map.find('<OpenDRIVE')
                     old_map = old_map[index:]
 
                 if data != old_map:


### PR DESCRIPTION

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->
Using OpenDrive maps with the schema argument in the root element <OpenDRIVE> could not been read. 


#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04, Ubuntu 18.04
  * **Python version(s):** 3.6
  * **Unreal Engine version(s):** 4.26 
  * **CARLA version:** 0.9.13

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Theoretical it would allow multiple arguments or a missing  ">"  and could be better solved with a regex but not sure if that would be overkill.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/967)
<!-- Reviewable:end -->
