### PR TITLE
Backward compatible upgrade to fix deprecation warnings concerning LooseVersion and pkg_resources for Python3.8+

### DIFF
--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -20,7 +20,7 @@ import traceback
 import argparse
 from argparse import RawTextHelpFormatter
 from datetime import datetime
-from distutils.version import LooseVersion
+from packaging.version import Version
 import importlib
 import inspect
 import os
@@ -28,7 +28,7 @@ import signal
 import sys
 import time
 import json
-import pkg_resources
+from importlib.metadata import metadata
 
 import carla
 
@@ -92,9 +92,9 @@ class ScenarioRunner(object):
         # requests in the localhost at port 2000.
         self.client = carla.Client(args.host, int(args.port))
         self.client.set_timeout(self.client_timeout)
-        dist = pkg_resources.get_distribution("carla")
-        if LooseVersion(dist.version) < LooseVersion('0.9.15'):
-            raise ImportError("CARLA version 0.9.15 or newer required. CARLA version found: {}".format(dist))
+        md = metadata("carla")
+        if Version(md["Version"]) < Version('0.9.15'):
+            raise ImportError("CARLA version 0.9.15 or newer required. CARLA version found: {}".format(md["Version"]))
 
         # Load agent if requested via command line args
         # If something goes wrong an exception will be thrown by importlib (ok here)

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -20,7 +20,10 @@ import traceback
 import argparse
 from argparse import RawTextHelpFormatter
 from datetime import datetime
-from packaging.version import Version
+try:
+    from packaging.version import Version
+except ImportError:
+    from distutils.version import LooseVersion as Version # Python 2 fallback
 import importlib
 import inspect
 import os
@@ -28,21 +31,17 @@ import signal
 import sys
 import time
 import json
+
 try:
     # requires Python 3.8+
     from importlib.metadata import metadata
-    def assert_min_carla_version(v='0.9.15'):
-        md = metadata("carla")
-        if Version(md["Version"]) < Version(v):
-            raise ImportError("CARLA version {} or newer required. CARLA version found: {}".format(v, md["Version"]))
+    def get_carla_version():
+        return Version(metadata("carla")["Version"])
 except ModuleNotFoundError:
-    # backport checking for older Python versions
+    # backport checking for older Python versions; module is deprecated
     import pkg_resources
-    def assert_min_carla_version(v='0.9.15'):
-        dist = pkg_resources.get_distribution("carla")
-        if Version(dist.version) < Version(v):
-            raise ImportError("CARLA version {} or newer required. CARLA version found: {}".format(v, dist))
-    
+    def get_carla_version():
+        return Version(pkg_resources.get_distribution("carla").version)
 
 import carla
 
@@ -59,6 +58,9 @@ from srunner.scenarioconfigs.osc2_scenario_configuration import OSC2ScenarioConf
 
 # Version of scenario_runner
 VERSION = '0.9.13'
+
+# Minimum version of CARLA that is required
+MIN_CARLA_VERSION = '0.9.15'
 
 
 class ScenarioRunner(object):
@@ -106,7 +108,9 @@ class ScenarioRunner(object):
         # requests in the localhost at port 2000.
         self.client = carla.Client(args.host, int(args.port))
         self.client.set_timeout(self.client_timeout)
-        assert_min_carla_version('0.9.15')
+        carla_version = get_carla_version()
+        if carla_version < Version(MIN_CARLA_VERSION):
+            raise ImportError("CARLA version {} or newer required. CARLA version found: {}".format(MIN_CARLA_VERSION, carla_version))
 
         # Load agent if requested via command line args
         # If something goes wrong an exception will be thrown by importlib (ok here)

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -28,7 +28,21 @@ import signal
 import sys
 import time
 import json
-from importlib.metadata import metadata
+try:
+    # requires Python 3.8+
+    from importlib.metadata import metadata
+    def assert_min_carla_version(v='0.9.15'):
+        md = metadata("carla")
+        if Version(md["Version"]) < Version(v):
+            raise ImportError("CARLA version {} or newer required. CARLA version found: {}".format(v, md["Version"]))
+except ModuleNotFoundError:
+    # backport checking for older Python versions
+    import pkg_resources
+    def assert_min_carla_version(v='0.9.15'):
+        dist = pkg_resources.get_distribution("carla")
+        if Version(dist.version) < Version(v):
+            raise ImportError("CARLA version {} or newer required. CARLA version found: {}".format(v, dist))
+    
 
 import carla
 
@@ -92,9 +106,7 @@ class ScenarioRunner(object):
         # requests in the localhost at port 2000.
         self.client = carla.Client(args.host, int(args.port))
         self.client.set_timeout(self.client_timeout)
-        md = metadata("carla")
-        if Version(md["Version"]) < Version('0.9.15'):
-            raise ImportError("CARLA version 0.9.15 or newer required. CARLA version found: {}".format(md["Version"]))
+        assert_min_carla_version('0.9.15')
 
         # Load agent if requested via command line args
         # If something goes wrong an exception will be thrown by importlib (ok here)


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated

-->

#### Description

distutils LooseVersion and pkg_resources are deprecated and not available in later python versions.
This introduces two commits fixing these deprecation for Python3.8+ while maintaining functionality for Python3.7 and before.

NOTE: Reverting the second commit removes the backward compatibility to Python3.7, as `importlib.metadata` is introduced in Python3.8.

Fixes #

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.7, 3.8, 3.10
  * **Unreal Engine version(s):** 4.26
  * **CARLA version:** 0.9.14 (fails as expected), 0.9.15

#### Possible Drawbacks

The second commit bloats the code a bit and should be reverted when python3.7 should not be supported anymore removing pkg_resources entirely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1058)
<!-- Reviewable:end -->
