### PR TITLE
Fixed a typo in openscenario_parser.py

### DIFF
--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -274,7 +274,7 @@ class OpenScenarioParser(object):
         elif name.startswith("pos="):
             tl_pos = name[4:]
             pos = tl_pos.split(",")
-            for carla_tl in CCarlaDataProvider.get_all_actors().filter('traffic.traffic_light'):
+            for carla_tl in CarlaDataProvider.get_all_actors().filter('traffic.traffic_light'):
                 carla_tl_location = carla_tl.get_transform().location
                 distance = carla_tl_location.distance(carla.Location(float(pos[0]),
                                                                      float(pos[1]),


### PR DESCRIPTION
#### Description

There was a typo in function "get_traffic_light_from_osc_name" in openscenario_parser.py, which was trying to access "CCarlaDataProvider" insted of "CarlaDataProvider". Typo fixed.

This is the typo.
![image](https://github.com/user-attachments/assets/66ee222f-5c26-488a-aa88-a49f7febf9ef)
Runs without problems after fixing the typo.

#### Where has this been tested?

  * **Platform(s):** Win11
  * **Python version(s):** 3.8.10
  * **CARLA version:** 0.9.15

#### Possible Drawbacks

None.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1118)
<!-- Reviewable:end -->
