### PR TITLE
[Feature] Blueprint-based spawn_actor function for CarlaDataProvider

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -12,6 +12,10 @@
 * [CARLA ScenarioRunner 0.9.5](#carla-scenariorunner-095)
 * [CARLA ScenarioRunner 0.9.2](#carla-scenariorunner-092)
 
+## Upcoming
+* Improvements to the CarlaDataProvider:
+ - Added `spawn_actor` for a blueprint based actor creation similar to `World.spawn_actor`
+
 ## CARLA ScenarioRunner 0.9.15
 ### :rocket: New Features
 * Add waypoint reached threshold so that the precision of the actor reaching to waypoints can be adjusted based on object types.

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -683,7 +683,7 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
     def spawn_actor(bp, spawn_point, must_spawn=False, track_physics=None, attach_to=None, attachment_type=carla.AttachmentType.Rigid):
         # type: (carla.ActorBlueprint, carla.Waypoint | carla.Transform, bool, bool | None, carla.Actor | None, carla.AttachmentType) -> carla.Actor | None
         """
-        The method will create, return and spawn an actor into the world. 
+        The method will spawn and return an actor.
         The actor will need an available blueprint to be created.
         It can also be attached to a parent with a certain attachment type. 
 
@@ -694,12 +694,12 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
                 If True, the actor will be spawned or an exception will be raised.
                 If False, the function returns None if the actor could not be spawned.
                 Defaults to False.
-            track_physics (bool, optional): 
+            track_physics (bool | None, optional): 
                 If True, `get_location`, `get_transform` and `get_velocity` 
                 can be used for this actor.
                 If None, the actor will be tracked if it is a Vehicle or Walker.
                 Defaults to None.
-            attach_to (Optional[carla.Actor], optional): 
+            attach_to (carla.Actor | None, optional): 
                 The parent object that the spawned actor will follow around. 
                 Defaults to None.
             attachment_type (carla.AttachmentType, optional): 

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -680,8 +680,8 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
         return actors
 
     @staticmethod
-    def spawn_actor(bp, spawn_point, must_spawn=False, track_physics=True, attach_to=None, attachment_type=carla.AttachmentType.Rigid):
-        # type: (carla.ActorBlueprint, carla.Waypoint | carla.Transform, bool, bool, carla.Actor | None, carla.AttachmentType) -> carla.Actor | None
+    def spawn_actor(bp, spawn_point, must_spawn=False, track_physics=None, attach_to=None, attachment_type=carla.AttachmentType.Rigid):
+        # type: (carla.ActorBlueprint, carla.Waypoint | carla.Transform, bool, bool | None, carla.Actor | None, carla.AttachmentType) -> carla.Actor | None
         """
         The method will create, return and spawn an actor into the world. 
         The actor will need an available blueprint to be created.
@@ -696,7 +696,9 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
                 Defaults to False.
             track_physics (bool, optional): 
                 If True, `get_location`, `get_transform` and `get_velocity` 
-                can be used for this actor. 
+                can be used for this actor.
+                If None, the actor will be tracked if it is neither a
+                Sensor nor a TrafficSign.
                 Defaults to True.
             attach_to (Optional[carla.Actor], optional): 
                 The parent object that the spawned actor will follow around. 
@@ -723,6 +725,9 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
                 return None
         # Register for cleanup
         CarlaDataProvider._carla_actor_pool[actor.id] = actor
+        if track_physics is None:
+            # Decide
+            track_physics = not isinstance(actor, (carla.Sensor, carla.TrafficSign))
         if track_physics:
             # Register for physics
             CarlaDataProvider.register_actor(actor, spawn_point)

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -680,6 +680,55 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
         return actors
 
     @staticmethod
+    def spawn_actor(bp, spawn_point, must_spawn=False, track_physics=True, attach_to=None, attachment_type=carla.AttachmentType.Rigid):
+        # type: (carla.ActorBlueprint, carla.Waypoint | carla.Transform, bool, bool, carla.Actor | None, carla.AttachmentType) -> carla.Actor | None
+        """
+        The method will create, return and spawn an actor into the world. 
+        The actor will need an available blueprint to be created.
+        It can also be attached to a parent with a certain attachment type. 
+
+        Args:
+            bp (carla.ActorBlueprint): The blueprint of the actor to spawn.
+            spawn_point (carla.Transform): The spawn point of the actor.
+            must_spawn (bool, optional): 
+                If True, the actor will be spawned or an exception will be raised.
+                If False, the function returns None if the actor could not be spawned.
+                Defaults to False.
+            track_physics (bool, optional): 
+                If True, `get_location`, `get_transform` and `get_velocity` 
+                can be used for this actor. 
+                Defaults to True.
+            attach_to (Optional[carla.Actor], optional): 
+                The parent object that the spawned actor will follow around. 
+                Defaults to None.
+            attachment_type (carla.AttachmentType, optional): 
+                Determines how fixed and rigorous should be the changes in position 
+                according to its parent object.
+                Defaults to carla.AttachmentType.Rigid.
+
+        Returns:
+            carla.Actor | None: The spawned actor if successful, None otherwise.
+            
+        Raises:
+            RuntimeError: if `must_spawn` is True and the actor could not be spawned.
+        """
+        if isinstance(spawn_point, carla.Waypoint):
+            spawn_point = spawn_point.transform
+        world = CarlaDataProvider.get_world()
+        if must_spawn:
+            actor = world.spawn_actor(bp, spawn_point, attach_to, attachment_type)
+        else:
+            actor = world.try_spawn_actor(bp, spawn_point, attach_to, attachment_type)
+            if actor is None:
+                return None
+        # Register for cleanup
+        CarlaDataProvider._carla_actor_pool[actor.id] = actor
+        if track_physics:
+            # Register for physics
+            CarlaDataProvider.register_actor(actor, spawn_point)
+        return actor
+
+    @staticmethod
     def request_new_actor(model, spawn_point, rolename='scenario', autopilot=False,
                           random_location=False, color=None, actor_category="car",
                           attribute_filter=None, tick=True):

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -697,9 +697,8 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
             track_physics (bool, optional): 
                 If True, `get_location`, `get_transform` and `get_velocity` 
                 can be used for this actor.
-                If None, the actor will be tracked if it is neither a
-                Sensor nor a TrafficSign.
-                Defaults to True.
+                If None, the actor will be tracked if it is a Vehicle or Walker.
+                Defaults to None.
             attach_to (Optional[carla.Actor], optional): 
                 The parent object that the spawned actor will follow around. 
                 Defaults to None.
@@ -727,7 +726,7 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
         CarlaDataProvider._carla_actor_pool[actor.id] = actor
         if track_physics is None:
             # Decide
-            track_physics = not isinstance(actor, (carla.Sensor, carla.TrafficSign))
+            track_physics = isinstance(actor, (carla.Vehicle, carla.Walker))
         if track_physics:
             # Register for physics
             CarlaDataProvider.register_actor(actor, spawn_point)


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x]  Changelog is updated

-->

#### Description

Currently when one wants to spawn an Actor from a blueprint this is only possibly via the World object.
There is no addition to the hidden `CarlaDataProvider._carla_actor_pool` and `CarlaDataProvider.register_actor` must be called manually.

This PR adds an analogue version, which always adds the actor to the pool for cleanup and if not specified otherwise calls register_actor on Vehicles and Walkers.

```py
def spawn_actor(bp, spawn_point, must_spawn=False, track_physics=None, attach_to=None, attachment_type=carla.AttachmentType.Rigid)
```

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** Python 3.10
  * **Unreal Engine version(s):** ...
  * **CARLA version:** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->


#### Possible Changes

Possibly favor a second `.try_spawn_actor` instead of `must_spawn=False`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1071)
<!-- Reviewable:end -->
