### PR TITLE
 [Help wanted] Update requirements.txt for Python > 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,29 @@
+# Python 3.7 - 3.10
+opencv-python==4.2.0.32; python_version <= "3.7"
+opencv-python~=4.5.5.64,<=4.5.5.64; python_version < "3.10"
+opencv-python==4.5.5.64; python_version == "3.10"
+
+# opencv 4.5+ will install numpy>=1.21.2
+numpy==1.18.4; python_version >= '3.0' and python_version <= "3.7"
+
+# 2.2 breaks in 3.10
+networkx==2.2; python_version < "3.10"
+
+networkx>=2.7<3.0; python_version >= "3.10"
+
+# Python 3.10 + 
+opencv-python~=4.5.5.64,<=4.10.0.84; python_version > "3.10"
+
+# Needs to be more fine grained
+Shapely==1.7.1; python_version < "3.10"
+Shapely==1.8.*; python_version == "3.10"
+
 py-trees==0.8.3
-numpy==1.18.4; python_version >= '3.0'
-networkx==2.2
-Shapely==1.7.1
+
 psutil
 xmlschema==1.0.18
 ephem
 tabulate
-opencv-python==4.2.0.32
 matplotlib
 six
 simple-watchdog-timer


### PR DESCRIPTION
The current requirements are quite restrictive and outdated for newer python versions. I think we should update the requirements file with some version checks to allow Python3.7+ and the latest supported 3.10 to install and work smoothly

- opencv_python & numpy are the most important.
- networkx breaks in Python 3.10; needs at least networkx 2.7 if I recall correctly.
- Shapely needs at last +1 minor version
- ...

**Maybe you can share your installations from 3.8 - 3.10 and help on this draft to craft a working version for the newer python versions.**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1095)
<!-- Reviewable:end -->
