### PR TITLE
Fix: Implemented a safety check to stop carla from crashing when using reloadWorld argument with same town

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ results*.txt
 *.svg
 *.dot
 .venv
+test.ipynb

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -325,13 +325,21 @@ class ScenarioRunner(object):
         with open(file_name, 'w', encoding='utf-8') as fp:
             json.dump(criteria_dict, fp, sort_keys=False, indent=4)
 
+    def _get_town_name(self):
+        town_name = self.world.get_map().name
+        town_id = os.path.basename(town_name)[0:6]
+        return town_id
+
     def _load_and_wait_for_world(self, town, ego_vehicles=None):
         """
         Load a new CARLA world and provide data to CarlaDataProvider
         """
 
         if self._args.reloadWorld:
-            self.world = self.client.load_world(town)
+            if self._get_town_name() == town[0:6] :
+                print(f"{town} is already loaded into the simulator.")
+            else:
+                self.world = self.client.load_world(town)
         else:
             # if the world should not be reloaded, wait at least until all ego vehicles are ready
             ego_vehicle_found = False


### PR DESCRIPTION
… Implemented a safety check before loading the town into carla world

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted and checked with Utilities/code_check_and_formatting.sh
  - [ ] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Python version(s):** ...
  * **Unreal Engine version(s):** ...
  * **CARLA version:** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1153)
<!-- Reviewable:end -->
