### PR TITLE
Don't depend on distutils

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Upcoming
 * Improvements to the CarlaDataProvider:
  - Added `spawn_actor` for a blueprint based actor creation similar to `World.spawn_actor`
+* Implement `strtobool` formerly included in `distutils`, which is removed in Python 3.12.
 
 ## CARLA ScenarioRunner 0.9.15
 ### :rocket: New Features

--- a/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
+++ b/srunner/scenariomanager/actorcontrols/simple_vehicle_control.py
@@ -14,7 +14,7 @@ Limitations:
 - Can only consider obstacles in forward facing reaching (i.e. in tight corners obstacles may be ignored).
 """
 
-from distutils.util import strtobool
+from srunner.tools.util import strtobool
 import math
 
 import carla

--- a/srunner/scenarios/open_scenario.py
+++ b/srunner/scenarios/open_scenario.py
@@ -11,7 +11,7 @@ Basic scenario class using the OpenSCENARIO definition
 
 from __future__ import print_function
 
-from distutils.util import strtobool
+from srunner.tools.util import strtobool
 import itertools
 import os
 import py_trees

--- a/srunner/tools/openscenario_parser.py
+++ b/srunner/tools/openscenario_parser.py
@@ -11,7 +11,7 @@ This module provides a parser for scenario configuration files based on OpenSCEN
 
 from __future__ import print_function
 
-from distutils.util import strtobool
+from srunner.tools.util import strtobool
 import re
 import copy
 import datetime

--- a/srunner/tools/util.py
+++ b/srunner/tools/util.py
@@ -1,0 +1,14 @@
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError(f"invalid truth value {val!r}")


### PR DESCRIPTION
Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

#### Description

distutils are no longer available in Python 3.12. Therefore, we copy the strtobool function from distutils to our own module. This is in line with https://peps.python.org/pep-0632/#migration-advice.

#### Where has this been tested?

  * **Platform(s):** Linux
  * **Python version(s):** 3.12
  * **Unreal Engine version(s):** 4.26
  * **CARLA version:** 0.9.15

#### Possible Drawbacks

Hopefully none.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1121)
<!-- Reviewable:end -->
