### PR TITLE
Replace deprecated distutils and pkg_resources with modern alternatives

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ six
 simple-watchdog-timer
 antlr4-python3-runtime==4.10
 graphviz
+packaging

--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -20,10 +20,7 @@ import traceback
 import argparse
 from argparse import RawTextHelpFormatter
 from datetime import datetime
-try:
-    from packaging.version import Version
-except ImportError:
-    from distutils.version import LooseVersion as Version  # Python 2 fallback
+from packaging.version import Version
 import importlib
 import inspect
 import os
@@ -32,18 +29,11 @@ import sys
 import time
 import json
 
-try:
-    # requires Python 3.8+
-    from importlib.metadata import metadata
+from importlib.metadata import metadata
 
-    def get_carla_version():
-        return Version(metadata("carla")["Version"])
-except ModuleNotFoundError:
-    # backport checking for older Python versions; module is deprecated
-    import pkg_resources
 
-    def get_carla_version():
-        return Version(pkg_resources.get_distribution("carla").version)
+def get_carla_version():
+    return Version(metadata("carla")["Version"])
 
 import carla
 


### PR DESCRIPTION
## Summary
- Replace `distutils.version.LooseVersion` fallback with direct `packaging.version.Version` import (`distutils` was removed in Python 3.12)
- Replace `pkg_resources` fallback with direct `importlib.metadata.metadata` import (available since Python 3.8, which is already the minimum required by numpy 1.24.4)
- Add `packaging` as an explicit dependency in `requirements.txt`

## Motivation
The `distutils` module was deprecated in Python 3.10 and **removed entirely in Python 3.12** ([PEP 632](https://peps.python.org/pep-0632/)). Similarly, `pkg_resources` from `setuptools` is deprecated in favor of `importlib.metadata` (available since Python 3.8).

Since the project already requires Python 3.8+ (numpy 1.24.4 requires it), both `packaging.version.Version` and `importlib.metadata` are guaranteed to be available, making the try/except fallbacks unnecessary.

This partially addresses #1128 by removing deprecated imports that cause warnings and failures on newer Python versions.

## Changes
- **`scenario_runner.py`**: Replaced `try/except` import blocks with direct imports
- **`requirements.txt`**: Added `packaging` as an explicit dependency (was previously only used if available)

## Test plan
- [ ] Verify `python scenario_runner.py --help` runs without import errors on Python 3.8+
- [ ] Verify `pip install -r requirements.txt` succeeds and includes `packaging`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/scenario_runner/1160)
<!-- Reviewable:end -->
