### PR TITLE
Fixed scenario triggerer

### DIFF
--- a/srunner/scenarios/route_scenario.py
+++ b/srunner/scenarios/route_scenario.py
@@ -276,7 +276,8 @@ class RouteScenario(BasicScenario):
             if scenario.behavior_tree is not None:
                 scenario_behaviors.append(scenario.behavior_tree)
                 blackboard_list.append([scenario.config.route_var_name,
-                                        scenario.config.trigger_points[0].location])
+                                        scenario.config.trigger_points[0].location,
+                                        scenario.name])
 
         # Add the behavior that manages the scenario trigger conditions
         scenario_triggerer = ScenarioTriggerer(


### PR DESCRIPTION
### Description

Fixed an issue brought by [commit](https://github.com/carla-simulator/scenario_runner/commit/5828e5913d7bace51de56d8516ca6c6190213acb), mentioned in PR [1136](https://github.com/carla-simulator/scenario_runner/pull/1136). This is an alternative of that PR that instead of reverting the lgoa gents, adds the missing information to the blackboard variable.

### Where has this been tested?

  * **Platform(s):** UBuntu 20.04
  * **Python version(s):** 3.8
  * **Unreal Engine version(s):** CARLA's
  * **CARLA version:** 0.9.15

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1141)
<!-- Reviewable:end -->
