### PR TITLE
Fix dead actor accumulation in CDP

### DIFF
--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -1003,11 +1003,12 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
         Remove an actor from the pool using its ID
         """
         if actor_id in CarlaDataProvider._carla_actor_pool:
-            CarlaDataProvider._carla_actor_pool[actor_id].destroy()
-            CarlaDataProvider._carla_actor_pool[actor_id] = None # type: ignore
+            was_destroyed = CarlaDataProvider._carla_actor_pool[actor_id].destroy()
+            CarlaDataProvider._carla_actor_pool[actor_id] = None
             CarlaDataProvider._carla_actor_pool.pop(actor_id)
-        else:
-            print("Trying to remove a non-existing actor id {}".format(actor_id))
+            return was_destroyed
+        print("Trying to remove a non-existing actor id {}".format(actor_id))
+        return None    
 
     @staticmethod
     def remove_actors_in_surrounding(location, distance):

--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -137,18 +137,24 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
         Callback from CARLA
         """
         with CarlaDataProvider._lock:
-            for actor in CarlaDataProvider._actor_velocity_map:
+            for actor in CarlaDataProvider._actor_velocity_map.copy():
                 if actor is not None and actor.is_alive:
                     CarlaDataProvider._actor_velocity_map[actor] = calculate_velocity(actor)
+                else:
+                    del CarlaDataProvider._actor_velocity_map[actor]
 
-            for actor in CarlaDataProvider._actor_location_map:
+            for actor in CarlaDataProvider._actor_location_map.copy():
                 if actor is not None and actor.is_alive:
                     CarlaDataProvider._actor_location_map[actor] = actor.get_location()
+                else:
+                    del CarlaDataProvider._actor_location_map[actor]
 
-            for actor in CarlaDataProvider._actor_transform_map:
+            for actor in CarlaDataProvider._actor_transform_map.copy():
                 if actor is not None and actor.is_alive:
                     CarlaDataProvider._actor_transform_map[actor] = actor.get_transform()
-
+                else:
+                    del CarlaDataProvider._actor_transform_map[actor]
+            
             world = CarlaDataProvider._world
             if world is None:
                 print("WARNING: CarlaDataProvider couldn't find the world")

--- a/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
+++ b/srunner/scenariomanager/scenarioatomics/atomic_behaviors.py
@@ -3471,7 +3471,7 @@ class ActorFlow(AtomicBehavior):
                     sensor.stop()
                     sensor.destroy()
                 self._collision_sensor_list.remove(sensor)
-                actor.destroy()
+                CarlaDataProvider.remove_actor_by_id(actor.id)
                 self._actor_list.remove(actor)
 
         # Spawn new actors if needed
@@ -3519,7 +3519,7 @@ class ActorFlow(AtomicBehavior):
             actor.set_target_velocity(carla.Vector3D(0,0,0))
             actor.set_target_angular_velocity(carla.Vector3D(0,0,0))
             try:
-                actor.destroy()
+                CarlaDataProvider.remove_actor_by_id(actor.id)
             except RuntimeError:
                 pass  # Actor was already destroyed
 
@@ -3635,7 +3635,7 @@ class OppositeActorFlow(AtomicBehavior):
                 continue
             sink_distance = self._sink_location.distance(location)
             if sink_distance < self._sink_dist:
-                actor.destroy()
+                CarlaDataProvider.remove_actor_by_id(actor.id)
                 self._actor_list.remove(actor_data)
             else:
                 actor.apply_control(controller.run_step())
@@ -3668,7 +3668,7 @@ class OppositeActorFlow(AtomicBehavior):
             actor.set_target_velocity(carla.Vector3D(0,0,0))
             actor.set_target_angular_velocity(carla.Vector3D(0,0,0))
             try:
-                actor.destroy()
+                CarlaDataProvider.remove_actor_by_id(actor.id)
             except RuntimeError:
                 pass  # Actor was already destroyed
 
@@ -3750,7 +3750,7 @@ class InvadingActorFlow(AtomicBehavior):
                 continue
             sink_distance = self._sink_location.distance(location)
             if sink_distance < self._sink_dist:
-                actor.destroy()
+                CarlaDataProvider.remove_actor_by_id(actor.id)
                 self._actor_list.remove(actor_data)
             else:
                 actor.apply_control(controller.run_step())
@@ -3783,7 +3783,7 @@ class InvadingActorFlow(AtomicBehavior):
             actor.set_target_velocity(carla.Vector3D(0,0,0))
             actor.set_target_angular_velocity(carla.Vector3D(0,0,0))
             try:
-                actor.destroy()
+                CarlaDataProvider.remove_actor_by_id(actor.id)
             except RuntimeError:
                 pass  # Actor was already destroyed
 
@@ -3889,7 +3889,7 @@ class BicycleFlow(AtomicBehavior):
                 continue
             sink_distance = self._sink_location.distance(location)
             if sink_distance < self._sink_dist:
-                actor.destroy()
+                CarlaDataProvider.remove_actor_by_id(actor.id)
                 self._actor_data.remove(actor_data)
             else:
                 actor.apply_control(controller.run_step())
@@ -3926,7 +3926,7 @@ class BicycleFlow(AtomicBehavior):
             actor.set_target_velocity(carla.Vector3D(0,0,0))
             actor.set_target_angular_velocity(carla.Vector3D(0,0,0))
             try:
-                actor.destroy()
+                CarlaDataProvider.remove_actor_by_id(actor.id)
             except RuntimeError:
                 pass  # Actor was already destroyed
 
@@ -4725,7 +4725,7 @@ class WalkerFlow(AtomicBehavior):
     def _destroy_walker(self, walker, controller):
         controller.stop()
         controller.destroy()
-        walker.destroy()
+        CarlaDataProvider.remove_actor_by_id(walker.id)
 
     def terminate(self, new_status):
         """
@@ -4805,7 +4805,7 @@ class AIWalkerBehavior(AtomicBehavior):
             controller.stop()
             controller.destroy()
         if walker:
-            walker.destroy()
+            CarlaDataProvider.remove_actor_by_id(walker.id)
 
     def terminate(self, new_status):
         """

--- a/srunner/scenarios/background_activity.py
+++ b/srunner/scenarios/background_activity.py
@@ -2549,7 +2549,7 @@ class BackgroundBehavior(AtomicBehavior):
         self._remove_actor_info(actor)
         try:
             actor.set_autopilot(False, self._tm_port)
-            actor.destroy()
+            CarlaDataProvider.remove_actor_by_id(actor.id)
         except RuntimeError:
             pass
 

--- a/srunner/scenarios/basic_scenario.py
+++ b/srunner/scenarios/basic_scenario.py
@@ -171,6 +171,14 @@ class BasicScenario(object):
 
             for new_actor in new_actors:
                 self.other_actors.append(new_actor)
+                
+    def _destroy_other_actors(self):
+        """
+        Remove all actors upon deletion
+        """
+        for actor in self.other_actors:
+            if CarlaDataProvider.remove_actor_by_id(actor.id) is None:
+                actor.destroy()
 
     def _setup_scenario_trigger(self, config):
         """

--- a/srunner/scenarios/cut_in_with_static_vehicle.py
+++ b/srunner/scenarios/cut_in_with_static_vehicle.py
@@ -95,8 +95,7 @@ class StaticCutIn(BasicScenario):
             # Move to the side
             side_wp = blocker_wp.get_left_lane() if self._direction == 'left' else blocker_wp.get_right_lane()
             if not side_wp:
-                for actor in self.other_actors:
-                    actor.destroy()
+                self._destroy_other_actors()
                 raise ValueError("Couldn't find a proper position for the cut in vehicle")
 
             if i == 1:
@@ -106,8 +105,7 @@ class StaticCutIn(BasicScenario):
             blocker_actor = CarlaDataProvider.request_new_actor(
                 'vehicle.*', side_wp.transform, 'scenario', attribute_filter=self._attributes)
             if not blocker_actor:
-                for actor in self.other_actors:
-                    actor.destroy()
+                self._destroy_other_actors()
                 raise ValueError("Couldn't spawn an actor")
             blocker_actor.apply_control(carla.VehicleControl(hand_brake=True))
 
@@ -119,8 +117,7 @@ class StaticCutIn(BasicScenario):
             # Move to the front
             next_wps = blocker_wp.next(self._vehicle_gap)
             if not next_wps:
-                for actor in self.other_actors:
-                    actor.destroy()
+                self._destroy_other_actors()
                 raise ValueError("Couldn't find a proper position for the cut in vehicle")
             blocker_wp = next_wps[0]
 
@@ -132,8 +129,7 @@ class StaticCutIn(BasicScenario):
         while dist < self._adversary_end_distance:
             next_wps = next_wp.next(step)
             if not next_wps:
-                for actor in self.other_actors:
-                    actor.destroy()
+                self._destroy_other_actors()
                 raise ValueError("Couldn't find a proper position for the cut in vehicle")
             next_wp = next_wps[0]
             self._plan.append([next_wp, RoadOption.STRAIGHT])
@@ -143,15 +139,13 @@ class StaticCutIn(BasicScenario):
         # Spawn the cut in vehicle
         side_wp = blocker_wp.get_left_lane() if self._direction == 'left' else blocker_wp.get_right_lane()
         if not side_wp:
-            for actor in self.other_actors:
-                actor.destroy()
+            self._destroy_other_actors()
             raise ValueError("Couldn't find a proper position for the cut in vehicle")
 
         self._adversary_actor = CarlaDataProvider.request_new_actor(
             'vehicle.*', side_wp.transform, 'scenario', attribute_filter=self._attributes)
         if not self._adversary_actor:
-            for actor in self.other_actors:
-                actor.destroy()
+            self._destroy_other_actors()
             raise ValueError("Couldn't spawn an actor")
 
         self._adversary_actor.set_simulate_physics(False)
@@ -165,8 +159,7 @@ class StaticCutIn(BasicScenario):
         # Move to the front
         next_wps = blocker_wp.next(self._vehicle_gap)
         if not next_wps:
-            for actor in self.other_actors:
-                actor.destroy()
+            self._destroy_other_actors()
             raise ValueError("Couldn't find a proper position for the cut in vehicle")
         blocker_wp = next_wps[0]
 
@@ -175,16 +168,14 @@ class StaticCutIn(BasicScenario):
             # Move to the side
             side_wp = blocker_wp.get_left_lane() if self._direction == 'left' else blocker_wp.get_right_lane()
             if not side_wp:
-                for actor in self.other_actors:
-                    actor.destroy()
+                self._destroy_other_actors()
                 raise ValueError("Couldn't find a proper position for the cut in vehicle")
 
             # Spawn the actor
             blocker_actor = CarlaDataProvider.request_new_actor(
                 'vehicle.*', side_wp.transform, 'scenario', attribute_filter=self._attributes)
             if not blocker_actor:
-                for actor in self.other_actors:
-                    actor.destroy()
+                self._destroy_other_actors()
                 raise ValueError("Couldn't spawn an actor")
             blocker_actor.apply_control(carla.VehicleControl(hand_brake=True))
 
@@ -196,8 +187,7 @@ class StaticCutIn(BasicScenario):
             # Move to the front
             next_wps = blocker_wp.next(self._vehicle_gap)
             if not next_wps:
-                for actor in self.other_actors:
-                    actor.destroy()
+                self._destroy_other_actors()
                 raise ValueError("Couldn't find a proper position for the cut in vehicle")
             blocker_wp = next_wps[0]
 

--- a/srunner/scenarios/object_crash_intersection.py
+++ b/srunner/scenarios/object_crash_intersection.py
@@ -417,7 +417,7 @@ class VehicleTurningRoutePedestrian(BasicScenario):
     def _replace_walker(self, adversary):
         """As the adversary is probably, replace it with another one"""
         type_id = adversary.type_id
-        adversary.destroy()
+        CarlaDataProvider.remove_actor_by_id(adversary.id)
         spawn_transform = self.ego_vehicles[0].get_transform()
         spawn_transform.location.z -= 50
         adversary = CarlaDataProvider.request_new_actor(type_id, spawn_transform)

--- a/srunner/scenarios/object_crash_vehicle.py
+++ b/srunner/scenarios/object_crash_vehicle.py
@@ -266,7 +266,7 @@ class DynamicObjectCrossing(BasicScenario):
             self._adversary_transform = self._get_sidewalk_transform(walker_wp, offset)
             adversary = CarlaDataProvider.request_new_actor('walker.*', self._adversary_transform)
             if adversary is None:
-                blocker.destroy()
+                CarlaDataProvider.remove_actor_by_id(blocker.id)
                 self._number_of_attempts -= 1
                 move_dist = self._retry_dist
                 print("Failed to spawn an adversary")
@@ -350,7 +350,7 @@ class DynamicObjectCrossing(BasicScenario):
     def _replace_walker(self, adversary):
         """As the adversary is probably, replace it with another one"""
         type_id = adversary.type_id
-        adversary.destroy()
+        CarlaDataProvider.remove_actor_by_id(adversary.id)
         spawn_transform = self.ego_vehicles[0].get_transform()
         spawn_transform.location.z -= 50
         adversary = CarlaDataProvider.request_new_actor(type_id, spawn_transform)
@@ -557,7 +557,7 @@ class ParkingCrossingPedestrian(BasicScenario):
     def _replace_walker(self, walker):
         """As the adversary is probably, replace it with another one"""
         type_id = walker.type_id
-        walker.destroy()
+        CarlaDataProvider.remove_actor_by_id(walker.id)
         spawn_transform = self.ego_vehicles[0].get_transform()
         spawn_transform.location.z -= 50
         walker = CarlaDataProvider.request_new_actor(type_id, spawn_transform)

--- a/srunner/scenarios/parking_exit.py
+++ b/srunner/scenarios/parking_exit.py
@@ -140,7 +140,7 @@ class ParkingExit(BasicScenario):
         actor_behind = CarlaDataProvider.request_new_actor(
             'vehicle.*', behind_points[0].transform, rolename='scenario no lights', attribute_filter=self._bp_attributes)
         if actor_behind is None:
-            actor_front.destroy()
+            CarlaDataProvider.remove_actor_by_id(actor_front.id)
             raise ValueError("Couldn't spawn the vehicle behind the parking point")
         actor_behind.apply_control(carla.VehicleControl(hand_brake=True))
         self.other_actors.append(actor_behind)

--- a/srunner/scenarios/pedestrian_crossing.py
+++ b/srunner/scenarios/pedestrian_crossing.py
@@ -130,8 +130,7 @@ class PedestrianCrossing(BasicScenario):
             spawn_transform = self._get_walker_transform(start_wp, walker_data)
             walker = CarlaDataProvider.request_new_actor('walker.*', spawn_transform)
             if walker is None:
-                for walker in self.other_actors:
-                    walker.destroy()
+                self._destroy_other_actors()
                 raise ValueError("Failed to spawn an adversary")
 
             walker.set_location(spawn_transform.location + carla.Location(z=-200))
@@ -220,7 +219,7 @@ class PedestrianCrossing(BasicScenario):
     def _replace_walker(self, walker):
         """As the adversary is probably, replace it with another one"""
         type_id = walker.type_id
-        walker.destroy()
+        CarlaDataProvider.remove_actor_by_id(walker.id)
         spawn_transform = self.ego_vehicles[0].get_transform()
         spawn_transform.location.z -= 50
         walker = CarlaDataProvider.request_new_actor(type_id, spawn_transform)


### PR DESCRIPTION
I realized that in the `CarlaDataProvider._carla_actor_pool` more and more dead actors accumulated over time when scenarios run. The reason is that actors are created over the CDP and are added to the pool, however, they are not destroyed over the CDP.  
I think I located most of the locations where this is the case - however I think there is still at least one missing.

As a side result it the `remove_actor_by_id` function is now also slightly more informative. If the return value is `None` the users needs to take care of the destruction.

---

I also propose an update to the `CarlaDataProvider._actor_[velocity, location, transform]_map`, while this new code is in itself more expensive it was in the long run still faster as the sizes were overall smaller. Of course, just talking about a few *ms*.

---


### Tested on 

    Platform(s): Ubuntu
    Python version(s): 3.7 and 3.10
    Unreal Engine version(s): 4.24
    CARLA version: 0.9.15 dev


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1091)
<!-- Reviewable:end -->
