### PR TITLE
osc2_scenario: Fix SyntaxWarnings

### DIFF
--- a/Docs/CHANGELOG.md
+++ b/Docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Upcoming
 * Improvements to the CarlaDataProvider:
  - Added `spawn_actor` for a blueprint based actor creation similar to `World.spawn_actor`
+* Removed SyntaxWarnings in osc2_scenario.py
 
 ## CARLA ScenarioRunner 0.9.15
 ### :rocket: New Features

--- a/srunner/scenarios/osc2_scenario.py
+++ b/srunner/scenarios/osc2_scenario.py
@@ -512,8 +512,8 @@ class OSC2Scenario(BasicScenario):
 
         def bool_result(self, option):
             # wait(x < y) @drive_distance Handling of Boolean expressions x < y
-            expression_value = re.split("\W+", option)
-            symbol = re.search("\W+", option).group()
+            expression_value = re.split(r"\W+", option)
+            symbol = re.search(r"\W+", option).group()
             if symbol == "<":
                 symbol = operator.lt
             elif symbol == ">":
@@ -1194,10 +1194,10 @@ class OSC2Scenario(BasicScenario):
                 if isinstance(para_value, (Physical, float, int)):
                     return para_value
                 para_value = para_value.strip('"')
-                if re.fullmatch("(^[-]?[0-9]+(\.[0-9]+)?)\s*(\w+)", para_value):
+                if re.fullmatch(r"(^[-]?[0-9]+(\.[0-9]+)?)\s*(\w+)", para_value):
                     # Regular expression ^[-]?[0-9]+(\.[0-9]+)? matching float
                     # para_value_num = re.findall('^[-]?[0-9]+(\.[0-9]+)?', para_value)[0]
-                    patter = re.compile("(^[-]?[0-9]+[\.[0-9]+]?)\s*(\w+)")
+                    patter = re.compile(r"(^[-]?[0-9]+[\.[0-9]+]?)\s*(\w+)")
                     para_value_num, para_value_unit = patter.match(para_value).groups()
                     if para_value_num.count(".") == 1:
                         return Physical(


### PR DESCRIPTION
Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [x] Changelog is updated

#### Description

This fixes warnings like the one below:

    .../srunner/scenarios/osc2_scenario.py:515: SyntaxWarning: invalid escape sequence '\W'
    expression_value = re.split("\W+", option)

These were introduced in Python 3.12. See https://docs.python.org/3.12/reference/lexical_analysis.html#escape-sequences.

#### Where has this been tested?

  * **Platform(s):** Linux
  * **Python version(s):** 3.12
  * **Unreal Engine version(s):** 4.26
  * **CARLA version:** 0.9.15

#### Possible Drawbacks

Hopefully none. r-strings are available even in Python 2.6, so this should work even with older Python versions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1122)
<!-- Reviewable:end -->
