### PR TITLE
Speed up information retrieval

### DIFF
--- a/srunner/scenariomanager/carla_data_provider.py
+++ b/srunner/scenariomanager/carla_data_provider.py
@@ -160,6 +160,9 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
         """
         returns the absolute velocity for the given actor
         """
+        if actor in CarlaDataProvider._actor_velocity_map:
+            return CarlaDataProvider._actor_velocity_map[actor]
+        # Look for same actor, but stored as different python object
         for key in CarlaDataProvider._actor_velocity_map:
             if key.id == actor.id:
                 return CarlaDataProvider._actor_velocity_map[key]
@@ -174,6 +177,8 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
         """
         returns the location for the given actor
         """
+        if actor in CarlaDataProvider._actor_location_map:
+            return CarlaDataProvider._actor_location_map[actor]
         for key in CarlaDataProvider._actor_location_map:
             if key.id == actor.id:
                 return CarlaDataProvider._actor_location_map[key]
@@ -189,6 +194,8 @@ class CarlaDataProvider(object):  # pylint: disable=too-many-public-methods
         """
         returns the transform for the given actor
         """
+        if actor in CarlaDataProvider._actor_transform_map:
+            return CarlaDataProvider._actor_transform_map[actor] or actor.get_transform()
         for key in CarlaDataProvider._actor_transform_map:
             if key.id == actor.id:
                 # The velocity location information is the entire behavior tree updated every tick


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated

-->

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** Python 3.7 and 3.10
  * **CARLA version:** 0.9.15

---

When using `CarlaDataProvider.get_velocity / transform / location(actor)` the lookup function loops over all dict keys and compares the actor id of each key against the argument's id. Comparing all ids is necessary, as different python instances of the same actor have different hashes, but inefficient if the argument is a present key.

This PR adds a best-case lookup before and checks if the actor a present key before it falls back to the slower loop over all actors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1098)
<!-- Reviewable:end -->
