### PR TITLE
Add misc type default blueprint

### DIFF
--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -596,6 +596,7 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
             'train': '',
             'tram': '',
             'pedestrian': 'walker.pedestrian.0001',
+	    'misc': 'static.prop.streetbarrier'
         }
 
         # Set the model


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->
When creating a `MiscObject`, srunner will set the default category to[misc](https://github.com/carla-simulator/scenario_runner/blob/61101a00d180409e66f6653404934f9fe82d608b/srunner/scenarioconfigs/openscenario_configuration.py#L339), and carla will enter if this object does not exist in Carla, there is no default misc blueprint object[this](https://github.com/carla-simulator/scenario_runner/blob/85109e7ce130a192d99e78a728ce5e12ea2744ca/srunner/scenariomanager/carla_data_provider.py#L465), and a 'misc key error' will be reported. So the default blueprint object corresponding to misc was added

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.7
  * **Unreal Engine version(s):** UE4
  * **CARLA version:** 0.9.15

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
