### PR TITLE
[Leaderboard 2.0] Backward compatible upgrade to fix deprecation warnings concerning LooseVersion and pkg_resources for Python3.8+ (#1058 analog)

### DIFF
--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -20,7 +20,7 @@ import traceback
 import argparse
 from argparse import RawTextHelpFormatter
 from datetime import datetime
-from distutils.version import LooseVersion
+from packaging.version import Version
 import importlib
 import inspect
 import os
@@ -28,7 +28,7 @@ import signal
 import sys
 import time
 import json
-import pkg_resources
+from importlib.metadata import metadata
 
 import carla
 
@@ -89,10 +89,9 @@ class ScenarioRunner(object):
         # requests in the localhost at port 2000.
         self.client = carla.Client(args.host, int(args.port))
         self.client.set_timeout(self.client_timeout)
-
-        dist = pkg_resources.get_distribution("carla")
-        if LooseVersion(dist.version) < LooseVersion('0.9.12'):
-            raise ImportError("CARLA version 0.9.12 or newer required. CARLA version found: {}".format(dist))
+        md = metadata("carla")
+        if Version(md["Version"]) < Version('0.9.12'):
+            raise ImportError("CARLA version 0.9.12 or newer required. CARLA version found: {}".format(md["Version"]))
 
         # Load agent if requested via command line args
         # If something goes wrong an exception will be thrown by importlib (ok here)


### PR DESCRIPTION
This is is slight modification of #1058 for the leaderboard-2.0 branch with adjustments for Carla 0.9.12.

---

#### Description

distutils LooseVersion and pkg_resources are deprecated and not available in later python versions.
This introduces two commits fixing these deprecation for Python3.8+ while maintaining functionality for Python3.7.

NOTE: Reverting the second commit removes the backward compatibility to Python3.7, as `importlib.metadata` is introduced in Python3.8.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** 3.7, 3.8, 3.10
  * **Unreal Engine version(s):** 4.26
  * **CARLA version:** 0.9.14 (fails as expected), 0.9.15

#### Possible Drawbacks

The second commit bloats the code a bit and should be reverted when python3.7 should not be supported anymore removing pkg_resources entirely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1065)
<!-- Reviewable:end -->
